### PR TITLE
256 gtsummary select functions in type argument

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,8 @@ Checklist for PR reviewer
 - [ ] PR branch has pulled the most recent updates from master branch 
 - [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
 - [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
-- [ ] If a new function was added, was function included in `pkgdown.yml`
+- [ ] If a new function was added, function included in `pkgdown.yml`
+- [ ] If a bug was fixed, a unit test was added for the bug check
 - [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
 - [ ] Code coverage is suitable for any new functions/features. 
 - [ ] R CMD Check runs without errors, warnings, and notes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.4.9000
+Version: 1.2.4.9001
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # gtsummary (development version)
 
+* Functions `all_categorical()`, `all_dichotomous()`, and `all_continuous()` may now be used in `tbl_summary()` argument `type=` (#256)
+
+* Updates after the gt package deprecated `gt::cells_data()` in favor of `gt::cells_body()`
+
 # gtsummary 1.2.4
 
 * Bug fix in `as_kable()` where column header did not match statistics presented when certain levels of the `by=` variable are entirely missing in `tbl_summary()` (#304)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Functions `all_categorical()`, `all_dichotomous()`, and `all_continuous()` may now be used in `tbl_summary()` argument `type=` (#256)
 
-* Updates after the gt package deprecated `gt::cells_data()` in favor of `gt::cells_body()`
+* Updates after the gt package deprecated `gt::cells_data()` in favor of `gt::cells_body()`. Check added to `as_gt()` ensuring a version of gt with `gt::cells_body()` in its NAMESPACE
 
 # gtsummary 1.2.4
 

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -34,6 +34,16 @@
 #' \if{html}{\figure{as_gt_ex.png}{options: width=50\%}}
 
 as_gt <- function(x, include = NULL, exclude = NULL, omit = NULL) {
+  # checking if updated version of gt package is required 2019-12-25 -----------
+  if (!exists("cells_body", asNamespace("gt"))) {
+    usethis::ui_oops(glue(
+      "An updated version of the gt package is required to print table.\n",
+      "To install the most recent version of gt, run"
+    ))
+    usethis::ui_code_block("remotes::install_github(\"rstudio/gt\")")
+    return(invisible())
+  }
+
   # making list of commands to include -----------------------------------------
   if (!is.null(omit)) {
     lifecycle::deprecate_warn(

--- a/R/tbl_regression.R
+++ b/R/tbl_regression.R
@@ -120,8 +120,9 @@ tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
     getOption("gtsummary.conf.level", default = 0.95)
 
   # checking estimate_fun and pvalue_fun are functions
-  if (!is.function(estimate_fun) | !is.function(pvalue_fun)) {
-    stop("Inputs 'estimate_fun' and 'pvalue_fun' must be functions.")
+  if (!purrr::every(list(estimate_fun, pvalue_fun, tidy_fun %||% pvalue_fun), is.function)) {
+    stop("Inputs `estimate_fun`, `pvalue_fun`, `tidy_fun` must be functions.",
+         call. = FALSE)
   }
 
   # converting tidyselect formula lists to named lists
@@ -144,13 +145,13 @@ tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
         "Review the GitHub issue linked below for a possible solution."
       ))
       usethis::ui_code_block("https://github.com/ddsjoberg/gtsummary/issues/231")
-      stop(e)
+      stop(e, call. = FALSE)
     }
   )
   label <- tidyselect_to_list(model_frame, label, input_type = "label")
   # all sepcifed labels must be a string of length 1
   if (!every(label, ~ rlang::is_string(.x))) {
-    stop("Each `label` specified must be a string of length 1.")
+    stop("Each `label` specified must be a string of length 1.", call. = FALSE)
   }
 
   # will return call, and all object passed to in tbl_regression call
@@ -187,7 +188,7 @@ tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
     if (length(include_err) > 0) {
       stop(glue(
         "'include' must be be a subset of '{paste(table_body$variable %>% unique(), collapse = ', ')}'"
-      ))
+      ), call. = FALSE)
     }
   }
   if (is.null(include)) include <- table_body$variable %>% unique()

--- a/R/utils-tbl_summary.R
+++ b/R/utils-tbl_summary.R
@@ -166,7 +166,7 @@ assign_stat_display <- function(variable, summary_type, stat_display) {
 #'   summary_type = NULL, value = NULL
 #' )
 assign_summary_type <- function(data, variable, class, summary_type, value) {
-  map2_chr(
+  type <- map2_chr(
     variable, class,
     ~ summary_type[[.x]] %||%
       case_when(
@@ -202,6 +202,19 @@ assign_summary_type <- function(data, variable, class, summary_type, value) {
         TRUE ~ "continuous"
       )
   )
+
+  # checking user did not request a factor or character variable be summarized
+  # as a continuous variable
+  purrr::pwalk(
+    list(type, class, variable),
+    ~ if(..1 == "continuous" && ..2 %in% c("factor", "character"))
+      stop(glue(
+        "Column '{..3}' is class \"{..2}\" and cannot be summarized as a continuous variable."
+      ), call. = FALSE)
+  )
+
+
+  type
 }
 
 

--- a/R/utils-tbl_summary.R
+++ b/R/utils-tbl_summary.R
@@ -31,7 +31,7 @@ assign_class <- function(data, variable) {
   map2_chr(
     variable, classes_return,
     ~ ifelse(data[[.x]] %>% is.na() %>% all(),
-      NA_character_, .y
+             NA_character_, .y
     )
   )
 }
@@ -130,11 +130,11 @@ assign_stat_display <- function(variable, summary_type, stat_display) {
       variable, summary_type,
       ~ case_when(
         .y == "continuous" ~
-        stat_display[[.x]] %||%
+          stat_display[[.x]] %||%
           stat_display[["..continuous.."]] %||%
           "{median} ({p25}, {p75})",
         .y %in% c("categorical", "dichotomous") ~
-        stat_display[[.x]] %||%
+          stat_display[[.x]] %||%
           stat_display[["..categorical.."]] %||%
           "{n} ({p}%)"
       )
@@ -192,7 +192,7 @@ assign_summary_type <- function(data, variable, class, summary_type, value) {
 
         # factors and characters are categorical
         .y %in% c("factor", "character") ~
-        "categorical",
+          "categorical",
 
         # numeric variables with fewer than 10 levels will be categorical
         .y %in% c("integer", "numeric") & length(unique(na.omit(data[[.x]]))) < 10
@@ -488,7 +488,7 @@ summarize_categorical <- function(data, variable, by, var_label,
                                   missing_text, sort, percent) {
   percent_fun <-
     getOption("gtsummary.tbl_summary.percent_fun",
-      default = style_percent
+              default = style_percent
     )
   if (!rlang::is_function(percent_fun)) {
     stop(paste0(
@@ -607,8 +607,8 @@ summarize_categorical <- function(data, variable, by, var_label,
     nest() %>%
     mutate(
       missing_count = map_chr(data, ~ .x[[1]] %>%
-        is.na() %>%
-        sum())
+                                is.na() %>%
+                                sum())
     ) %>%
     select(c("by_col", "missing_count")) %>%
     spread(!!sym("by_col"), !!sym("missing_count")) %>%
@@ -976,23 +976,10 @@ tbl_summary_input_checks <- function(data, by, label, type, value, statistic,
     # all sepcifed types are continuous, categorical, or dichotomous
     if ("formula" %in% class(type)) type <- list(type)
     if (!every(type, ~ eval(rlang::f_rhs(.x)) %in% c("continuous", "categorical", "dichotomous")) |
-      !every(type, ~ rlang::is_string(eval(rlang::f_rhs(.x))))) {
+        !every(type, ~ rlang::is_string(eval(rlang::f_rhs(.x))))) {
       stop(glue(
         "The RHS of the formula in the 'type'  argument must of one and only one of ",
         "\"continuous\", \"categorical\", or \"dichotomous\""
-      ))
-    }
-
-    # functions all_continuous, all_categorical, and all_dichotomous cannot be used for type
-    if (some(
-      type,
-      ~ deparse(.x) %>% # converts a formula to a string
-        stringr::str_detect(c("all_continuous()", "all_categorical()", "all_dichotomous()")) %>%
-        any()
-    )) {
-      stop(glue(
-        "Select functions all_continuous(), all_categorical(), all_dichotomous() ",
-        "cannot be used in the 'type' argument."
       ))
     }
   }
@@ -1024,8 +1011,8 @@ tbl_summary_input_checks <- function(data, by, label, type, value, statistic,
     if (some(
       value,
       ~ deparse(.x) %>% # converts a formula to a string
-        stringr::str_detect(c("all_continuous()", "all_categorical()", "all_dichotomous()")) %>%
-        any()
+      stringr::str_detect(c("all_continuous()", "all_categorical()", "all_dichotomous()")) %>%
+      any()
     )) {
       stop(glue(
         "Select functions all_continuous(), all_categorical(), all_dichotomous() ",
@@ -1168,7 +1155,7 @@ tbl_summary_input_checks <- function(data, by, label, type, value, statistic,
     # all sepcifed types are frequency or alphanumeric
     if ("formula" %in% class(sort)) sort <- list(sort)
     if (!every(sort, ~ eval(rlang::f_rhs(.x)) %in% c("frequency", "alphanumeric")) |
-      !every(sort, ~ rlang::is_string(eval(rlang::f_rhs(.x))))) {
+        !every(sort, ~ rlang::is_string(eval(rlang::f_rhs(.x))))) {
       stop(glue(
         "The RHS of the formula in the 'sort' argument must of one and only one of ",
         "\"frequency\" or \"alphanumeric\""

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.4",
+  "version": "1.2.4.9001",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -431,7 +431,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1544.415KB",
+  "fileSize": "1544.394KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/tests/testthat/test-tbl_summary.R
+++ b/tests/testthat/test-tbl_summary.R
@@ -231,3 +231,13 @@ test_that("tbl_summary-order of output columns", {
     paste0("stat_", 1:3)
   )
 })
+
+test_that("tbl_summary-all_categorical() use with `type=`", {
+  # no variables should be dichotomous
+  expect_true(
+    !"dichotomous" %in%
+      (tbl_summary(trial, type = all_dichotomous() ~ "categorical") %>%
+      purrr::pluck("meta_data") %>%
+      dplyr::pull(summary_type))
+  )
+})

--- a/tests/testthat/test-tbl_summary_input_checks.R
+++ b/tests/testthat/test-tbl_summary_input_checks.R
@@ -10,10 +10,6 @@ test_that("input check", {
     "*"
   )
   expect_error(
-    tbl_summary(trial, type = all_continuous() ~ "continuous"),
-    "*"
-  )
-  expect_error(
     tbl_summary(trial, value = list("Drug")),
     "*"
   )


### PR DESCRIPTION
- What changes are proposed in this pull request?

Functions `all_categorical()`, `all_dichotomous()`, and `all_continuous()` may now be used in `tbl_summary()` argument `type=`.  We now make our best guess for the type each column is (i.e. continuous, categorical, or dichotomous).  After we make a guess, the user may use  `all_dichotomous()` to change all columns defaulting to dichotomous to categorical, for example (`type = all_dichotomous() ~ "categorical"`).

We also will now throw an error is the user requests a factor or character to be summarized continuously.

There were all small updates the the PR template and error messaging in `tbl_regression()`.

- If there is an GitHub issue associated with this pull request, please provide link.
#256, #320 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, was function included in `pkgdown.yml`
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. 
- [x] R CMD Check runs without errors, warnings, and notes
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

