### PR TITLE
#259 vars bug fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Bug fix in `vars()` selection where only first variable listed was being selected (#259)
+
 * Bug fix where logical variable labels printed as `NA` in `tbl_regression()` (#248)
 
 * Added `as_tibble()` function that converts any gtsummary table to a tibble (#245)

--- a/R/tidyselect_to_list.R
+++ b/R/tidyselect_to_list.R
@@ -69,20 +69,13 @@ tidyselect_to_list <- function(.data, x, .meta_data = NULL, input_type = NULL) {
 
   # if tidyselect function returned numeric position, grab character name
   lhs <- map_if(lhs, is.numeric, ~ names(.data)[.x])
-  # TODO: fix this garbage code for dplyr::vars()
-  # if tidyselect function returned quosure, convert to character
-  # > dplyr::vars(grade) %>% as.character()
-  # [1] "~grade"
-  lhs <- map_if(
-    lhs, ~ class(.x) == "quosures",
-    ~ as.character(.x) %>%
-      # remove ~ from quosure
-      stringr::str_remove(stringr::fixed("~")) %>%
-      # if variable name was wrapped in backticks, remove them
-      {ifelse(
-        startsWith(., "`") && endsWith(., "`"),
-        stringr::str_sub(., 2, -2), .
-      )}
+  # grabbing string column names from vars() call
+  lhs <- map(
+    lhs,
+    function(x) {
+      if (class(x) != "quosures") return(x)
+      map_chr(x, rlang::as_label)
+    }
   )
 
   # converting rhs and lhs into a named list


### PR DESCRIPTION
Bug fix where only the first variable wrapped in `dplyr::vars()` was being selected. #259 

I tested to make sure that multiple variables passed via `vars()` works as well as a single variable.  Non-standard variable names passed within backtics also appear to be selected properly.
```r
trial[c("response", "death")] %>%
  rlang::set_names(c("response", "death other cause")) %>%
  tbl_summary(
    type = list(vars(response, `death other cause`) ~ "categorical"),
    statistic = vars(response) ~ "{n}"
  )
```

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch 
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, was function included in `pkgdown.yml`
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] Code coverage is suitable for any new functions/features. 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [ ] When the branch is ready to be merged into master, bump the version number using `usethis::use_version(which = "dev")`, approve, and merge the PR.

