### PR TITLE
294 uvregress x

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.2.9000
+Version: 1.2.2.9001
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -83,6 +83,7 @@ VignetteBuilder:
     knitr
 RdMacros: 
     lifecycle
+Additional_repositories: http://ddsjoberg.github.io/drat
 Encoding: UTF-8
 Language: en-US
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,12 +67,10 @@ Imports:
 Suggests: 
     car (>= 3.0.2),
     covr (>= 3.2.1),
-    curl (>= 4.2),
     geepack (>= 1.2.1),
     ggplot2 (>= 3.1.0),
     Hmisc (>= 4.2.0),
     lme4 (>= 1.1.18.1),
-    remotes (>= 2.1.0),
     rmarkdown (>= 1.11),
     spelling (>= 2.0),
     testthat (>= 2.1.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # gtsummary (development version)
 
+* `tbl_uvregression()` now accepts an `x=` argument to build univariate regression models where the covariate `x` remains the same while models are built the with remaining variables as the outcome (#294)
+
+* Internal updates to the way {gt} is installed during CRAN checks.
+
 # gtsummary 1.2.2
 
 ## New Features

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Internal updates to the way {gt} is installed during CRAN checks.
 
+* Bug fix when stacking `tbl_summary` objects with calculated p-values.
+
 # gtsummary 1.2.2
 
 ## New Features

--- a/R/tbl_regression.R
+++ b/R/tbl_regression.R
@@ -120,38 +120,6 @@ tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
     stop("Inputs 'estimate_fun' and 'pvalue_fun' must be functions.")
   }
 
-  # label ----------------------------------------------------------------------
-  if (!is.null(label) & is.null(names(label))) { # checking names for deprecated named list input
-
-    # checking input type: must be a list of formulas, or one formula
-    if (!class(label) %in% c("list", "formula")) {
-      stop(glue(
-        "'label' argument must be a list of formulas. ",
-        "LHS of the formula is the variable specification, ",
-        "and the RHS is the label specification: ",
-        "list(vars(stage) ~ \"T Stage\")"
-      ))
-    }
-    if ("list" %in% class(label)) {
-      if (purrr::some(label, negate(rlang::is_bare_formula))) {
-        stop(glue(
-          "'label' argument must be a list of formulas. ",
-          "LHS of the formula is the variable specification, ",
-          "and the RHS is the label specification: ",
-          "list(vars(stage) ~ \"T Stage\")"
-        ))
-      }
-    }
-
-    # all sepcifed labels must be a string of length 1
-    if ("formula" %in% class(label)) label <- list(label)
-    if (!every(label, ~ rlang::is_string(eval(rlang::f_rhs(.x))))) {
-      stop(glue(
-        "The RHS of the formula in the 'label' argument must be a string."
-      ))
-    }
-  }
-
   # converting tidyselect formula lists to named lists
   # extracting model frame
   model_frame <- tryCatch({
@@ -174,6 +142,10 @@ tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
     stop(e)
   })
   label <- tidyselect_to_list(model_frame, label, input_type = "label")
+  # all sepcifed labels must be a string of length 1
+  if (!every(label, ~ rlang::is_string(.x))) {
+    stop("Each `label` specified must be a string of length 1.")
+  }
 
   # will return call, and all object passed to in tbl_regression call
   # the object func_inputs is a list of every object passed to the function

--- a/R/tbl_stack.R
+++ b/R/tbl_stack.R
@@ -1,12 +1,12 @@
-#' Stacks two or more gtsummary regression objects
+#' Stacks two or more gtsummary objects
 #'
 #' Assists in patching together more complex tables. `tbl_stack()` appends two
-#' or more `tbl_regression` or `tbl_merge` objects.
+#' or more `tbl_regression`, `tbl_summary`, or `tbl_merge` objects.
 #' {gt} attributes from the first regression object are utilized for output
-#' table (read: don't stack a `tbl_regression` object on top of a `tbl_summary`
-#' object).
+#' table.
 #'
-#' @param tbls List of gtsummary regression objects
+#' @param tbls List of gtsummary objects
+#' @family tbl_summary tools
 #' @family tbl_regression tools
 #' @family tbl_uvregression tools
 #' @seealso [tbl_merge]

--- a/R/tbl_stack.R
+++ b/R/tbl_stack.R
@@ -99,7 +99,9 @@ tbl_stack <- function(tbls) {
   # stacking tables ------------------------------------------------------------
   results <- tbls[[1]][names(tbls[[1]]) %>% intersect(c(
     "inputs", "gt_calls", "kable_calls", "estimate_funs",
-    "pvalue_funs", "qvalue_funs", "table_header", "tbls"
+    "pvalue_funs", "qvalue_funs",
+    "pvalue_fun", "qvalue_fun",
+    "table_header", "tbls"
   ))]
 
   results$table_body <-

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -2,14 +2,18 @@
 #'
 #' @description
 #' This function estimates univariate regression models and returns them in
-#' a publication-ready table. The function takes as arguments a data frame,
-#' the type of regression model, and the outcome variable. Each column in the
+#' a publication-ready table.  It can create univariate regression models holding
+#' either a covariate or outcome constant.
+#'
+#' For models holding outcome constant, the function takes as arguments a data frame,
+#' the type of regression model, and the outcome variable `y=`. Each column in the
 #' data frame is regressed on the specified outcome. The `tbl_uvregression`
 #' function arguments are similar to the [tbl_regression] arguments. Review the
 #' \href{http://www.danieldsjoberg.com/gtsummary/articles/tbl_regression.html#tbl_uvregression}{tbl_uvregression vignette}
 #' for detailed examples.
 #'
-#' You may also pass a data frame, the type of regression model, and a single
+#' You may alternatively hold a single covariate constant. For this, pass a data
+#' frame, the type of regression model, and a single
 #' covariate in the `x=` argument. Each column of the data frame will serve as
 #' the outcome in a univariate regression model. Take care using the `x` argument
 #' that each of the columns in the data frame are appropriate for the same type
@@ -121,7 +125,9 @@ tbl_uvregression <- function(data, method, y = NULL, x = NULL, method.args = NUL
   if (!rlang::quo_is_null(rlang::enquo(y))) y <- y_name
   if (!rlang::quo_is_null(rlang::enquo(x))) x <- x_name
   if (is.null(x) + is.null(y) != 1L) {
-    stop("Specify one, and only one, of `x` and `y`.")
+    stop("Specify one, and only one, of `x` and `y`. This function can
+         create univariate regression models holding either a covariate or outcome
+         constant.")
   }
 
   # checking formula correctly specified ---------------------------------------

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -10,8 +10,11 @@
 #' for detailed examples.
 #'
 #' You may also pass a data frame, the type of regression model, and a single
-#' covariate. Each column of the data frame will serve as the outcome to a
-#' regression model with the repeated covariate.
+#' covariate in the `x=` argument. Each column of the data frame will serve as
+#' the outcome in a univariate regression model. Take care using the `x` argument
+#' that each of the columns in the data frame are appropriate for the same type
+#' of model, e.g. they are all continuous variables appropriate for [lm], or
+#' binary variables appropriate for logistic regression with [glm].
 #'
 #' @inheritSection tbl_regression Setting Defaults
 #' @inheritSection tbl_regression Note
@@ -21,11 +24,12 @@
 #' @param method Regression method (e.g. [lm], [glm], [survival::coxph], and more).
 #' @param y Model outcome (e.g. `y = recurrence` or `y = Surv(time, recur)`).
 #' All other column in `data` will be regressed on `y`.
-#' Specify one and only one or `y` or `x`
+#' Specify one and only one of `y` or `x`
 #' @param x Model covariate (e.g. `x = trt`).
 #' All other columns in `data` will serve as the outcome in a regression model
-#' with `x` as a covariate.
-#' Specify one and only one or `y` or `x`
+#' with `x` as a covariate.  Output table is best when `x` is a continuous or
+#' binary variable displayed on a single row.
+#' Specify one and only one of `y` or `x`
 #' @param formula String of the model formula.
 #' Uses [glue::glue] syntax. Default is `"{y} ~ {x}"`, where `{y}`
 #' is the dependent variable, and `{x}` represents a single covariate. For a
@@ -270,7 +274,7 @@ tbl_uvregression <- function(data, method, y = NULL, x = NULL, method.args = NUL
   # column headers
   results <- modify_header_internal(
     results,
-    label = "**Characteristic**",
+    label = ifelse(!is.null(y), "**Covariate**", "**Outcome**"),
     estimate = glue("**{estimate_header(model_obj_list[[1]], exponentiate)}**"),
     ci = glue("**{style_percent(conf.level, symbol = TRUE)} CI**"),
     p.value = "**p-value**"

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -1,5 +1,6 @@
 #' Display univariate regression model results in table
 #'
+#' @description
 #' This function estimates univariate regression models and returns them in
 #' a publication-ready table. The function takes as arguments a data frame,
 #' the type of regression model, and the outcome variable. Each column in the
@@ -8,13 +9,23 @@
 #' \href{http://www.danieldsjoberg.com/gtsummary/articles/tbl_regression.html#tbl_uvregression}{tbl_uvregression vignette}
 #' for detailed examples.
 #'
+#' You may also pass a data frame, the type of regression model, and a single
+#' covariate. Each column of the data frame will serve as the outcome to a
+#' regression model with the repeated covariate.
+#'
 #' @inheritSection tbl_regression Setting Defaults
 #' @inheritSection tbl_regression Note
 #'
 #' @param data Data frame to be used in univariate regression modeling.  Data
 #' frame includes the outcome variable(s) and the independent variables.
 #' @param method Regression method (e.g. [lm], [glm], [survival::coxph], and more).
-#' @param y Model outcome (e.g. `y = recurrence` or `y = Surv(time, recur)`)
+#' @param y Model outcome (e.g. `y = recurrence` or `y = Surv(time, recur)`).
+#' All other column in `data` will be regressed on `y`.
+#' Specify one and only one or `y` or `x`
+#' @param x Model covariate (e.g. `x = trt`).
+#' All other columns in `data` will serve as the outcome in a regression model
+#' with `x` as a covariate.
+#' Specify one and only one or `y` or `x`
 #' @param formula String of the model formula.
 #' Uses [glue::glue] syntax. Default is `"{y} ~ {x}"`, where `{y}`
 #' is the dependent variable, and `{x}` represents a single covariate. For a
@@ -71,7 +82,7 @@
 #'
 #' \if{html}{\figure{tbl_uv_ex2.png}{options: width=50\%}}
 
-tbl_uvregression <- function(data, method, y, method.args = NULL,
+tbl_uvregression <- function(data, method, y = NULL, x = NULL, method.args = NULL,
                              formula = "{y} ~ {x}",
                              exponentiate = FALSE, label = NULL,
                              include = NULL, exclude = NULL,
@@ -101,107 +112,125 @@ tbl_uvregression <- function(data, method, y, method.args = NULL,
   # updated method and y inputs to be bare, and converting them to strings
   # to be compatible with the rest of the function that assumes character input
   method <- deparse(substitute(method)) %>% as.character()
-  y <- deparse(substitute(y)) %>% as.character()
+  y_name <- deparse(substitute(y)) %>% as.character()
+  x_name <- deparse(substitute(x)) %>% as.character()
+  if (!rlang::quo_is_null(rlang::enquo(y))) y <- y_name
+  if (!rlang::quo_is_null(rlang::enquo(x))) x <- x_name
+  if (is.null(x) + is.null(y) != 1L) {
+    stop("Specify one, and only one, of `x` and `y`.")
+  }
 
-  # checking estimate_fun and pvalue_fun are functions
+  # checking formula correctly specified ---------------------------------------
+  # checking that '{x}' appears on RHS of formula
+  if (word(formula, start = 2L, sep = fixed("~")) %>%
+      str_detect(pattern = fixed("{x}")) == FALSE) {
+    stop("'{x}' must appear on RHS of '~' in formula argument")
+  }
+  # checking that '{y}' appears on LHS of formula
+  if (word(formula, start = 1L, sep = fixed("~")) %>%
+      str_detect(pattern = fixed("{y}")) == FALSE) {
+    stop("'{y}' must appear on LHS of '~' in formula argument")
+  }
+
+  # checking estimate_fun and pvalue_fun are functions -------------------------
   if (!is.function(estimate_fun) | !is.function(pvalue_fun)) {
-    stop("Inputs 'estimate_fun' and 'pvalue_fun' must be functions.")
+    stop("Arguments 'estimate_fun' and 'pvalue_fun' must be functions.")
   }
 
-  if (!is.null(label) & is.null(names(label))) { # checking names for deprecated named list input
-
-    # checking input type: must be a list of formulas, or one formula
-    if (!class(label) %in% c("list", "formula")) {
-      stop(glue(
-        "'label' argument must be a list of formulas. ",
-        "LHS of the formula is the variable specification, ",
-        "and the RHS is the label specification: ",
-        "list(vars(stage) ~ \"T Stage\")"
-      ))
-    }
-    if ("list" %in% class(label)) {
-      if (purrr::some(label, negate(rlang::is_bare_formula))) {
-        stop(glue(
-          "'label' argument must be a list of formulas. ",
-          "LHS of the formula is the variable specification, ",
-          "and the RHS is the label specification: ",
-          "list(vars(stage) ~ \"T Stage\")"
-        ))
-      }
-    }
-
-    # all sepcifed labels must be a string of length 1
-    if ("formula" %in% class(label)) label <- list(label)
-    if (!every(label, ~ rlang::is_string(eval(rlang::f_rhs(.x))))) {
-      stop(glue(
-        "The RHS of the formula in the 'label' argument must be a string."
-      ))
-    }
+  # converting tidyselect formula lists to named lists -------------------------
+  label <- tidyselect_to_list(data, label, .meta_data = NULL, input_type = "label")
+  # all sepcifed labels must be a string of length 1
+  if (!every(label, ~ rlang::is_string(.x))) {
+    stop("Each `label` specified must be a string of length 1.")
   }
+
   # data -----------------------------------------------------------------------
   # data is a data frame
   if (!is.data.frame(data)) {
-    stop(glue(
-      "'data' input must be a data frame."
-    ))
+    stop("'data' input must be a data frame.")
   }
 
   # will return call, and all object passed to in table1 call
   # the object func_inputs is a list of every object passed to the function
   tbl_uvregression_inputs <- as.list(environment())
+  tbl_uvregression_inputs <-
+    tbl_uvregression_inputs[!names(tbl_uvregression_inputs) %in% c("x_name", "y_name")]
 
-  # checking that '{x}' appears on RHS of formula
-  if (word(formula, start = 2L, sep = fixed("~")) %>%
-    str_detect(pattern = fixed("{x}")) == FALSE) {
-    stop("'{x}' must appear on RHS of '~' in formula argument")
-  }
+  # get all vars not specified -------------------------------------------------
+  all_vars <-
+    names(data) %>%
+    # removing x or y variable
+    setdiff(paste(c(y, x), "~ 1") %>% stats::as.formula() %>% all.vars()) %>%
+    # removing any other variables listed in the formula
+    setdiff(all.vars(stats::as.formula(formula), unique = FALSE)) %>%
+    # removing {y} and {x}
+    setdiff(c("x", "y"))
 
-  # get all x vars -------------------------------------------------------------
-  x_vars <- names(data) %>%
-    setdiff( # removing outcome variable(s)
-      paste0(y, "~1") %>%
-        stats::as.formula() %>%
-        all.vars()
-    ) %>%
-    setdiff( # removing potential variables added to model formula (e.g. random intercepts)
-      all.vars(stats::as.formula(formula)[[3]]) %>% remove_one_x() # the one x removed is the {x}
-    )
-  if (!is.null(include)) x_vars <- intersect(x_vars, include)
-  x_vars <- x_vars %>% setdiff(exclude)
-  if (length(x_vars) == 0) {
+  if (!is.null(include)) all_vars <- intersect(all_vars, include)
+  all_vars <- all_vars %>% setdiff(exclude)
+  if (length(all_vars) == 0) {
     stop("There were no covariates selected.")
   }
 
-  # bulding regression models
-  model_obj_list <-
-    map(
-      x_vars,
-      function(x)
-        do.call(
-          what = method,
-          args = c(
-            list(
-              formula = glue(formula) %>% stats::as.formula(),
-              data = data
-            ),
-            method.args
-          )
-        )
-    )
-  names(model_obj_list) <- x_vars
-
-  # formatting regression models
-  tbl_regression_list <-
-    imap(
-      model_obj_list,
-      ~ tbl_regression(
-        .x,
-        exponentiate = exponentiate,
-        conf.level = conf.level,
-        label = label,
-        show_single_row = intersect(.y, show_single_row)
+  # bulding regression models --------------------------------------------------
+  if (is.null(x)) {
+    model_obj_list <-
+      map(
+        all_vars,
+        function(x)
+          do.call(what = method,
+                  args = c(list(formula = glue(formula) %>% stats::as.formula(),
+                                data = data),
+                           method.args))
       )
-    )
+  }
+  else if (is.null(y)) {
+    model_obj_list <-
+      map(
+        all_vars,
+        function(y)
+          do.call(what = method,
+                  args = c(list(formula = glue(formula) %>% stats::as.formula(),
+                                data = data),
+                           method.args))
+      )
+  }
+  names(model_obj_list) <- all_vars
+
+  # formatting regression models with tbl_regression ---------------------------
+  if (is.null(x)) {
+    tbl_regression_list <-
+      imap(
+        model_obj_list,
+        ~ tbl_regression(
+          .x,
+          exponentiate = exponentiate,
+          conf.level = conf.level,
+          label = label,
+          show_single_row = intersect(.y, show_single_row)
+        )
+      )
+  }
+  else if (is.null(y)) {
+    tbl_regression_list <-
+      imap(
+        model_obj_list,
+        function(tbl, var) {
+          tbl_uv <-
+            tbl_regression(
+              tbl,
+              label = list(label[[var]] %||% attr(data[[var]], "label") %||% var) %>% set_names(x),
+              exponentiate = exponentiate,
+              conf.level = conf.level,
+              include = x,
+              show_single_row = show_single_row
+            )
+          tbl_uv$table_body$variable = var
+          tbl_uv$table_body$var_type = NA_character_
+          tbl_uv
+        }
+      )
+  }
 
   # extracting model tables and stacking
   table_body <-

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.2.9000",
+  "version": "1.2.2.9001",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -431,7 +431,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1539.491KB",
+  "fileSize": "1539.861KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/codemeta.json
+++ b/codemeta.json
@@ -111,19 +111,6 @@
     },
     {
       "@type": "SoftwareApplication",
-      "identifier": "curl",
-      "name": "curl",
-      "version": ">= 4.2",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=curl"
-    },
-    {
-      "@type": "SoftwareApplication",
       "identifier": "geepack",
       "name": "geepack",
       "version": ">= 1.2.1",
@@ -173,19 +160,6 @@
         "url": "https://cran.r-project.org"
       },
       "sameAs": "https://CRAN.R-project.org/package=lme4"
-    },
-    {
-      "@type": "SoftwareApplication",
-      "identifier": "remotes",
-      "name": "remotes",
-      "version": ">= 2.1.0",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=remotes"
     },
     {
       "@type": "SoftwareApplication",
@@ -457,7 +431,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1539.475KB",
+  "fileSize": "1539.491KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/codemeta.json
+++ b/codemeta.json
@@ -457,7 +457,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1539.215KB",
+  "fileSize": "1539.475KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -31,7 +31,6 @@ rstudio
 RStudio
 Rtools
 sig
-stackable
 survfit
 tbl
 tibble

--- a/man/add_n.Rd
+++ b/man/add_n.Rd
@@ -62,7 +62,8 @@ Other tbl_summary tools: \code{\link{add_overall}},
   \code{\link{inline_text.tbl_summary}},
   \code{\link{modify_header}},
   \code{\link{sort_p.tbl_summary}},
-  \code{\link{tbl_merge}}, \code{\link{tbl_summary}}
+  \code{\link{tbl_merge}}, \code{\link{tbl_stack}},
+  \code{\link{tbl_summary}}
 }
 \author{
 Daniel D. Sjoberg

--- a/man/add_overall.Rd
+++ b/man/add_overall.Rd
@@ -40,7 +40,8 @@ Other tbl_summary tools: \code{\link{add_n}},
   \code{\link{inline_text.tbl_summary}},
   \code{\link{modify_header}},
   \code{\link{sort_p.tbl_summary}},
-  \code{\link{tbl_merge}}, \code{\link{tbl_summary}}
+  \code{\link{tbl_merge}}, \code{\link{tbl_stack}},
+  \code{\link{tbl_summary}}
 }
 \author{
 Daniel D. Sjoberg

--- a/man/add_p.Rd
+++ b/man/add_p.Rd
@@ -112,7 +112,8 @@ Other tbl_summary tools: \code{\link{add_n}},
   \code{\link{inline_text.tbl_summary}},
   \code{\link{modify_header}},
   \code{\link{sort_p.tbl_summary}},
-  \code{\link{tbl_merge}}, \code{\link{tbl_summary}}
+  \code{\link{tbl_merge}}, \code{\link{tbl_stack}},
+  \code{\link{tbl_summary}}
 }
 \author{
 Emily C. Zabor, Daniel D. Sjoberg

--- a/man/add_q.tbl_summary.Rd
+++ b/man/add_q.tbl_summary.Rd
@@ -51,7 +51,8 @@ Other tbl_summary tools: \code{\link{add_n}},
   \code{\link{inline_text.tbl_summary}},
   \code{\link{modify_header}},
   \code{\link{sort_p.tbl_summary}},
-  \code{\link{tbl_merge}}, \code{\link{tbl_summary}}
+  \code{\link{tbl_merge}}, \code{\link{tbl_stack}},
+  \code{\link{tbl_summary}}
 }
 \author{
 Esther Drill, Daniel D. Sjoberg

--- a/man/add_stat_label.Rd
+++ b/man/add_stat_label.Rd
@@ -37,7 +37,8 @@ Other tbl_summary tools: \code{\link{add_n}},
   \code{\link{inline_text.tbl_summary}},
   \code{\link{modify_header}},
   \code{\link{sort_p.tbl_summary}},
-  \code{\link{tbl_merge}}, \code{\link{tbl_summary}}
+  \code{\link{tbl_merge}}, \code{\link{tbl_stack}},
+  \code{\link{tbl_summary}}
 }
 \author{
 Daniel D. Sjoberg

--- a/man/bold_italicize_labels_levels.Rd
+++ b/man/bold_italicize_labels_levels.Rd
@@ -60,7 +60,8 @@ Other tbl_summary tools: \code{\link{add_n}},
   \code{\link{inline_text.tbl_summary}},
   \code{\link{modify_header}},
   \code{\link{sort_p.tbl_summary}},
-  \code{\link{tbl_merge}}, \code{\link{tbl_summary}}
+  \code{\link{tbl_merge}}, \code{\link{tbl_stack}},
+  \code{\link{tbl_summary}}
 
 Other tbl_regression tools: \code{\link{add_global_p.tbl_regression}},
   \code{\link{add_nevent.tbl_regression}},

--- a/man/bold_p.tbl_summary.Rd
+++ b/man/bold_p.tbl_summary.Rd
@@ -45,7 +45,8 @@ Other tbl_summary tools: \code{\link{add_n}},
   \code{\link{inline_text.tbl_summary}},
   \code{\link{modify_header}},
   \code{\link{sort_p.tbl_summary}},
-  \code{\link{tbl_merge}}, \code{\link{tbl_summary}}
+  \code{\link{tbl_merge}}, \code{\link{tbl_stack}},
+  \code{\link{tbl_summary}}
 }
 \author{
 Daniel D. Sjoberg, Esther Drill

--- a/man/inline_text.tbl_summary.Rd
+++ b/man/inline_text.tbl_summary.Rd
@@ -53,7 +53,8 @@ Other tbl_summary tools: \code{\link{add_n}},
   \code{\link{bold_p.tbl_summary}},
   \code{\link{modify_header}},
   \code{\link{sort_p.tbl_summary}},
-  \code{\link{tbl_merge}}, \code{\link{tbl_summary}}
+  \code{\link{tbl_merge}}, \code{\link{tbl_stack}},
+  \code{\link{tbl_summary}}
 }
 \author{
 Daniel D. Sjoberg

--- a/man/modify_header.Rd
+++ b/man/modify_header.Rd
@@ -76,7 +76,8 @@ Other tbl_summary tools: \code{\link{add_n}},
   \code{\link{bold_p.tbl_summary}},
   \code{\link{inline_text.tbl_summary}},
   \code{\link{sort_p.tbl_summary}},
-  \code{\link{tbl_merge}}, \code{\link{tbl_summary}}
+  \code{\link{tbl_merge}}, \code{\link{tbl_stack}},
+  \code{\link{tbl_summary}}
 
 Other tbl_regression tools: \code{\link{add_global_p.tbl_regression}},
   \code{\link{add_nevent.tbl_regression}},

--- a/man/sort_p.tbl_summary.Rd
+++ b/man/sort_p.tbl_summary.Rd
@@ -42,7 +42,7 @@ Other tbl_summary tools: \code{\link{add_n}},
   \code{\link{bold_p.tbl_summary}},
   \code{\link{inline_text.tbl_summary}},
   \code{\link{modify_header}}, \code{\link{tbl_merge}},
-  \code{\link{tbl_summary}}
+  \code{\link{tbl_stack}}, \code{\link{tbl_summary}}
 }
 \author{
 Karissa Whiting

--- a/man/tbl_merge.Rd
+++ b/man/tbl_merge.Rd
@@ -100,7 +100,7 @@ Other tbl_summary tools: \code{\link{add_n}},
   \code{\link{inline_text.tbl_summary}},
   \code{\link{modify_header}},
   \code{\link{sort_p.tbl_summary}},
-  \code{\link{tbl_summary}}
+  \code{\link{tbl_stack}}, \code{\link{tbl_summary}}
 }
 \author{
 Daniel D. Sjoberg

--- a/man/tbl_stack.Rd
+++ b/man/tbl_stack.Rd
@@ -2,22 +2,21 @@
 % Please edit documentation in R/tbl_stack.R
 \name{tbl_stack}
 \alias{tbl_stack}
-\title{Stacks two or more gtsummary regression objects}
+\title{Stacks two or more gtsummary objects}
 \usage{
 tbl_stack(tbls)
 }
 \arguments{
-\item{tbls}{List of gtsummary regression objects}
+\item{tbls}{List of gtsummary objects}
 }
 \value{
 A \code{tbl_stack} object
 }
 \description{
 Assists in patching together more complex tables. \code{tbl_stack()} appends two
-or more \code{tbl_regression} or \code{tbl_merge} objects.
+or more \code{tbl_regression}, \code{tbl_summary}, or \code{tbl_merge} objects.
 {gt} attributes from the first regression object are utilized for output
-table (read: don't stack a \code{tbl_regression} object on top of a \code{tbl_summary}
-object).
+table.
 }
 \section{Example Output}{
 
@@ -76,6 +75,17 @@ tbl_stack_ex2 <-
 \seealso{
 \link{tbl_merge}
 
+Other tbl_summary tools: \code{\link{add_n}},
+  \code{\link{add_overall}}, \code{\link{add_p}},
+  \code{\link{add_q.tbl_summary}},
+  \code{\link{add_stat_label}},
+  \code{\link{bold_italicize_labels_levels}},
+  \code{\link{bold_p.tbl_summary}},
+  \code{\link{inline_text.tbl_summary}},
+  \code{\link{modify_header}},
+  \code{\link{sort_p.tbl_summary}},
+  \code{\link{tbl_merge}}, \code{\link{tbl_summary}}
+
 Other tbl_regression tools: \code{\link{add_global_p.tbl_regression}},
   \code{\link{add_nevent.tbl_regression}},
   \code{\link{bold_italicize_labels_levels}},
@@ -101,4 +111,5 @@ Other tbl_uvregression tools: \code{\link{add_global_p.tbl_uvregression}},
 Daniel D. Sjoberg
 }
 \concept{tbl_regression tools}
+\concept{tbl_summary tools}
 \concept{tbl_uvregression tools}

--- a/man/tbl_summary.Rd
+++ b/man/tbl_summary.Rd
@@ -183,7 +183,8 @@ Other tbl_summary tools: \code{\link{add_n}},
   \code{\link{bold_p.tbl_summary}},
   \code{\link{inline_text.tbl_summary}},
   \code{\link{modify_header}},
-  \code{\link{sort_p.tbl_summary}}, \code{\link{tbl_merge}}
+  \code{\link{sort_p.tbl_summary}},
+  \code{\link{tbl_merge}}, \code{\link{tbl_stack}}
 }
 \author{
 Daniel D. Sjoberg

--- a/man/tbl_uvregression.Rd
+++ b/man/tbl_uvregression.Rd
@@ -18,12 +18,13 @@ frame includes the outcome variable(s) and the independent variables.}
 
 \item{y}{Model outcome (e.g. \code{y = recurrence} or \code{y = Surv(time, recur)}).
 All other column in \code{data} will be regressed on \code{y}.
-Specify one and only one or \code{y} or \code{x}}
+Specify one and only one of \code{y} or \code{x}}
 
 \item{x}{Model covariate (e.g. \code{x = trt}).
 All other columns in \code{data} will serve as the outcome in a regression model
-with \code{x} as a covariate.
-Specify one and only one or \code{y} or \code{x}}
+with \code{x} as a covariate.  Output table is best when \code{x} is a continuous or
+binary variable displayed on a single row.
+Specify one and only one of \code{y} or \code{x}}
 
 \item{method.args}{List of additional arguments passed on to the regression
 function defined by \code{method}.}
@@ -79,8 +80,11 @@ function arguments are similar to the \link{tbl_regression} arguments. Review th
 for detailed examples.
 
 You may also pass a data frame, the type of regression model, and a single
-covariate. Each column of the data frame will serve as the outcome to a
-regression model with the repeated covariate.
+covariate in the \code{x=} argument. Each column of the data frame will serve as
+the outcome in a univariate regression model. Take care using the \code{x} argument
+that each of the columns in the data frame are appropriate for the same type
+of model, e.g. they are all continuous variables appropriate for \link{lm}, or
+binary variables appropriate for logistic regression with \link{glm}.
 }
 \section{Example Output}{
 

--- a/man/tbl_uvregression.Rd
+++ b/man/tbl_uvregression.Rd
@@ -72,14 +72,18 @@ A \code{tbl_uvregression} object
 }
 \description{
 This function estimates univariate regression models and returns them in
-a publication-ready table. The function takes as arguments a data frame,
-the type of regression model, and the outcome variable. Each column in the
+a publication-ready table.  It can create univariate regression models holding
+either a covariate or outcome constant.
+
+For models holding outcome constant, the function takes as arguments a data frame,
+the type of regression model, and the outcome variable \code{y=}. Each column in the
 data frame is regressed on the specified outcome. The \code{tbl_uvregression}
 function arguments are similar to the \link{tbl_regression} arguments. Review the
 \href{http://www.danieldsjoberg.com/gtsummary/articles/tbl_regression.html#tbl_uvregression}{tbl_uvregression vignette}
 for detailed examples.
 
-You may also pass a data frame, the type of regression model, and a single
+You may alternatively hold a single covariate constant. For this, pass a data
+frame, the type of regression model, and a single
 covariate in the \code{x=} argument. Each column of the data frame will serve as
 the outcome in a univariate regression model. Take care using the \code{x} argument
 that each of the columns in the data frame are appropriate for the same type

--- a/man/tbl_uvregression.Rd
+++ b/man/tbl_uvregression.Rd
@@ -4,9 +4,9 @@
 \alias{tbl_uvregression}
 \title{Display univariate regression model results in table}
 \usage{
-tbl_uvregression(data, method, y, method.args = NULL,
-  formula = "{y} ~ {x}", exponentiate = FALSE, label = NULL,
-  include = NULL, exclude = NULL, hide_n = FALSE,
+tbl_uvregression(data, method, y = NULL, x = NULL,
+  method.args = NULL, formula = "{y} ~ {x}", exponentiate = FALSE,
+  label = NULL, include = NULL, exclude = NULL, hide_n = FALSE,
   show_single_row = NULL, conf.level = NULL, estimate_fun = NULL,
   pvalue_fun = NULL, show_yesno = NULL)
 }
@@ -16,7 +16,14 @@ frame includes the outcome variable(s) and the independent variables.}
 
 \item{method}{Regression method (e.g. \link{lm}, \link{glm}, \link[survival:coxph]{survival::coxph}, and more).}
 
-\item{y}{Model outcome (e.g. \code{y = recurrence} or \code{y = Surv(time, recur)})}
+\item{y}{Model outcome (e.g. \code{y = recurrence} or \code{y = Surv(time, recur)}).
+All other column in \code{data} will be regressed on \code{y}.
+Specify one and only one or \code{y} or \code{x}}
+
+\item{x}{Model covariate (e.g. \code{x = trt}).
+All other columns in \code{data} will serve as the outcome in a regression model
+with \code{x} as a covariate.
+Specify one and only one or \code{y} or \code{x}}
 
 \item{method.args}{List of additional arguments passed on to the regression
 function defined by \code{method}.}
@@ -70,6 +77,10 @@ data frame is regressed on the specified outcome. The \code{tbl_uvregression}
 function arguments are similar to the \link{tbl_regression} arguments. Review the
 \href{http://www.danieldsjoberg.com/gtsummary/articles/tbl_regression.html#tbl_uvregression}{tbl_uvregression vignette}
 for detailed examples.
+
+You may also pass a data frame, the type of regression model, and a single
+covariate. Each column of the data frame will serve as the outcome to a
+regression model with the repeated covariate.
 }
 \section{Example Output}{
 

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -66,8 +66,6 @@ reference:
       - add_global_p.tbl_uvregression
       - add_nevent.tbl_uvregression
       - add_q.tbl_uvregression
-      - tbl_merge
-      - tbl_stack
 
   - title: "Inline Reporting"
     desc: >
@@ -82,6 +80,8 @@ reference:
     desc: >
       Functions for modifying table ascetics
     contents:
+      - tbl_merge
+      - tbl_stack
       - modify_header
       - style_percent
       - style_pvalue

--- a/tests/testthat/test-tbl_stack.R
+++ b/tests/testthat/test-tbl_stack.R
@@ -64,3 +64,13 @@ test_that("Stacking tbl_merge objects", {
     NA
   )
 })
+
+test_that("Stacking tbl_summary objects", {
+  yy <- tbl_summary(trial, by = response) %>% add_p() %>% add_q()
+  tt <- tbl_summary(trial, by = trt) %>% add_p() %>% add_q()
+
+  expect_error(
+    zz <- tbl_stack(list(yy, tt)),
+    NA
+  )
+})

--- a/tests/testthat/test-tbl_uvregression.R
+++ b/tests/testthat/test-tbl_uvregression.R
@@ -96,7 +96,29 @@ test_that("glmer: no errors/warnings with standard use", {
   )
 })
 
-test_that("tbl_regression creates errors with bad inputs", {
+test_that("tbl_uvregression x= argument tests", {
+  expect_error(
+    ux_x <- tbl_uvregression(
+      data = trial[c("age", "marker", "response")],
+      method = lm,
+      label = list(vars(`age`) ~ "PATIENT AGE"),
+      x = response
+    ),
+    NA
+  )
+
+  expect_identical(
+    ux_x$meta_data$label[1],
+    "PATIENT AGE"
+  )
+
+  expect_identical(
+    ux_x$tbl_regression_list$age$model_obj %>% coef(),
+    lm(age ~ response, trial) %>% coef()
+  )
+})
+
+test_that("tbl_uvregression creates errors with bad inputs", {
   expect_error(
     tbl_uvregression(
       data = mtcars,

--- a/tests/testthat/test-tbl_uvregression.R
+++ b/tests/testthat/test-tbl_uvregression.R
@@ -17,22 +17,31 @@ test_that("lm: no errors/warnings with standard use", {
 })
 
 test_that("coxph: no errors/warnings with standard use", {
-  expect_error(lung %>%
-    tbl_uvregression(
-      method = coxph,
-      y = Surv(time, status)
-    ), NA)
-  expect_warning(lung %>%
-    tbl_uvregression(
-      method = coxph,
-      y = Surv(time, status)
-    ), NA)
+  expect_error(
+    coxph_uv <-
+      lung %>%
+      tbl_uvregression(
+        method = coxph,
+        y = Surv(time, status)
+      ), NA)
+  expect_warning(
+    lung %>%
+      tbl_uvregression(
+        method = coxph,
+        y = Surv(time, status)
+      ), NA)
+
+  expect_identical(
+    coxph_uv$meta_data$variable,
+    setdiff(names(lung), c("time", "status"))
+  )
 })
 
 
 test_that("glmer: no errors/warnings with standard use", {
   expect_error(
-    mtcars %>%
+    lme4_uv <-
+      mtcars %>%
       dplyr::select("am", "gear", "hp", "cyl") %>%
       tbl_uvregression(
         method = glmer,
@@ -54,6 +63,10 @@ test_that("glmer: no errors/warnings with standard use", {
       ), NA
   )
 
+  expect_identical(
+    lme4_uv$meta_data$variable,
+    c("hp", "cyl")
+  )
 
   expect_error(
     mtcars %>%

--- a/vignettes/gallery.Rmd
+++ b/vignettes/gallery.Rmd
@@ -14,17 +14,17 @@ knitr::opts_chunk$set(
   comment = "#>"
 )
 
-# installing gt 
-if (curl::has_internet()) {
-  # adding tmpdir to libPath
-  temp_path <- file.path(tempdir(), "gt_folder")
-  dir.create(temp_path)
-  lib_path <-.libPaths()
-  .libPaths(c(lib_path, temp_path))
-  
-  # installing gt
-  remotes::install_github("rstudio/gt", lib = temp_path)
-}
+# # installing gt 
+# if (curl::has_internet()) {
+#   # adding tmpdir to libPath
+#   temp_path <- file.path(tempdir(), "gt_folder")
+#   dir.create(temp_path)
+#   lib_path <-.libPaths()
+#   .libPaths(c(lib_path, temp_path))
+#   
+#   # installing gt
+#   remotes::install_github("rstudio/gt", lib = temp_path)
+# }
 ```
 
 Gallery showing various tables possible with the {gtsummary} package.  If you have created an interesting table using {gtsummary}, please submit it to the gallery via a pull request to the [GitHub repository](https://github.com/ddsjoberg/gtsummary).

--- a/vignettes/gallery.Rmd
+++ b/vignettes/gallery.Rmd
@@ -16,9 +16,9 @@ knitr::opts_chunk$set(
 ```
 
 <!-- Not creating vignette if gt is not installed. -->
-`r if(requireNamespace("gt")){"The system this vignette was built on did not have the required {gt} package installed. Please visit the package website for the full vignette. http://www.danieldsjoberg.com/gtsummary/articles/gallery.html"}`
+`r if(!requireNamespace("gt")){"The system this vignette was built on did not have the required {gt} package installed. Please visit the package website for the full vignette. http://www.danieldsjoberg.com/gtsummary/articles/gallery.html"}`
 
-```{r exit_early, include = FALSE, eval = requireNamespace("gt")}
+```{r exit_early, include = FALSE, eval = !requireNamespace("gt")}
 knitr::knit_exit()
 ```
 

--- a/vignettes/gallery.Rmd
+++ b/vignettes/gallery.Rmd
@@ -152,7 +152,7 @@ tbl_merge(list(gt_eventn, gt_model)) %>%
 
 ---
 
-Regression model where the covariate remain the same, and the outcome changes.
+Regression model where the covariate remains the same, and the outcome changes.
 
 ```{r}
 tbl_reg <-

--- a/vignettes/gallery.Rmd
+++ b/vignettes/gallery.Rmd
@@ -156,7 +156,7 @@ tbl_merge(list(gt_eventn, gt_model)) %>%
 
 ---
 
-Regression model where the covariates remain the same, and the outcome changes.
+Regression model where the covariate remain the same, and the outcome changes.
 
 ```{r}
 df_models <-

--- a/vignettes/gallery.Rmd
+++ b/vignettes/gallery.Rmd
@@ -13,20 +13,16 @@ knitr::opts_chunk$set(
   eval = TRUE,
   comment = "#>"
 )
-
-# # installing gt 
-# if (curl::has_internet()) {
-#   # adding tmpdir to libPath
-#   temp_path <- file.path(tempdir(), "gt_folder")
-#   dir.create(temp_path)
-#   lib_path <-.libPaths()
-#   .libPaths(c(lib_path, temp_path))
-#   
-#   # installing gt
-#   remotes::install_github("rstudio/gt", lib = temp_path)
-# }
 ```
 
+<!-- Not creating vignette if gt is not installed. -->
+`r if(requireNamespace("gt")){"The system this vignette was built on did not have the required {gt} package installed. Please visit the package website for the full vignette. http://www.danieldsjoberg.com/gtsummary/articles/gallery.html"}`
+
+```{r exit_early, include = FALSE, eval = requireNamespace("gt")}
+knitr::knit_exit()
+```
+
+<!-- Start of vignette -->
 Gallery showing various tables possible with the {gtsummary} package.  If you have created an interesting table using {gtsummary}, please submit it to the gallery via a pull request to the [GitHub repository](https://github.com/ddsjoberg/gtsummary).
 
 ```{r, echo=FALSE, comment=""}
@@ -159,26 +155,20 @@ tbl_merge(list(gt_eventn, gt_model)) %>%
 Regression model where the covariate remain the same, and the outcome changes.
 
 ```{r}
-df_models <-
-  tibble(outcome = c("age", "marker")) %>%
-  mutate(
-    outcome_label = map_chr(outcome,
-                        ~attr(trial[[.x]], 'label')),
-    lm_model = map(outcome,
-                   ~lm(str_glue("{.x} ~ trt"), trial)),
-    tbl_reg = map2(
-      lm_model, outcome_label,
-      ~tbl_regression(.x, show_single_row = "trt", label = list(trt = .y))
-    )
-  )
-
-df_models %>%
-  pull(tbl_reg) %>%
-  tbl_stack() %>%
+tbl_reg <-
+  trial[c("age", "marker", "trt")] %>%
+  tbl_uvregression(
+    method = lm,
+    x = trt,
+    show_single_row = "trt",
+    hide_n = TRUE
+  ) %>%
   modify_header(
     label = md("**Model Outcome**"),
     estimate = md("**Treatment Coef.**")
-  ) %>%
+  ) 
+
+tbl_reg %>%
   as_gt() %>%
   tab_footnote(
     footnote = "Values larger than 0 indicate larger values in the Drug group.", 
@@ -198,21 +188,8 @@ gt_sum <-
   add_n() %>%
   modify_header(stat_by = md("**{level}**"))
 
-# before we merge we need to update the variable name in df_models gtsummary tables 
-# to match the tbl_summary object
-df_models2 <-
-  df_models %>%
-  mutate(tbl_reg = map2(tbl_reg, outcome,
-                        function(x, y){
-                          x$table_body$variable <- y 
-                          x
-                        }))
 
-
-tbl_merge(list(
-  gt_sum,
-  pull(df_models2, tbl_reg) %>% tbl_stack()
-)) %>%
+tbl_merge(list(gt_sum, tbl_reg))  %>%
   modify_header(estimate_2 = md("**Difference**")) %>%
   as_gt(exclude = "tab_spanner")
 ```

--- a/vignettes/global_options.Rmd
+++ b/vignettes/global_options.Rmd
@@ -15,6 +15,14 @@ knitr::opts_chunk$set(
 )
 ```
 
+<!-- Not creating vignette if gt is not installed. -->
+`r if(!requireNamespace("gt")){"The system this vignette was built on did not have the required {gt} package installed. Please visit the package website for the full vignette. http://www.danieldsjoberg.com/gtsummary/articles/global_options.html"}`
+
+```{r exit_early, include = FALSE, eval = !requireNamespace("gt")}
+knitr::knit_exit()
+```
+
+<!-- Start of vignette -->
 There are various global options that can be set for {gtsummary}.
 Here we review a complete list of options available to users.
 

--- a/vignettes/tbl_regression.Rmd
+++ b/vignettes/tbl_regression.Rmd
@@ -38,17 +38,17 @@ Before going through the tutorial, install {gtsummary} and {gt}.
 library(gtsummary)
 library(dplyr)
 
-# installing gt 
-if (curl::has_internet()) {
-  # adding tmpdir to libPath
-  temp_path <- file.path(tempdir(), "gt_folder")
-  dir.create(temp_path)
-  lib_path <-.libPaths()
-  .libPaths(c(lib_path, temp_path))
-  
-  # installing gt
-  remotes::install_github("rstudio/gt", lib = temp_path)
-}
+# # installing gt 
+# if (curl::has_internet()) {
+#   # adding tmpdir to libPath
+#   temp_path <- file.path(tempdir(), "gt_folder")
+#   dir.create(temp_path)
+#   lib_path <-.libPaths()
+#   .libPaths(c(lib_path, temp_path))
+#   
+#   # installing gt
+#   remotes::install_github("rstudio/gt", lib = temp_path)
+# }
 ```
 
 ```{r, eval=FALSE}

--- a/vignettes/tbl_regression.Rmd
+++ b/vignettes/tbl_regression.Rmd
@@ -19,6 +19,14 @@ knitr::opts_chunk$set(
 )
 ```
 
+<!-- Not creating vignette if gt is not installed. -->
+`r if(!requireNamespace("gt")){"The system this vignette was built on did not have the required {gt} package installed. Please visit the package website for the full vignette. http://www.danieldsjoberg.com/gtsummary/articles/tbl_regression.html"}`
+
+```{r exit_early, include = FALSE, eval = !requireNamespace("gt")}
+knitr::knit_exit()
+```
+
+<!-- Start of vignette -->
 ## Introduction
 
 This vignette will walk a reader through the `tbl_regression()` function, and the various functions available to modify and make additions to an existing formatted regression table. `tbl_regression()` uses `broom::tidy()` to perform the initial model formatting, and can accommodate many different model types (e.g. `lm()`, `glm()`, `survival::coxph()`, `survival::survreg()` and more). If your class of model is not supported , please [request support](https://github.com/ddsjoberg/gtsummary/issues).  In some cases, it is simple to support a new class of model.
@@ -37,18 +45,6 @@ Before going through the tutorial, install {gtsummary} and {gt}.
 ```{r, include=FALSE}
 library(gtsummary)
 library(dplyr)
-
-# # installing gt 
-# if (curl::has_internet()) {
-#   # adding tmpdir to libPath
-#   temp_path <- file.path(tempdir(), "gt_folder")
-#   dir.create(temp_path)
-#   lib_path <-.libPaths()
-#   .libPaths(c(lib_path, temp_path))
-#   
-#   # installing gt
-#   remotes::install_github("rstudio/gt", lib = temp_path)
-# }
 ```
 
 ```{r, eval=FALSE}

--- a/vignettes/tbl_summary.Rmd
+++ b/vignettes/tbl_summary.Rmd
@@ -45,17 +45,17 @@ Before going through the tutorial, install {gtsummary} and {gt}.
 library(gtsummary)
 library(dplyr)
 
-# installing gt 
-if (curl::has_internet()) {
-  # adding tmpdir to libPath
-  temp_path <- file.path(tempdir(), "gt_folder")
-  dir.create(temp_path)
-  lib_path <-.libPaths()
-  .libPaths(c(lib_path, temp_path))
-  
-  # installing gt
-  remotes::install_github("rstudio/gt", lib = temp_path)
-}
+# # installing gt 
+# if (curl::has_internet()) {
+#   # adding tmpdir to libPath
+#   temp_path <- file.path(tempdir(), "gt_folder")
+#   dir.create(temp_path)
+#   lib_path <-.libPaths()
+#   .libPaths(c(lib_path, temp_path))
+#   
+#   # installing gt
+#   remotes::install_github("rstudio/gt", lib = temp_path)
+# }
 ```
 
 ```{r, eval=FALSE}

--- a/vignettes/tbl_summary.Rmd
+++ b/vignettes/tbl_summary.Rmd
@@ -18,6 +18,14 @@ knitr::opts_chunk$set(
 )
 ```
 
+<!-- Not creating vignette if gt is not installed. -->
+`r if(!requireNamespace("gt")){"The system this vignette was built on did not have the required {gt} package installed. Please visit the package website for the full vignette. http://www.danieldsjoberg.com/gtsummary/articles/tbl_summary.html"}`
+
+```{r exit_early, include = FALSE, eval = !requireNamespace("gt")}
+knitr::knit_exit()
+```
+
+<!-- Start of vignette -->
 ## Introduction
 
 This vignette will walk a reader through the `tbl_summary()` function, and the various functions available to modify and make additions to an existing table summary object.
@@ -44,18 +52,6 @@ Before going through the tutorial, install {gtsummary} and {gt}.
 ```{r, include=FALSE}
 library(gtsummary)
 library(dplyr)
-
-# # installing gt 
-# if (curl::has_internet()) {
-#   # adding tmpdir to libPath
-#   temp_path <- file.path(tempdir(), "gt_folder")
-#   dir.create(temp_path)
-#   lib_path <-.libPaths()
-#   .libPaths(c(lib_path, temp_path))
-#   
-#   # installing gt
-#   remotes::install_github("rstudio/gt", lib = temp_path)
-# }
 ```
 
 ```{r, eval=FALSE}


### PR DESCRIPTION
- What changes are proposed in this pull request?
  - no longer installing gt from github
  - added gt to a drat repo, and installing from there 
  - added functionality for `tbl_uvregression()` to keep a co variate constant and vary the outcome. (#294)
  - fixed bug where labels for `tbl_uvregression()` and `tbl_regression()` could not be passed as named lists.
  - changed the label header in `tbl_uvregression()` and `tbl_regression()` from **Characteristic** to **Covariate**.  In `tbl_uvregression()`, if the user specified the `x=` argument (rather than `y=), the header is now **Outcome**



--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, was function included in `pkgdown.yml`
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

