### PR TITLE
Update tbl_merge.R

### DIFF
--- a/R/tbl_merge.R
+++ b/R/tbl_merge.R
@@ -91,7 +91,7 @@ tbl_merge <- function(tbls, tab_spanner = NULL) {
     tbls,
     ~ class(.x) == "tbl_summary",
     function(x){
-      x$table_header$footnote[startsWith(x$table_header$column, "stat_")][1] =
+      x$table_header$footnote[startsWith(x$table_header$column, "stat_")] =
         x$table_header$footnote[x$table_header$column == "label"][1]
 
       x$table_header$footnote[x$table_header$column == "label"][1] = list(NULL)


### PR DESCRIPTION
- What changes are proposed in this pull request?
After a `tbl_summary` object is merged, the footnote is moved to all statistics columns (previously it was only moved to the first, but was confusing it user didn't need the spanning columns.


- If there is an GitHub issue associated with this pull request, please provide link.
#274 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch 
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, was function included in `pkgdown.yml`
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] Code coverage is suitable for any new functions/features. 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [ ] When the branch is ready to be merged into master, bump the version number using `usethis::use_version(which = "dev")`, approve, and merge the PR.

