### PR TITLE
updated cells_data to cells_body

### DIFF
--- a/R/bold_italicise_labels_levels.R
+++ b/R/bold_italicise_labels_levels.R
@@ -40,7 +40,7 @@ bold_labels <- function(x) {
   # adding p-value formatting
   x[["gt_calls"]][["bold_labels"]] <- glue(
     "gt::tab_style(style = gt::cell_text(weight = 'bold'), ",
-    "locations = gt::cells_data(columns = gt::vars(label),",
+    "locations = gt::cells_body(columns = gt::vars(label),",
     "rows = row_type == 'label'))"
   )
 
@@ -77,7 +77,7 @@ bold_levels <- function(x) {
   # adding p-value formatting
   x[["gt_calls"]][["bold_levels"]] <- glue(
     "gt::tab_style(style = gt::cell_text(weight = 'bold'), ",
-    "locations = gt::cells_data(columns = gt::vars(label),",
+    "locations = gt::cells_body(columns = gt::vars(label),",
     "rows = row_type %in% c('level', 'missing')))"
   )
 
@@ -116,7 +116,7 @@ italicize_labels <- function(x) {
   # adding p-value formatting
   x[["gt_calls"]][["italicize_labels"]] <- glue(
     "gt::tab_style(style = gt::cell_text(style = 'italic'), ",
-    "locations = gt::cells_data(columns = gt::vars(label),",
+    "locations = gt::cells_body(columns = gt::vars(label),",
     "rows = row_type == 'label'))"
   )
 
@@ -155,7 +155,7 @@ italicize_levels <- function(x) {
   # adding p-value formatting
   x[["gt_calls"]][["italicize_levels"]] <- glue(
     "gt::tab_style(style = gt::cell_text(style = 'italic'), ",
-    "locations = gt::cells_data(columns = gt::vars(label),",
+    "locations = gt::cells_body(columns = gt::vars(label),",
     "rows = row_type %in% c('level', 'missing')))"
   )
 

--- a/R/tbl_merge.R
+++ b/R/tbl_merge.R
@@ -267,7 +267,7 @@ gt_tbl_merge <- quote(list(
   tab_style_text_indent = glue(
     "gt::tab_style(",
     "style = gt::cell_text(indent = gt::px(10), align = 'left'),",
-    "locations = gt::cells_data(",
+    "locations = gt::cells_body(",
     "columns = gt::vars(label),",
     "rows = row_type != 'label'",
     "))"

--- a/R/tbl_regression.R
+++ b/R/tbl_regression.R
@@ -282,7 +282,7 @@ gt_tbl_regression <- quote(list(
   tab_style_text_indent = glue(
     "gt::tab_style(",
     "style = gt::cell_text(indent = gt::px(10), align = 'left'),",
-    "locations = gt::cells_data(",
+    "locations = gt::cells_body(",
     "columns = gt::vars(label), ",
     "rows = row_type != 'label'",
     "))"

--- a/R/tbl_summary.R
+++ b/R/tbl_summary.R
@@ -372,7 +372,7 @@ gt_tbl_summary <- quote(list(
   tab_style_text_indent = glue(
     "gt::tab_style(",
     "style = gt::cell_text(indent = gt::px(10), align = 'left'),",
-    "locations = gt::cells_data(",
+    "locations = gt::cells_body(",
     "columns = gt::vars(label),",
     "rows = row_type != 'label'",
     "))"

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -349,7 +349,7 @@ gt_tbl_uvregression <- quote(list(
   tab_style_text_indent = glue(
     "gt::tab_style(",
     "style = gt::cell_text(indent = gt::px(10), align = 'left'),",
-    "locations = gt::cells_data(",
+    "locations = gt::cells_body(",
     "columns = gt::vars(label), ",
     "rows = row_type != 'label'",
     "))"

--- a/R/utils-table_headers.R
+++ b/R/utils-table_headers.R
@@ -102,7 +102,7 @@ table_header_to_gt_fmt <- function(table_header) {
       col_label_code =
         glue(
           "gt::tab_style(style = gt::cell_text(weight = 'bold'), ",
-          "locations = gt::cells_data(columns = gt::vars({column}), ",
+          "locations = gt::cells_body(columns = gt::vars({column}), ",
           "rows = {column} <= {bold}))"
         )
     ) %>%


### PR DESCRIPTION
- What changes are proposed in this pull request?

The gt package has deprecated `cells_data()` in favor of `cells_body()`

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, was function included in `pkgdown.yml`
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

