### PR TITLE
bolding spanning headers #253

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.1.9007
+Version: 1.2.1.9008
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* `tbl_merge()` now interprets `tab_spanner =` text with `gt::md()` (#253)
+
 * Bug fix where logical variable labels printed as `NA` in `tbl_regression()` (#248)
 
 * Added `as_tibble()` function that converts any gtsummary table to a tibble (#245)

--- a/R/tbl_merge.R
+++ b/R/tbl_merge.R
@@ -6,7 +6,7 @@
 #' @param tbls List of gtsummary objects to merge
 #' @param tab_spanner Character vector specifying the spanning headers.
 #' Must be the same length as `tbls`. The
-#' strings are interpreted with [gt::md].
+#' strings are interpreted with `gt::md`.
 #' Must be same length as `tbls` argument
 #' @family tbl_regression tools
 #' @family tbl_uvregression tools

--- a/R/tbl_merge.R
+++ b/R/tbl_merge.R
@@ -5,6 +5,8 @@
 #'
 #' @param tbls List of gtsummary objects to merge
 #' @param tab_spanner Character vector specifying the spanning headers.
+#' Must be the same length as `tbls`. The
+#' strings are interpreted with [gt::md].
 #' Must be same length as `tbls` argument
 #' @family tbl_regression tools
 #' @family tbl_uvregression tools
@@ -25,7 +27,7 @@
 #' tbl_merge_ex1 <-
 #'   tbl_merge(
 #'     tbls = list(t1, t2),
-#'     tab_spanner = c("Tumor Response", "Time to Death")
+#'     tab_spanner = c("**Tumor Response**", "**Time to Death**")
 #'   )
 #' \donttest{
 #' # Descriptive statistics alongside univariate regression, with no spanning header
@@ -56,9 +58,13 @@
 #'
 #' \if{html}{\figure{tbl_merge_ex2.png}{options: width=65\%}}
 #'
-tbl_merge <- function(tbls,
-                      tab_spanner = paste0(c("Table "), seq_len(length(tbls)))) {
+tbl_merge <- function(tbls, tab_spanner = NULL) {
   # input checks ---------------------------------------------------------------
+  # if tab spanner is null, default is Table 1, Table 2, etc....
+  if (is.null(tab_spanner)) {
+    tab_spanner <-  paste0(c("**Table "), seq_len(length(tbls)), "**")
+  }
+
   # class of tbls
   if (!"list" %in% class(tbls)) {
     stop("Expecting 'tbls' to be a list, e.g. 'tbls = list(tbl1, tbl2)'")
@@ -255,7 +261,7 @@ gt_tbl_merge <- quote(list(
   # table spanner
   tab_spanner =
     glue(
-      "gt::tab_spanner(label = '{tab_spanner}', columns = gt::ends_with('_{seq_len(tbls_length)}'))"
+      "gt::tab_spanner(label = gt::md('{tab_spanner}'), columns = gt::ends_with('_{seq_len(tbls_length)}'))"
     ) %>%
     glue_collapse(sep = " %>% ")
 ))

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "http://www.danieldsjoberg.com/gtsummary/",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.1.9006",
+  "version": "1.2.1.9008",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -444,7 +444,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1434.634KB",
+  "fileSize": "1434.348KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -20,7 +20,6 @@ Lifecycle
 lm
 lme
 magrittr
-md
 mL
 nevent
 ng

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -20,6 +20,7 @@ Lifecycle
 lm
 lme
 magrittr
+md
 mL
 nevent
 ng

--- a/man/tbl_merge.Rd
+++ b/man/tbl_merge.Rd
@@ -11,7 +11,7 @@ tbl_merge(tbls, tab_spanner = NULL)
 
 \item{tab_spanner}{Character vector specifying the spanning headers.
 Must be the same length as \code{tbls}. The
-strings are interpreted with \link[gt:md]{gt::md}.
+strings are interpreted with \code{gt::md}.
 Must be same length as \code{tbls} argument}
 }
 \value{

--- a/man/tbl_merge.Rd
+++ b/man/tbl_merge.Rd
@@ -4,12 +4,14 @@
 \alias{tbl_merge}
 \title{Merge two or more gtsummary objects}
 \usage{
-tbl_merge(tbls, tab_spanner = paste0(c("Table "), seq_len(length(tbls))))
+tbl_merge(tbls, tab_spanner = NULL)
 }
 \arguments{
 \item{tbls}{List of gtsummary objects to merge}
 
 \item{tab_spanner}{Character vector specifying the spanning headers.
+Must be the same length as \code{tbls}. The
+strings are interpreted with \link[gt:md]{gt::md}.
 Must be same length as \code{tbls} argument}
 }
 \value{
@@ -42,7 +44,7 @@ t2 <-
 tbl_merge_ex1 <-
   tbl_merge(
     tbls = list(t1, t2),
-    tab_spanner = c("Tumor Response", "Time to Death")
+    tab_spanner = c("**Tumor Response**", "**Time to Death**")
   )
 \donttest{
 # Descriptive statistics alongside univariate regression, with no spanning header


### PR DESCRIPTION
- What changes are proposed in this pull request?
`tbl_merge()` now interprets `tab_spanner = ` with `gt::md()`

Need to double check this does NOT cause problems if gt is not installed on a machine....

- If there is an GitHub issue associated with this pull request, please provide link.
#253 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, was function included in `pkgdown.yml`
- [x] R CMD Check runs without errors, warnings, and notes
- [x] Code coverage is suitable for any new functions/features. 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] When the branch is ready to be merged into master, bump the version number using `usethis::use_version(which = "dev")`, approve, and merge the PR.

