### PR TITLE
Option to append any gt call to the end of a gtsummary print

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.1.9016
+Version: 1.2.1.9017
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Users can add an option to their script to append any {gt} calls when a {gtsummary} object is printed: `gtsummary.as_gt.addl_cmds`
+
 * No longer checking outcome variable name for consistency in `tbl_regression()`---only checking independent variable names (#287)
 
 * Added a gallery of tables possible by merging, stacking, and modifying gtsummary arguments (#258)

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -51,6 +51,8 @@ as_gt <- function(x, include = NULL, exclude = NULL, omit = NULL) {
 
   # taking each gt function call, concatenating them with %>% separating them
   x$gt_calls[call_names] %>%
+    # adding default gt formatting options
+    union(getOption("gtsummary.as_gt.addl_cmds", default = NULL)) %>%
     # removing NULL elements
     compact() %>%
     glue_collapse(sep = " %>% ") %>%

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.1.9016",
+  "version": "1.2.1.9017",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -457,7 +457,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1808.217KB",
+  "fileSize": "1808.279KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",


### PR DESCRIPTION
- What changes are proposed in this pull request?
Small update that looks for the option `gtsummary.as_gt.addl_cmds` which can contain {gt} calls that will be appended to the end of the `.$gt_calls` list when printing.

Users must be careful, however....these must be commands that can be called on any gtsummary table.

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, was function included in `pkgdown.yml`
- [x] R CMD Check runs without errors, warnings, and notes
- [x] Code coverage is suitable for any new functions/features. 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] When the branch is ready to be merged into master, bump the version number using `usethis::use_version(which = "dev")`, approve, and merge the PR.

