### PR TITLE
Update utils-tbl_regression.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.1.9015
+Version: 1.2.1.9016
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* No longer checking outcome variable name for consistency in `tbl_regression()`---only checking independent variable names (#287)
+
 * Added a gallery of tables possible by merging, stacking, and modifying gtsummary arguments (#258)
 
 * `tbl_summary` objects are now stackable with `tbl_stack()` (#255)

--- a/R/utils-tbl_regression.R
+++ b/R/utils-tbl_regression.R
@@ -126,7 +126,7 @@ parse_fit <- function(fit, tidy, label, show_single_row) {
     message(glue(
       "Some variable names contain ':', which may cause formatting issues. ",
       "Please rename columns without ':'.\n\n",
-      "Variable name(s): {paste0('`', names(model_frame[, -1]), '`', collapse = ' ')}"
+      "Variable name(s): {paste0('`', names(model_frame[, -1, drop = FALSE]), '`', collapse = ' ')}"
     ))
   }
 

--- a/R/utils-tbl_regression.R
+++ b/R/utils-tbl_regression.R
@@ -64,6 +64,7 @@ tidy_wrap <- function(x, exponentiate, conf.level) {
 #' @param tidy broom tidy result
 #' @inheritParams tbl_regression
 #' @noRd
+#' @importFrom stringr fixed str_detect
 #' @keywords internal
 
 parse_fit <- function(fit, tidy, label, show_single_row) {
@@ -100,7 +101,7 @@ parse_fit <- function(fit, tidy, label, show_single_row) {
         term_match %>%
         mutate(
           variable = ifelse(
-            stringr::str_starts(stringr::fixed(.data$term), stringr::fixed(v)) &
+            stringr::str_starts(fixed(.data$term), fixed(v)) &
               .data$term %in% paste0(v, unique(model_frame[[v]])) &
               is.na(.data$variable),
             v,
@@ -121,10 +122,11 @@ parse_fit <- function(fit, tidy, label, show_single_row) {
   }
 
   # if the variable name contains a ':', weird formatting will likely happen
-  if (stringr::str_detect(stringr::fixed(names(model_frame)), stringr::fixed(":")) %>% any()) {
-    warning(glue(
+  if (str_detect(fixed(names(model_frame[, -1, drop = FALSE])), fixed(":")) %>% any()) {
+    message(glue(
       "Some variable names contain ':', which may cause formatting issues. ",
-      "Please rename columns without ':'."
+      "Please rename columns without ':'.\n\n",
+      "Variable name(s): {paste0('`', names(model_frame[, -1]), '`', collapse = ' ')}"
     ))
   }
 
@@ -136,8 +138,8 @@ parse_fit <- function(fit, tidy, label, show_single_row) {
         if (any(class(model_frame[[x]]) %in% c("factor", "character"))) {
           unique(model_frame[[x]]) %>%
             as.character() %>%
-            stringr::fixed() %>%
-            stringr::str_detect(stringr::fixed(":")) %>%
+            fixed() %>%
+            str_detect(fixed(":")) %>%
             any() %>%
             return()
         }
@@ -224,7 +226,7 @@ parse_fit <- function(fit, tidy, label, show_single_row) {
           if (variable_type == "continuous") {
             return(variable_lbl)
           }
-          stringr::str_remove(term_split, pattern = stringr::fixed(variable))
+          stringr::str_remove(term_split, pattern = fixed(variable))
         }
       )
     )

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.1.9015",
+  "version": "1.2.1.9016",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -457,7 +457,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1438.552KB",
+  "fileSize": "1808.217KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",


### PR DESCRIPTION
- What changes are proposed in this pull request?
In `tbl_regression()`, we no longer check the outcome variable for the presence of colon in the variable name (which causes formatting issues).

- If there is an GitHub issue associated with this pull request, please provide link.
#287 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, was function included in `pkgdown.yml`
- [x] R CMD Check runs without errors, warnings, and notes
- [x] Code coverage is suitable for any new functions/features. 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] When the branch is ready to be merged into master, bump the version number using `usethis::use_version(which = "dev")`, approve, and merge the PR.

