### PR TITLE
# 283 update add_p() warnings and errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.3.9001
+Version: 1.2.3.9002
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Updated the trial example dataset `"trt"` variable to be `"Drug A"` and `"Drug B"` instead of `"Placebo"` and `"Drug"`
 
+* Improved messaging to users when an error or warning occurs while calculating a p-value in `add_p()`.  Also, p-values are no longer omitted from output when a warning is encountered during their calculation (#283) 
+
 # gtsummary 1.2.3
 
 * `tbl_uvregression()` now accepts an `x=` argument to build univariate regression models where the covariate `x` remains the same while models are built the with remaining variables as the outcome (#294)

--- a/R/utils-add_p.R
+++ b/R/utils-add_p.R
@@ -202,7 +202,6 @@ add_p_test_safe <- function(data, variable, by, group, test, include = NULL, typ
           "and test '{test}':\n ", as.character(w)
         ))
         invokeRestart("muffleWarning")
-        return(NULL)
       }
     ),
     error = function(e) {

--- a/R/utils-add_p.R
+++ b/R/utils-add_p.R
@@ -171,37 +171,48 @@ add_p_test_safe <- function(data, variable, by, group, test, include = NULL, typ
   data <- stats::na.omit(data[c(variable, by, group)])
 
   # calculating pvalue
-  tryCatch({
-    test_func <- switch(
-      test,
-      t.test = add_p_test_t.test,
-      aov = add_p_test_aov,
-      kruskal.test = add_p_test_kruskal.test,
-      wilcox.test = add_p_test_wilcox.test,
-      chisq.test = add_p_test_chisq.test,
-      chisq.test.no.correct = add_p_test_chisq.test.no.correct,
-      fisher.test = add_p_test_fisher.test,
-      lme4 = add_p_test_lme4
-    ) %||% # if not an internal test, then resolving to function name supplied
-      test
+  tryCatch(
+    withCallingHandlers(
+      {
+        test_func <- switch(
+          test,
+          t.test = add_p_test_t.test,
+          aov = add_p_test_aov,
+          kruskal.test = add_p_test_kruskal.test,
+          wilcox.test = add_p_test_wilcox.test,
+          chisq.test = add_p_test_chisq.test,
+          chisq.test.no.correct = add_p_test_chisq.test.no.correct,
+          fisher.test = add_p_test_fisher.test,
+          lme4 = add_p_test_lme4
+        ) %||% # if not an internal test, then resolving to function name supplied
+          test
 
-    # initializing to NA
-    pval <- NA_real_
-    pval <- do.call(test_func, list(data = data, variable = variable,
-                                    by = by, group = group, test = test,
-                                    type = type))
-  },
-  # printing warning and errors as message
-  warning = function(w) {
-    message(glue("Warning in 'add_p()' for variable '{variable}' ",
-                 "and test '{test}', p-value omitted:\n", as.character(w)))
-    return(NULL)
-  },
-  error = function(e) {
-    message(glue("Error in 'add_p()' for variable '{variable}' ",
-                 "and test '{test}', p-value omitted:\n", as.character(e)))
-    return(NULL)
-  })
+        # initializing to NA
+        pval <- NA_real_
+        pval <- do.call(test_func, list(
+          data = data, variable = variable,
+          by = by, group = group, test = test,
+          type = type
+        ))
+      },
+      # printing warning and errors as message
+      warning = function(w) {
+        message(glue(
+          "Warning in 'add_p()' for variable '{variable}' ",
+          "and test '{test}':\n ", as.character(w)
+        ))
+        invokeRestart("muffleWarning")
+        return(NULL)
+      }
+    ),
+    error = function(e) {
+      message(glue(
+        "There was an error in 'add_p()' for variable '{variable}' ",
+        "and test '{test}', p-value omitted:\n", as.character(e)
+      ))
+      return(NULL)
+    }
+  )
 
   pval
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.3.9001",
+  "version": "1.2.3.9002",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -429,9 +429,9 @@
       "sameAs": "https://CRAN.R-project.org/package=usethis"
     }
   ],
-  "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
-  "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1539.728KB",
+  "releaseNotes": "https://github.com/karissawhiting/gtsummary/blob/master/NEWS.md",
+  "readme": "https://github.com/karissawhiting/gtsummary/blob/master/README.md",
+  "fileSize": "1542.508KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",


### PR DESCRIPTION

- **What changes are proposed in this pull request?** - Previously p-value calculations that threw a warning were not included in summary tables. With this PR, the warning is displayed, but the p-value calculation is still completed and p-value is available in tables. 

- **If there is a GitHub issue associated with this pull request, please provide link.**
#283 

Code to test warnings:

```
library(tidyverse)

df <- tribble( ~x, ~y, ~z,
               0, 2, 0,
               3, 4, 0,
               3, 4, 1,
               1, 0, 0 )

df %>%
  tbl_summary(by = y) %>%
  add_p(test = all_numeric() ~ "chisq.test")
```

Code to test errors + warnings:


```
library(tidyverse)

df <- tribble( ~x, ~y, ~z, 
               0, 0, 0,
               0, 0, 0,
               0, 4, 1,
               0, 0, 0 )

df %>%
  tbl_summary(by = y) %>%
  add_p(test = all_numeric() ~ "chisq.test")
```


--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, was function included in `pkgdown.yml`
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

