### PR TITLE
pre-biostatR updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Imports:
     magrittr (>= 1.5),
     purrr (>= 0.3.0),
     rlang (>= 0.3.1),
-    stringr (>= 1.3.1),
+    stringr (>= 1.4.0),
     survival,
     tibble (>= 2.0.1),
     tidyr (>= 0.8.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.1.9001
+Version: 1.2.1.9002
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 * Add standard evaluation variants, `tbl_summary_()` and `add_p_()` (#223)
 
+* Remove `gt::cols_merge()` function ahead of the gt PR #355 that changes the `cols_merge()` API (#222)
+
+* Updated the `show_yesno` argument to `show_single_row`. It is now generic and any binary variable can be shown on a single row. (#220)
+
 # gtsummary 1.2.1
 
 * Vignettes install the {gt} package to a temporary directory (required for CRAN check) (#217)

--- a/R/tbl_regression.R
+++ b/R/tbl_regression.R
@@ -41,7 +41,7 @@
 #' in the output.  Default is `FALSE`
 #' @param show_single_row By default categorical variables are printed on a
 #' multiple rows.  If a variable is binary (e.g. Yes/No) and you wish to print
-#' the regression coefficient on a single row, include the variable names here,
+#' the regression coefficient on a single row, include the variable name here,
 #' e.g. `show_single_row = c("var1", "var2")`
 #' @param estimate_fun Function to round and format coefficient estimates.
 #' Default is [style_sigfig] when the coefficients are not transformed, and
@@ -160,8 +160,8 @@ tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
     # adding character CI
     mutate(
       ci = if_else(
-        !is.na(conf.low),
-        paste0(estimate_fun(conf.low), ", ", estimate_fun(conf.high)),
+        !is.na(.data$conf.low),
+        paste0(estimate_fun(.data$conf.low), ", ", estimate_fun(.data$conf.high)),
         NA_character_
       )
     ) %>%

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -241,7 +241,7 @@ tbl_uvregression <- function(data, method, y, method.args = NULL,
     results,
     label = "**Characteristic**",
     estimate = glue("**{estimate_header(model_obj_list[[1]], exponentiate)}**"),
-    conf.low = glue("**{style_percent(conf.level, symbol = TRUE)} CI**"),
+    ci = glue("**{style_percent(conf.level, symbol = TRUE)} CI**"),
     p.value = "**p-value**"
   )
 
@@ -281,13 +281,8 @@ gt_tbl_uvregression <- quote(list(
 
   # Show "---" for reference groups
   fmt_missing_ref =
-    "gt::fmt_missing(columns = gt::vars(estimate, conf.low, conf.high), rows = row_ref == TRUE, missing_text = '---')" %>%
+    "gt::fmt_missing(columns = gt::vars(estimate, ci), rows = row_ref == TRUE, missing_text = '---')" %>%
       glue(),
-
-  # combining conf.low and conf.high to print confidence interval
-  cols_merge_ci =
-    "gt::cols_merge(col_1 = gt::vars(conf.low), col_2 = gt::vars(conf.high), pattern = '{1}, {2}')" %>%
-      glue::as_glue(),
 
   # indenting levels and missing rows
   tab_style_text_indent = glue(

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -79,7 +79,7 @@
 tbl_uvregression <- function(data, method, y, method.args = NULL,
                              formula = "{y} ~ {x}",
                              exponentiate = FALSE, label = NULL,
-                             hide_n = FALSE, show_yesno = NULL, conf.level = NULL,
+                             hide_n = FALSE, show_single_row = NULL, conf.level = NULL,
                              estimate_fun = NULL, pvalue_fun = NULL) {
   # setting defaults -----------------------------------------------------------
   pvalue_fun <-
@@ -192,7 +192,7 @@ tbl_uvregression <- function(data, method, y, method.args = NULL,
         exponentiate = exponentiate,
         conf.level = conf.level,
         label = label,
-        show_yesno = show_yesno
+        show_single_row = intersect(.y, show_single_row)
       )
     )
 

--- a/R/utils-table_headers.R
+++ b/R/utils-table_headers.R
@@ -127,10 +127,7 @@ table_header_to_gt_cols_label <- function(table_header) {
 # gt table_header to gt cols_hide code
 table_header_to_gt_cols_hide <- function(table_header) {
   table_header %>%
-    filter(
-      .data$hide == TRUE,
-      !startsWith(.data$column, "conf.high")
-    ) %>%
+    filter(.data$hide == TRUE) %>%
     pull(.data$column) %>%
     glue_collapse(sep = ", ") %>%
     {

--- a/R/utils-tbl_regression.R
+++ b/R/utils-tbl_regression.R
@@ -66,7 +66,7 @@ tidy_wrap <- function(x, exponentiate, conf.level) {
 #' @noRd
 #' @keywords internal
 
-parse_fit <- function(fit, tidy, label, show_yesno) {
+parse_fit <- function(fit, tidy, label, show_single_row) {
   # extracting model frame
   model_frame <- stats::model.frame(fit)
 
@@ -154,29 +154,6 @@ parse_fit <- function(fit, tidy, label, show_yesno) {
       "Please re-level values without ':'."
     ))
   }
-
-  # show yes-no ----------------------------------------------------------------
-  # creating a list of variables that are yes/no that will,
-  # by default, be printed on a single row
-  yesno_levels <- list(c("No", "Yes"), c("no", "yes"), c("NO", "YES"))
-  yesno_variables <- NULL
-  for (v in term_match$variable) {
-    for (yn in yesno_levels) {
-      if ("character" %in% class(model_frame[[v]]) &
-        model_frame[[v]] %>%
-          stats::na.omit() %>%
-          setequal(yn)) {
-        yesno_variables <- c(yesno_variables, v)
-      }
-      # for factors the ORDER must be no THEN yes (making no the reference group)
-      else if ("factor" %in% class(model_frame[[v]]) &
-        attr(model_frame[[v]], "level") %>% identical(yn)) {
-        yesno_variables <- c(yesno_variables, v)
-      }
-    }
-  }
-  # removing variables user requested to show both levels
-  yesno_variables <- yesno_variables %>% setdiff(show_yesno)
 
   # more  var labels -----------------------------------------------------------
   # model.frame() strips variable labels from cox models.  this attempts
@@ -287,7 +264,7 @@ parse_fit <- function(fit, tidy, label, show_yesno) {
           if (var_type == "continuous") {
             return(TRUE)
           }
-          if (var_type == "categorical" & group %in% yesno_variables) {
+          if (var_type == "categorical" & group %in% show_single_row) {
             return(TRUE)
           }
           if (var_type == "categorical") {
@@ -306,6 +283,35 @@ parse_fit <- function(fit, tidy, label, show_yesno) {
         }
       )
     )
+
+  # show_single_row check ------------------------------------------------------
+  # checking that all variables listed in show_single_row appear in results
+  for (i in show_single_row) {
+    if (!i %in% tidy_group$group)
+      stop(glue(
+        "'{i}' from argument 'show_single_row' is not a variable ",
+        "from the model. Select from:\n",
+        "{paste(tidy_group$group %>% setdiff('(Intercept)'), collapse = ', ')}"
+      ))
+  }
+
+  # check that all variables in show_single_row are dichotomous
+  bad_show_single_row <-
+    tidy_group %>%
+    mutate(
+      bad_show_single_row = purrr::map2_lgl(
+        .data$group, .data$data,
+        ~ .x %in% show_single_row && nrow(.y) > 1
+      )
+    ) %>%
+    filter(.data$bad_show_single_row == TRUE) %>%
+    pull(.data$group)
+  if (length(bad_show_single_row) > 0 ) {
+      stop(glue(
+        "'{paste(bad_show_single_row, collapse = \"', '\")}' from argument ",
+        "'show_single_row' may only be applied to binary variables."
+      ))
+  }
 
   # final touches to result ----------------------------------------------------
   # adding in refernce rows, and header rows for categorical and interaction variables

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "http://www.danieldsjoberg.com/gtsummary/",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.1.9001",
+  "version": "1.2.1.9002",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -431,7 +431,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1357.363KB",
+  "fileSize": "1357.794KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/codemeta.json
+++ b/codemeta.json
@@ -368,7 +368,7 @@
       "@type": "SoftwareApplication",
       "identifier": "stringr",
       "name": "stringr",
-      "version": ">= 1.3.1",
+      "version": ">= 1.4.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -431,7 +431,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1357.668KB",
+  "fileSize": "1357.363KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/man/tbl_regression.Rd
+++ b/man/tbl_regression.Rd
@@ -5,7 +5,7 @@
 \title{Display regression model results in table}
 \usage{
 tbl_regression(x, label = NULL, exponentiate = FALSE, include = NULL,
-  exclude = NULL, show_yesno = NULL, conf.level = NULL,
+  exclude = NULL, show_single_row = NULL, conf.level = NULL,
   intercept = FALSE, estimate_fun = NULL, pvalue_fun = NULL)
 }
 \arguments{
@@ -21,10 +21,10 @@ coefficient estimates. Default is \code{FALSE}.}
 
 \item{exclude}{Names of variables to exclude from output.}
 
-\item{show_yesno}{By default yes/no categorical variables are printed on a
-single row, when the 'No' category is the reference group.  To print both
-levels in the output table, include the variable name in the show_yesno
-vector, e.g. `show_yesno = c("var1", "var2")``}
+\item{show_single_row}{By default categorical variables are printed on a
+multiple rows.  If a variable is binary (e.g. Yes/No) and you wish to print
+the regression coefficient on a single row, include the variable name here,
+e.g. \code{show_single_row = c("var1", "var2")}}
 
 \item{conf.level}{Must be strictly greater than 0 and less than 1.
 Defaults to 0.95, which corresponds to a 95 percent confidence interval.}

--- a/man/tbl_uvregression.Rd
+++ b/man/tbl_uvregression.Rd
@@ -6,7 +6,7 @@
 \usage{
 tbl_uvregression(data, method, y, method.args = NULL,
   formula = "{y} ~ {x}", exponentiate = FALSE, label = NULL,
-  hide_n = FALSE, show_yesno = NULL, conf.level = NULL,
+  hide_n = FALSE, show_single_row = NULL, conf.level = NULL,
   estimate_fun = NULL, pvalue_fun = NULL)
 }
 \arguments{
@@ -33,10 +33,10 @@ e.g. \code{list("age" ~ "Age, yrs", "ptstage" ~ "Path T Stage")}}
 
 \item{hide_n}{Hide N column. Default is \code{FALSE}}
 
-\item{show_yesno}{By default yes/no categorical variables are printed on a
-single row, when the 'No' category is the reference group.  To print both
-levels in the output table, include the variable name in the show_yesno
-vector, e.g. `show_yesno = c("var1", "var2")``}
+\item{show_single_row}{By default categorical variables are printed on a
+multiple rows.  If a variable is binary (e.g. Yes/No) and you wish to print
+the regression coefficient on a single row, include the variable name here,
+e.g. \code{show_single_row = c("var1", "var2")}}
 
 \item{conf.level}{Must be strictly greater than 0 and less than 1.
 Defaults to 0.95, which corresponds to a 95 percent confidence interval.}


### PR DESCRIPTION
This PR addresses two open issues
1. #222 remove `gt::cols_merge()` function ahead of the gt PR that changes the `cols_merge()` API
1. #220 changed the `show_yesno` argument to `show_single_row`. It is now generic and any binary variable can be shown on a single row (rather than on three rows: label, one row per level)
  - Is the name of the argument ok?
  - I didn't deprecate the old argument `show_yesno`.  Do you think it's ok? Oy, there are already so many deprecated items in the package!  Can't wait to purge them all!
  - Should i just get rid of this option altogether?  If the user wants a single row they can simply make a numeric version?