### PR TITLE
added show_noyes deprecation note

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.1.9006
+Version: 1.2.1.9007
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/R/tbl_regression.R
+++ b/R/tbl_regression.R
@@ -52,6 +52,7 @@
 #' and return a string that is the rounded/formatted p-value (e.g.
 #' `pvalue_fun = function(x) style_pvalue(x, digits = 2)` or equivalently,
 #'  `purrr::partial(style_pvalue, digits = 2)`).
+#' @param show_yesno deprecated
 #' @author Daniel D. Sjoberg
 #' @seealso See tbl_regression \href{http://www.danieldsjoberg.com/gtsummary/articles/tbl_regression.html}{vignette} for detailed examples
 #' @family tbl_regression tools
@@ -87,7 +88,13 @@
 tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
                            include = NULL, exclude = NULL,
                            show_single_row = NULL, conf.level = NULL, intercept = FALSE,
-                           estimate_fun = NULL, pvalue_fun = NULL) {
+                           estimate_fun = NULL, pvalue_fun = NULL, show_yesno = NULL) {
+  # deprecated arguments -------------------------------------------------------
+  if (!is.null(show_yesno)) {
+    lifecycle::deprecate_stop("1.2.2", "tbl_regression(show_yesno = )",
+                              "tbl_regression(show_single_row = )")
+  }
+
   # setting defaults -----------------------------------------------------------
   pvalue_fun <-
     pvalue_fun %||%

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -64,7 +64,13 @@ tbl_uvregression <- function(data, method, y, method.args = NULL,
                              exponentiate = FALSE, label = NULL,
                              include = NULL, exclude = NULL,
                              hide_n = FALSE, show_single_row = NULL, conf.level = NULL,
-                             estimate_fun = NULL, pvalue_fun = NULL) {
+                             estimate_fun = NULL, pvalue_fun = NULL, show_yesno = NULL) {
+  # deprecated arguments -------------------------------------------------------
+  if (!is.null(show_yesno)) {
+    lifecycle::deprecate_stop("1.2.2", "tbl_uvregression(show_yesno = )",
+                              "tbl_uvregression(show_single_row = )")
+  }
+
   # setting defaults -----------------------------------------------------------
   pvalue_fun <-
     pvalue_fun %||%

--- a/man/tbl_regression.Rd
+++ b/man/tbl_regression.Rd
@@ -6,7 +6,8 @@
 \usage{
 tbl_regression(x, label = NULL, exponentiate = FALSE, include = NULL,
   exclude = NULL, show_single_row = NULL, conf.level = NULL,
-  intercept = FALSE, estimate_fun = NULL, pvalue_fun = NULL)
+  intercept = FALSE, estimate_fun = NULL, pvalue_fun = NULL,
+  show_yesno = NULL)
 }
 \arguments{
 \item{x}{Regression model object}
@@ -42,6 +43,8 @@ The function must have a numeric vector input (the numeric, exact p-value),
 and return a string that is the rounded/formatted p-value (e.g.
 \code{pvalue_fun = function(x) style_pvalue(x, digits = 2)} or equivalently,
 \code{purrr::partial(style_pvalue, digits = 2)}).}
+
+\item{show_yesno}{deprecated}
 }
 \value{
 A \code{tbl_regression} object

--- a/man/tbl_uvregression.Rd
+++ b/man/tbl_uvregression.Rd
@@ -8,7 +8,7 @@ tbl_uvregression(data, method, y, method.args = NULL,
   formula = "{y} ~ {x}", exponentiate = FALSE, label = NULL,
   include = NULL, exclude = NULL, hide_n = FALSE,
   show_single_row = NULL, conf.level = NULL, estimate_fun = NULL,
-  pvalue_fun = NULL)
+  pvalue_fun = NULL, show_yesno = NULL)
 }
 \arguments{
 \item{data}{Data frame to be used in univariate regression modeling.  Data
@@ -56,6 +56,8 @@ The function must have a numeric vector input (the numeric, exact p-value),
 and return a string that is the rounded/formatted p-value (e.g.
 \code{pvalue_fun = function(x) style_pvalue(x, digits = 2)} or equivalently,
 \code{purrr::partial(style_pvalue, digits = 2)}).}
+
+\item{show_yesno}{deprecated}
 }
 \value{
 A \code{tbl_uvregression} object


### PR DESCRIPTION
Added a note about the deprecated argument `show_noyes=` in `tbl_regression()` and `tbl_uvregression()`

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, was function included in `pkgdown.yml`
- [x] R CMD Check runs without errors, warnings, and notes
- [x] Code coverage is suitable for any new functions/features. 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] When the branch is ready to be merged into master, bump the version number using `usethis::use_version(which = "dev")`, approve, and merge the PR.

