### PR TITLE
deprecated exclude argument

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
-- What changes are proposed in this pull request?
+**What changes are proposed in this pull request?**
 
-- If there is an GitHub issue associated with this pull request, please provide link.
+
+**If there is an GitHub issue associated with this pull request, please provide link.**
 
 
 --------------------------------------------------------------------------------

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.4.9004
+Version: 1.2.4.9005
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
     
     purrr::map(c("trt", "grade"), ~tbl_summary(trial, by = .x))
     ```
-* After the input updates in #250, the `exclude=` argument appearing in `add_p()`, `tbl_regression()`, `tbl_uvregression()`, `as_gt()`, `as_kable()`, and `as_tibble()` was redundent.  The `exclude=` argument is now deprecated (#331)
+* After the input updates in #250, the `exclude=` argument appearing in `add_p()`, `tbl_regression()`, `tbl_uvregression()`, `as_gt()`, `as_kable()`, and `as_tibble()` was redundant.  The `exclude=` argument is now deprecated (#331)
 
 * New `pattern=` argument in `inline_text.tbl_summary()`.  Previously, we could only grab the entire cell from a `tbl_summary()` with `inline_text()`, and now we can get any single statistic reported (#254)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gtsummary (development version)
 
-* Package-wide update allowing arguments that accept variable names to accept bare/symbol inputs, character inputs, stored character inputs, and tidyselect helpers.  When passing a single variable, the `vars()` function wrapper is no longer required. #250
+* Package-wide update allowing arguments that accept variable names to accept bare/symbol inputs, character inputs, stored character inputs, and tidyselect helpers.  When passing a single variable, the `vars()` function wrapper is no longer required. (#250)
 
     ```r
     tbl_summary(trial, label = age ~ "NEW LABEL"))
@@ -16,14 +16,15 @@
     
     purrr::map(c("trt", "grade"), ~tbl_summary(trial, by = .x))
     ```
+* After the input updates in #250, the `exclude=` argument appearing in `add_p()`, `tbl_regression()`, `tbl_uvregression()`, `as_gt()`, `as_kable()`, and `as_tibble()` was redundent.  The `exclude=` argument is now deprecated (#331)
 
-* New `pattern=` argument in `inline_text.tbl_summary()`.  Previously, we could only grab the entire cell from a `tbl_summary()` with `inline_text()`, and now we can get any single statistic reported #254
+* New `pattern=` argument in `inline_text.tbl_summary()`.  Previously, we could only grab the entire cell from a `tbl_summary()` with `inline_text()`, and now we can get any single statistic reported (#254)
 
-* Cubic spline terms are now accurately matched to a variable name/term #312
+* Cubic spline terms are now accurately matched to a variable name/term (#312)
 
-* Improved error messaging in `tidyselect_to_list()` #300
+* Improved error messaging in `tidyselect_to_list()` (#300)
 
-* Functions `tbl_summary_()` and `add_p_()` have been deprecated because the `by=` and `group=` arguments now accept strings #250
+* Functions `tbl_summary_()` and `add_p_()` have been deprecated because the `by=` and `group=` arguments now accept strings (#250)
 
 * Bug fix when non-standard evaluation arguments were passed in `method.args=` argument of `tbl_uvregression()` (#322)
 

--- a/R/add_global_p.R
+++ b/R/add_global_p.R
@@ -6,7 +6,7 @@
 #'
 #' @section Note:
 #' If a needed class of model is not supported by
-#' [car::Anova], please create an
+#' [car::Anova], please create a
 #' [GitHub Issue](https://github.com/ddsjoberg/gtsummary/issues) to request support.
 #'
 #' @param x `tbl_regression` or `tbl_uvregression` object
@@ -34,8 +34,8 @@ add_global_p <- function(x, ...) {
 #'
 #' @section Note:
 #' If a needed class of model is not supported by
-#' [car::Anova], please create an
-#' [issue](https://github.com/ddsjoberg/gtsummary/issues) to request support.
+#' [car::Anova], please create a
+#' [GitHub Issue](https://github.com/ddsjoberg/gtsummary/issues) to request support.
 #'
 #'
 #' @param x Object with class `tbl_regression` from the
@@ -47,8 +47,6 @@ add_global_p <- function(x, ...) {
 #' quoted or unquoted variable names. tidyselect and gtsummary select helper
 #' functions are also accepted. Default is `NULL`, which adds global p-values
 #' for all categorical and interaction terms.
-#' @param include Character vector or tidyselect function indicating
-#' variables to include global p-values
 #' @param terms DEPRECATED.  Use `include=` argument instead.
 #' @param ... Additional arguments to be passed to [car::Anova]
 #' @author Daniel D. Sjoberg

--- a/R/add_global_p.R
+++ b/R/add_global_p.R
@@ -67,7 +67,7 @@ add_global_p.tbl_regression <- function(x, include = NULL,
   # deprecated arguments -------------------------------------------------------
   if (!is.null(terms)) {
     lifecycle::deprecate_warn(
-      "1.3.0", "gtsummary::add_global_p.tbl_regression(terms = )",
+      "1.2.5", "gtsummary::add_global_p.tbl_regression(terms = )",
       "add_global_p.tbl_regression(include = )"
     )
     include <- terms

--- a/R/add_global_p.R
+++ b/R/add_global_p.R
@@ -7,7 +7,7 @@
 #' @section Note:
 #' If a needed class of model is not supported by
 #' [car::Anova], please create an
-#' [issue](https://github.com/ddsjoberg/gtsummary/issues) to request support.
+#' [GitHub Issue](https://github.com/ddsjoberg/gtsummary/issues) to request support.
 #'
 #' @param x `tbl_regression` or `tbl_uvregression` object
 #' @param ... Further arguments passed to or from other methods.
@@ -43,8 +43,11 @@ add_global_p <- function(x, ...) {
 #' @param keep Logical argument indicating whether to also retain the individual
 #' p-values in the table output for each level of the categorical variable.
 #' Default is `FALSE`
+#' @param include Variables to calculate global p-value for. Input may be a vector of
+#' quoted or unquoted variable names. tidyselect and gtsummary select helper
+#' functions are also accepted. Default is `NULL`, which adds global p-values
+#' for all categorical and interaction terms.
 #' @param include Character vector or tidyselect function indicating variables to include global p-values
-#' @param exclude Character vector or tidyselect function indicating variables to exclude global p-values
 #' @param terms DEPRECATED.  Use `include=` argument instead.
 #' @param ... Additional arguments to be passed to [car::Anova]
 #' @author Daniel D. Sjoberg
@@ -59,7 +62,7 @@ add_global_p <- function(x, ...) {
 #' @section Example Output:
 #' \if{html}{\figure{tbl_lm_global_ex1.png}{options: width=50\%}}
 
-add_global_p.tbl_regression <- function(x, include = NULL, exclude = NULL,
+add_global_p.tbl_regression <- function(x, include = NULL,
                                         keep = FALSE, terms = NULL, ...) {
   # deprecated arguments -------------------------------------------------------
   if (!is.null(terms)) {
@@ -73,8 +76,6 @@ add_global_p.tbl_regression <- function(x, include = NULL, exclude = NULL,
   # converting to charcter vector ----------------------------------------------
   include <- var_input_to_string(data = vctr_2_tibble(unique(x$table_body$variable)),
                                  select_input = !!rlang::enquo(include))
-  exclude <- var_input_to_string(data = vctr_2_tibble(unique(x$table_body$variable)),
-                                 select_input = !!rlang::enquo(exclude))
 
   # fetching categorical variables from model
   if (is.null(include))
@@ -83,10 +84,6 @@ add_global_p.tbl_regression <- function(x, include = NULL, exclude = NULL,
     filter(.data$var_type %in% c("categorical", "interaction")) %>%
     pull(.data$variable) %>%
     unique()
-
-  include <- include %>% setdiff(exclude)
-
-
 
   # if no terms are provided, stop and return x
   if (length(include) == 0) {

--- a/R/add_global_p.R
+++ b/R/add_global_p.R
@@ -47,7 +47,8 @@ add_global_p <- function(x, ...) {
 #' quoted or unquoted variable names. tidyselect and gtsummary select helper
 #' functions are also accepted. Default is `NULL`, which adds global p-values
 #' for all categorical and interaction terms.
-#' @param include Character vector or tidyselect function indicating variables to include global p-values
+#' @param include Character vector or tidyselect function indicating
+#' variables to include global p-values
 #' @param terms DEPRECATED.  Use `include=` argument instead.
 #' @param ... Additional arguments to be passed to [car::Anova]
 #' @author Daniel D. Sjoberg
@@ -62,7 +63,8 @@ add_global_p <- function(x, ...) {
 #' @section Example Output:
 #' \if{html}{\figure{tbl_lm_global_ex1.png}{options: width=50\%}}
 
-add_global_p.tbl_regression <- function(x, include = NULL,
+add_global_p.tbl_regression <- function(x,
+                                        include = x$table_body$variable[x$table_body$var_type %in% c("categorical", "interaction")],
                                         keep = FALSE, terms = NULL, ...) {
   # deprecated arguments -------------------------------------------------------
   if (!is.null(terms)) {
@@ -77,20 +79,11 @@ add_global_p.tbl_regression <- function(x, include = NULL,
   include <- var_input_to_string(data = vctr_2_tibble(unique(x$table_body$variable)),
                                  select_input = !!rlang::enquo(include))
 
-  # fetching categorical variables from model
-  if (is.null(include))
-    include <- x %>%
-    pluck("table_body") %>%
-    filter(.data$var_type %in% c("categorical", "interaction")) %>%
-    pull(.data$variable) %>%
-    unique()
-
   # if no terms are provided, stop and return x
   if (length(include) == 0) {
     message("No terms were selected, and no global p-values added to table")
     return(x)
   }
-
 
   # calculating global pvalues
   tryCatch(

--- a/R/add_p.R
+++ b/R/add_p.R
@@ -76,7 +76,7 @@
 #' \if{html}{\figure{add_p_ex2.png}{options: width=45\%}}
 
 add_p <- function(x, test = NULL, pvalue_fun = NULL,
-                  group = NULL, include = NULL, exclude = NULL) {
+                  group = NULL, include = everything(), exclude = NULL) {
 
   # DEPRECATION notes ----------------------------------------------------------
   if (!rlang::quo_is_null(rlang::enquo(exclude))) {
@@ -158,7 +158,6 @@ add_p <- function(x, test = NULL, pvalue_fun = NULL,
   }
 
   # Getting p-values only for included variables
-  if (is.null(include)) include <- x$table_body$variable %>% unique()
   include <- include %>% setdiff(exclude)
 
 

--- a/R/add_p.R
+++ b/R/add_p.R
@@ -32,9 +32,9 @@
 #' for categorical variables with any expected cell count <5.
 #' A custom test function can be added for all or some variables. See below for
 #' an example.
-#' @param group Column name of an ID or grouping variable. The column can be
-#' used calculate p-values with correlated data (e.g. when the test argument
-#' is `"lme4"`). Default is `NULL`.  If specified,
+#' @param group Column name (unquoted or quoted) of an ID or grouping variable.
+#' The column can be used calculate p-values with correlated data (e.g. when
+#' the test argument is `"lme4"`). Default is `NULL`.  If specified,
 #' the row associated with this variable is omitted from the summary table.
 #' @inheritParams tbl_regression
 #' @inheritParams tbl_summary
@@ -77,6 +77,20 @@
 
 add_p <- function(x, test = NULL, pvalue_fun = NULL,
                   group = NULL, include = NULL, exclude = NULL) {
+
+  # DEPRECATION notes ----------------------------------------------------------
+  if (!rlang::quo_is_null(rlang::enquo(exclude))) {
+    lifecycle::deprecate_warn(
+      "1.2.5",
+      "gtsummary::add_p(exclude = )",
+      "add_p(include = )",
+      details = paste0(
+        "The `include` argument accepts quoted and unquoted expressions similar\n",
+        "`dplyr::select()`. To exclude variable, use the minus sign.\n",
+        "For example, `include = -c(age, stage)`"
+      )
+    )
+  }
 
   # converting bare arguments to string ----------------------------------------
   group <- var_input_to_string(data = x$inputs$data, select_input = !!rlang::enquo(group),

--- a/R/add_p.R
+++ b/R/add_p.R
@@ -33,7 +33,7 @@
 #' A custom test function can be added for all or some variables. See below for
 #' an example.
 #' @param group Column name (unquoted or quoted) of an ID or grouping variable.
-#' The column can be used calculate p-values with correlated data (e.g. when
+#' The column can be used to calculate p-values with correlated data (e.g. when
 #' the test argument is `"lme4"`). Default is `NULL`.  If specified,
 #' the row associated with this variable is omitted from the summary table.
 #' @inheritParams tbl_regression
@@ -86,7 +86,7 @@ add_p <- function(x, test = NULL, pvalue_fun = NULL,
       "add_p(include = )",
       details = paste0(
         "The `include` argument accepts quoted and unquoted expressions similar\n",
-        "`dplyr::select()`. To exclude variable, use the minus sign.\n",
+        "to `dplyr::select()`. To exclude variable, use the minus sign.\n",
         "For example, `include = -c(age, stage)`"
       )
     )

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -35,7 +35,7 @@
 #' \if{html}{\figure{as_gt_ex.png}{options: width=50\%}}
 
 as_gt <- function(x, include = everything(), exclude = NULL, omit = NULL) {
-  # DEPRECATRED notice ---------------------------------------------------------
+  # DEPRECATED notice ---------------------------------------------------------
   # checking if updated version of gt package is required 2019-12-25 -----------
   if (!exists("cells_body", asNamespace("gt"))) {
     usethis::ui_oops(glue(
@@ -54,7 +54,7 @@ as_gt <- function(x, include = everything(), exclude = NULL, omit = NULL) {
       "as_gt(include = )",
       details = paste0(
         "The `include` argument accepts quoted and unquoted expressions similar\n",
-        "`dplyr::select()`. To exclude commands, use the minus sign.\n",
+        "to `dplyr::select()`. To exclude commands, use the minus sign.\n",
         "For example, `include = -tab_spanner`"
       )
     )
@@ -67,7 +67,7 @@ as_gt <- function(x, include = everything(), exclude = NULL, omit = NULL) {
       "as_gt(include = )",
       details = paste0(
         "The `include` argument accepts quoted and unquoted expressions similar\n",
-        "`dplyr::select()`. To exclude commands, use the minus sign.\n",
+        "to `dplyr::select()`. To exclude commands, use the minus sign.\n",
         "For example, `include = -tab_spanner`"
       )
     )

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -15,7 +15,7 @@
 #' @param include Commands to include in output. Input may be a vector of
 #' quoted or unquoted names. tidyselect and gtsummary select helper
 #' functions are also accepted.
-#' Default is `NULL`, which includes all commands in `x$gt_calls`.
+#' Default is `everything()`, which includes all commands in `x$gt_calls`.
 #' @param exclude DEPRECATED.
 #' @param omit DEPRECATED.
 #' vector of named gt commands to omit. Default is `NULL`
@@ -34,7 +34,7 @@
 #'
 #' \if{html}{\figure{as_gt_ex.png}{options: width=50\%}}
 
-as_gt <- function(x, include = NULL, exclude = NULL, omit = NULL) {
+as_gt <- function(x, include = everything(), exclude = NULL, omit = NULL) {
   # DEPRECATRED notice ---------------------------------------------------------
   # checking if updated version of gt package is required 2019-12-25 -----------
   if (!exists("cells_body", asNamespace("gt"))) {
@@ -80,16 +80,15 @@ as_gt <- function(x, include = NULL, exclude = NULL, omit = NULL) {
   exclude <- var_input_to_string(data = vctr_2_tibble(names(x$gt_calls)),
                                  select_input = !!rlang::enquo(exclude))
 
-  if (is.null(include)) include <- names(x$gt_calls)
   # this ensures list is in the same order as names(x$gt_calls)
   include <- names(x$gt_calls) %>% intersect(include)
 
   # user cannot omit the first 'gt' command
-  call_names <- include %>% setdiff(exclude)
-  call_names <- "gt" %>% union(call_names)
+  include <- include %>% setdiff(exclude)
+  include <- "gt" %>% union(include)
 
   # taking each gt function call, concatenating them with %>% separating them
-  x$gt_calls[call_names] %>%
+  x$gt_calls[include] %>%
     # adding default gt formatting options
     union(getOption("gtsummary.as_gt.addl_cmds", default = NULL)) %>%
     # removing NULL elements

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -12,11 +12,12 @@
 #'
 #' @param x Object created by a function from the gtsummary package
 #' (e.g. [tbl_summary] or [tbl_regression])
-#' @param include Character vector or tidyselect function naming gt commands to include in printing.
-#' Default is `NULL`, which utilizes all commands in `x$gt_calls`.
-#' @param exclude Character vector or tidyselect function naming gt commands to exclude in printing.
-#' Default is `NULL`.
-#' @param omit DEPRECATED. Argument is synonymous with `exclude`
+#' @param include Commands to include in output. Input may be a vector of
+#' quoted or unquoted names. tidyselect and gtsummary select helper
+#' functions are also accepted.
+#' Default is `NULL`, which includes all commands in `x$gt_calls`.
+#' @param exclude DEPRECATED.
+#' @param omit DEPRECATED.
 #' vector of named gt commands to omit. Default is `NULL`
 #' @export
 #' @return A `gt_tbl` object
@@ -46,14 +47,33 @@ as_gt <- function(x, include = NULL, exclude = NULL, omit = NULL) {
   }
 
   # making list of commands to include -----------------------------------------
+  if (!rlang::quo_is_null(rlang::enquo(exclude))) {
+    lifecycle::deprecate_warn(
+      "1.2.5",
+      "gtsummary::as_gt(exclude = )",
+      "as_gt(include = )",
+      details = paste0(
+        "The `include` argument accepts quoted and unquoted expressions similar\n",
+        "`dplyr::select()`. To exclude commands, use the minus sign.\n",
+        "For example, `include = -tab_spanner`"
+      )
+    )
+  }
+
   if (!is.null(omit)) {
     lifecycle::deprecate_warn(
       "1.2.0",
       "gtsummary::as_gt(omit = )",
-      "as_gt(exclude = )"
+      "as_gt(include = )",
+      details = paste0(
+        "The `include` argument accepts quoted and unquoted expressions similar\n",
+        "`dplyr::select()`. To exclude commands, use the minus sign.\n",
+        "For example, `include = -tab_spanner`"
+      )
     )
     exclude <- omit
   }
+
   # converting to charcter vector ----------------------------------------------
   include <- var_input_to_string(data = vctr_2_tibble(names(x$gt_calls)),
                                  select_input = !!rlang::enquo(include))

--- a/R/as_kable.R
+++ b/R/as_kable.R
@@ -51,7 +51,7 @@ as_kable <- function(x, include = everything(), exclude = NULL, ...) {
       "as_kable(include = )",
       details = paste0(
         "The `include` argument accepts quoted and unquoted expressions similar\n",
-        "`dplyr::select()`. To exclude commands, use the minus sign.\n",
+        "to `dplyr::select()`. To exclude commands, use the minus sign.\n",
         "For example, `include = -cols_hide`"
       )
     )

--- a/R/as_kable.R
+++ b/R/as_kable.R
@@ -7,10 +7,11 @@
 #'
 #' @param x Object created by a function from the gtsummary package
 #' (e.g. [tbl_summary] or [tbl_regression])
-#' @param include Character vector  or tidyselect function naming kable commands to include in printing.
-#' Default is `NULL`, which utilizes all commands in `x$kable_calls`.
-#' @param exclude Character vector  or tidyselect function naming kable commands to exclude in printing.
-#' Default is `NULL`.
+#' @param include Commands to include in output. Input may be a vector of
+#' quoted or unquoted names. tidyselect and gtsummary select helper
+#' functions are also accepted.
+#' Default is `NULL`, which includes all commands in `x$kable_calls`.
+#' @param exclude DEPRECATED
 #' @param ... Additional arguments passed to [knitr::kable]
 #' @export
 #' @return A `knitr_kable` object
@@ -39,6 +40,20 @@ as_kable <- function(x, include = NULL, exclude = NULL, ...) {
       "or spanning headers. \n",
       "Tables styled by the gt package support footers and spanning headers."
     ))
+  }
+
+  # DEPRECATION notes ----------------------------------------------------------
+  if (!rlang::quo_is_null(rlang::enquo(exclude))) {
+    lifecycle::deprecate_warn(
+      "1.2.5",
+      "gtsummary::as_kable(exclude = )",
+      "as_kable(include = )",
+      details = paste0(
+        "The `include` argument accepts quoted and unquoted expressions similar\n",
+        "`dplyr::select()`. To exclude commands, use the minus sign.\n",
+        "For example, `include = -cols_hide`"
+      )
+    )
   }
 
   # converting to charcter vector ----------------------------------------------

--- a/R/as_kable.R
+++ b/R/as_kable.R
@@ -10,7 +10,7 @@
 #' @param include Commands to include in output. Input may be a vector of
 #' quoted or unquoted names. tidyselect and gtsummary select helper
 #' functions are also accepted.
-#' Default is `NULL`, which includes all commands in `x$kable_calls`.
+#' Default is `everything()`, which includes all commands in `x$kable_calls`.
 #' @param exclude DEPRECATED
 #' @param ... Additional arguments passed to [knitr::kable]
 #' @export
@@ -21,7 +21,8 @@
 #' trial %>%
 #'   tbl_summary(by = trt) %>%
 #'   as_kable()
-as_kable <- function(x, include = NULL, exclude = NULL, ...) {
+
+as_kable <- function(x, include = everything(), exclude = NULL, ...) {
   # print message about kable limitations
   # printing message about downloading gt package
   if (is.null(getOption("gtsummary.print_engine"))) {
@@ -63,13 +64,12 @@ as_kable <- function(x, include = NULL, exclude = NULL, ...) {
                                  select_input = !!rlang::enquo(exclude))
 
   # making list of commands to include -----------------------------------------
-  if (is.null(include)) include <- names(x$kable_calls)
   # this ensures list is in the same order as names(x$kable_calls)
   include <- names(x$kable_calls) %>% intersect(include)
 
   # user cannot exclude the first 'kable' command
-  call_names <- include %>% setdiff(exclude)
-  call_names <- "kable" %>% union(call_names)
+  include <- include %>% setdiff(exclude)
+  include <- "kable" %>% union(include)
 
   # saving vector of column labels
   col_labels <-
@@ -78,7 +78,7 @@ as_kable <- function(x, include = NULL, exclude = NULL, ...) {
     pull(.data$label)
 
   # taking each kable function call, concatenating them with %>% separating them
-  x$kable_calls[call_names] %>%
+  x$kable_calls[include] %>%
     # removing NULL elements
     compact() %>%
     glue_collapse(sep = " %>% ") %>%

--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -41,7 +41,7 @@ as_tibble.tbl_summary <- function(x, include = everything(), col_labels = TRUE,
       "as_tibble(include = )",
       details = paste0(
         "The `include` argument accepts quoted and unquoted expressions similar\n",
-        "`dplyr::select()`. To exclude commands, use the minus sign.\n",
+        "to `dplyr::select()`. To exclude commands, use the minus sign.\n",
         "For example, `include = -cols_hide`"
       )
     )

--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -24,7 +24,7 @@ NULL
 
 #' @rdname as_tibbleS3
 #' @export
-as_tibble.tbl_summary <- function(x, include = NULL, col_labels = TRUE,
+as_tibble.tbl_summary <- function(x, include = everything(), col_labels = TRUE,
                                   exclude = NULL,  ...) {
   # Printing message that spanning headers and footnotes will be lost
   message(glue(
@@ -54,13 +54,12 @@ as_tibble.tbl_summary <- function(x, include = NULL, col_labels = TRUE,
                                  select_input = !!rlang::enquo(exclude))
 
   # making list of commands to include -----------------------------------------
-  if (is.null(include)) include <- names(x$kable_calls)
   # this ensures list is in the same order as names(x$kable_calls)
   include <- names(x$kable_calls) %>% intersect(include)
 
   # user cannot exclude the first 'kable' command
-  call_names <- include %>% setdiff(exclude)
-  call_names <- "kable" %>% union(call_names)
+  include <- include %>% setdiff(exclude)
+  include <- "kable" %>% union(include)
 
   # saving vector of column labels
   column_labels <-
@@ -70,7 +69,7 @@ as_tibble.tbl_summary <- function(x, include = NULL, col_labels = TRUE,
 
   # taking each kable function call, concatenating them with %>% separating them
   tbl <-
-    x$kable_calls[call_names] %>%
+    x$kable_calls[include] %>%
     # removing NULL elements
     compact() %>%
     glue_collapse(sep = " %>% ") %>%

--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -4,12 +4,7 @@
 #' `x$kable_calls` is applied.
 #'
 #' @name as_tibbleS3
-#' @param x Object created by a function from the gtsummary package
-#' (e.g. [tbl_summary] or [tbl_regression])
-#' @param include Character vector or tidyselect function naming kable commands to include in printing.
-#' Default is `NULL`, which utilizes all commands in `x$kable_calls`.
-#' @param exclude Character vector or tidyselect function naming kable commands to exclude in printing.
-#' Default is `NULL`.
+#' @inheritParams as_kable
 #' @param col_labels Logical argument adding column labels to output tibble.
 #' Default is `TRUE`.
 #' @param ... Not used
@@ -29,14 +24,28 @@ NULL
 
 #' @rdname as_tibbleS3
 #' @export
-as_tibble.tbl_summary <- function(x, include = NULL, exclude = NULL,
-                                  col_labels = TRUE, ...) {
+as_tibble.tbl_summary <- function(x, include = NULL, col_labels = TRUE,
+                                  exclude = NULL,  ...) {
   # Printing message that spanning headers and footnotes will be lost
   message(glue(
     "Results printed using 'knitr::kable()' do not support footers \n",
     "or spanning headers. \n",
     "Tables styled by the gt package support footers and spanning headers."
   ))
+
+  # DEPRECATION notes ----------------------------------------------------------
+  if (!rlang::quo_is_null(rlang::enquo(exclude))) {
+    lifecycle::deprecate_warn(
+      "1.2.5",
+      "gtsummary::as_tibble(exclude = )",
+      "as_tibble(include = )",
+      details = paste0(
+        "The `include` argument accepts quoted and unquoted expressions similar\n",
+        "`dplyr::select()`. To exclude commands, use the minus sign.\n",
+        "For example, `include = -cols_hide`"
+      )
+    )
+  }
 
   # converting to charcter vector ----------------------------------------------
   include <- var_input_to_string(data = vctr_2_tibble(names(x$kable_calls)),

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -72,14 +72,14 @@ tab_style_bold_levels <- function(...) {
 #' @rdname deprecated
 #' @export
 tbl_summary_ <- function(...) {
-  lifecycle::deprecate_warn("1.3.0", "gtsummary::tbl_summary_()", "tbl_summary()")
+  lifecycle::deprecate_warn("1.2.5", "gtsummary::tbl_summary_()", "tbl_summary()")
   tbl_summary(...)
 }
 
 #' @rdname deprecated
 #' @export
 add_p_ <- function(...) {
-  lifecycle::deprecate_warn("1.3.0", "gtsummary::add_p_()", "add_p()")
+  lifecycle::deprecate_warn("1.2.5", "gtsummary::add_p_()", "add_p()")
   add_p(...)
 }
 

--- a/R/tbl_merge.R
+++ b/R/tbl_merge.R
@@ -45,7 +45,7 @@
 #'   )
 #' tbl_merge_ex2 <-
 #'   tbl_merge(tbls = list(t3, t4)) %>%
-#'   as_gt(exclude = "tab_spanner") %>%
+#'   as_gt(include = -tab_spanner) %>%
 #'   gt::cols_label(stat_0_1 = gt::md("**Summary Statistics**"))
 #' }
 #' @section Example Output:

--- a/R/tbl_regression.R
+++ b/R/tbl_regression.R
@@ -32,17 +32,18 @@
 #' @param exponentiate Logical indicating whether to exponentiate the
 #' coefficient estimates. Default is `FALSE`.
 #' @param label List of formulas specifying variables labels,
-#' e.g. `list("age" ~ "Age, yrs", "ptstage" ~ "Path T Stage")`
-#' @param include Character vector or tidyselect function indicating variables to include from output.
-#' @param exclude Character vector or tidyselect function indicating variables to exclude from output.
+#' e.g. `list(age ~ "Age, yrs", stage ~ "Path T Stage")`
+#' @param include Variables to include in output. Input may be a vector of
+#' quoted or unquoted variable names. tidyselect and gtsummary select helper
+#' functions are also accepted. Default is `NULL`, which prints all variables.
 #' @param conf.level Must be strictly greater than 0 and less than 1.
 #' Defaults to 0.95, which corresponds to a 95 percent confidence interval.
 #' @param intercept Logical argument indicating whether to include the intercept
 #' in the output.  Default is `FALSE`
 #' @param show_single_row By default categorical variables are printed on
 #' multiple rows.  If a variable is binary (e.g. Yes/No) and you wish to print
-#' the regression coefficient on a single row, include the variable name here,
-#' e.g. `show_single_row = c("var1", "var2")`
+#' the regression coefficient on a single row, include the variable name(s)
+#' here--quoted and unquoted variable name accepted.
 #' @param estimate_fun Function to round and format coefficient estimates.
 #' Default is [style_sigfig] when the coefficients are not transformed, and
 #' [style_ratio] when the coefficients have been exponentiated.
@@ -52,10 +53,11 @@
 #' and return a string that is the rounded/formatted p-value (e.g.
 #' `pvalue_fun = function(x) style_pvalue(x, digits = 2)` or equivalently,
 #'  `purrr::partial(style_pvalue, digits = 2)`).
-#' @param show_yesno deprecated
 #' @param tidy_fun Option to specify a particular tidier function if the
 #' model is not a [vetted model][tidy_vetted] or you need to implement a
 #' custom method. Default is `NULL`
+#' @param exclude DEPRECATED
+#' @param show_yesno DEPRECATED
 #' @author Daniel D. Sjoberg
 #' @seealso See tbl_regression \href{http://www.danieldsjoberg.com/gtsummary/articles/tbl_regression.html}{vignette} for detailed examples
 #' @family tbl_regression tools
@@ -94,15 +96,29 @@
 #' \if{html}{\figure{tbl_regression_ex3.png}{options: width=50\%}}
 
 tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
-                           include = NULL, exclude = NULL,
-                           show_single_row = NULL, conf.level = NULL, intercept = FALSE,
-                           estimate_fun = NULL, pvalue_fun = NULL, show_yesno = NULL,
-                           tidy_fun = NULL) {
+                           include = NULL, show_single_row = NULL,
+                           conf.level = NULL, intercept = FALSE,
+                           estimate_fun = NULL, pvalue_fun = NULL,
+                           tidy_fun = NULL,
+                           show_yesno = NULL, exclude = NULL) {
   # deprecated arguments -------------------------------------------------------
   if (!is.null(show_yesno)) {
     lifecycle::deprecate_stop(
       "1.2.2", "tbl_regression(show_yesno = )",
       "tbl_regression(show_single_row = )"
+    )
+  }
+
+  if (!rlang::quo_is_null(rlang::enquo(exclude))) {
+    lifecycle::deprecate_warn(
+      "1.2.5",
+      "gtsummary::tbl_regression(exclude = )",
+      "tbl_regression(include = )",
+      details = paste0(
+        "The `include` argument accepts quoted and unquoted expressions similar\n",
+        "`dplyr::select()`. To exclude variable, use the minus sign.\n",
+        "For example, `include = -c(age, stage)`"
+      )
     )
   }
 

--- a/R/tbl_regression.R
+++ b/R/tbl_regression.R
@@ -34,8 +34,8 @@
 #' @param label List of formulas specifying variables labels,
 #' e.g. `list(age ~ "Age, yrs", stage ~ "Path T Stage")`
 #' @param include Variables to include in output. Input may be a vector of
-#' quoted or unquoted variable names. tidyselect and gtsummary select helper
-#' functions are also accepted. Default is `NULL`, which prints all variables.
+#' quoted variable names, unquoted variable names, or tidyselect select helper
+#' functions. Default is `everything()`.
 #' @param conf.level Must be strictly greater than 0 and less than 1.
 #' Defaults to 0.95, which corresponds to a 95 percent confidence interval.
 #' @param intercept Logical argument indicating whether to include the intercept
@@ -96,7 +96,7 @@
 #' \if{html}{\figure{tbl_regression_ex3.png}{options: width=50\%}}
 
 tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
-                           include = NULL, show_single_row = NULL,
+                           include = everything(), show_single_row = NULL,
                            conf.level = NULL, intercept = FALSE,
                            estimate_fun = NULL, pvalue_fun = NULL,
                            tidy_fun = NULL,
@@ -175,21 +175,6 @@ tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
   tidy_model <-
     tidy_wrap(x, exponentiate, conf.level, tidy_fun)
 
-  # converting to character list, using model frame and tidy terms as possible names
-  include <- var_input_to_string(
-    data = vctr_2_tibble(c(names(model_frame), tidy_model$term) %>% unique()),
-    select_input = !!include
-  )
-  exclude <- var_input_to_string(
-    data = vctr_2_tibble(c(names(model_frame), tidy_model$term) %>% unique()),
-    select_input = !!exclude
-  )
-  show_single_row <- var_input_to_string(
-    data = vctr_2_tibble(c(names(model_frame), tidy_model$term) %>% unique()),
-    select_input = !!show_single_row
-  )
-
-
   # parsing the terms from model and variable names
   # outputing a tibble of the parsed model with
   # rows for reference groups, and headers for
@@ -213,7 +198,6 @@ tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
   exclude <- var_input_to_string(data = vctr_2_tibble(unique(table_body$variable)),
                                  arg_name = "exclude", select_input = !!exclude)
 
-  if (is.null(include)) include <- table_body$variable %>% unique()
   if (intercept == FALSE) include <- include %>% setdiff("(Intercept)")
   include <- include %>% setdiff(exclude)
 

--- a/R/tbl_regression.R
+++ b/R/tbl_regression.R
@@ -116,7 +116,7 @@ tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
       "tbl_regression(include = )",
       details = paste0(
         "The `include` argument accepts quoted and unquoted expressions similar\n",
-        "`dplyr::select()`. To exclude variable, use the minus sign.\n",
+        "to `dplyr::select()`. To exclude variable, use the minus sign.\n",
         "For example, `include = -c(age, stage)`"
       )
     )

--- a/R/tbl_summary.R
+++ b/R/tbl_summary.R
@@ -6,18 +6,18 @@
 #' for detailed examples.
 #'
 #' @param data A data frame
-#' @param by A column name in data.
+#' @param by A column name (quoted or unquoted) in `data`.
 #' Summary statistics will be calculated separately for each level of the `by`
 #' variable (e.g. `by = trt`). If `NULL`, summary statistics
 #' are calculated using all observations.
 #' @param label List of formulas specifying variables labels,
-#' e.g. `list(vars(age) ~ "Age, yrs", vars(ptstage) ~ "Path T Stage")`.  If a
-#' variable's label is not specified here, the
-#' function will take the label attribute (`attr(data$age, "label")`).  If
+#' e.g. `list(age ~ "Age, yrs", stage ~ "Path T Stage")`.  If a
+#' variable's label is not specified here, the label attribute
+#' (`attr(data$age, "label")`) is used.  If
 #' attribute label is `NULL`, the variable name will be used.
 #' @param type List of formulas specifying variable types. Accepted values
 #' are `c("continuous", "categorical", "dichotomous")`,
-#' e.g. `type = list(starts_with(age) ~ "continuous", "female" ~ "dichotomous")`.
+#' e.g. `type = list(starts_with(age) ~ "continuous", female ~ "dichotomous")`.
 #' If type not specified for a variable, the function
 #' will default to an appropriate summary type.  See below for details.
 #' @param value List of formulas specifying the value to display for dichotomous
@@ -32,7 +32,7 @@
 #' When multiple statistics are displayed for a single variable, supply a vector
 #' rather than an integer.  For example, if the
 #' statistic being calculated is `"{mean} ({sd})"` and you want the mean rounded
-#' to 1 decimal place, and the SD to 2 use `digits = list("age" ~ c(1, 2))`.
+#' to 1 decimal place, and the SD to 2 use `digits = list(age ~ c(1, 2))`.
 #' @param missing Indicates whether to include counts of `NA` values in the table.
 #' Allowed values are `"no"` (never display NA values),
 #' `"ifany"` (only display if any NA values), and `"always"`
@@ -66,7 +66,7 @@
 #' @section statistic argument:
 #' The statistic argument specifies the statistics presented in the table. The
 #' input is a list of formulas that specify the statistics to report. For example,
-#' `statistic = list("age" ~ "{mean} ({sd})")` would report the mean and
+#' `statistic = list(age ~ "{mean} ({sd})")` would report the mean and
 #' standard deviation for age; `statistic = list(all_continuous() ~ "{mean} ({sd})")`
 #' would report the mean and standard deviation for all continuous variables.
 #'  A statistic name that appears between curly brackets
@@ -97,9 +97,9 @@
 #' are categorical variables that are displayed on a single row in the
 #' output table, rather than one row per level of the variable.
 #' Variables coded as TRUE/FALSE, 0/1, or yes/no are assumed to be dichotomous,
-#' and the TRUE, 1, and yes rows
-#' will be displayed.  Otherwise, the value to display must be specified in
-#' the `value` argument, e.g. `value = list("varname" ~ "level to show")`
+#' and the TRUE, 1, and yes rows are displayed.
+#' Otherwise, the value to display must be specified in
+#' the `value` argument, e.g. `value = list(varname ~ "level to show")`
 #' @export
 #' @return A `tbl_summary` object
 #' @family tbl_summary tools

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -89,7 +89,7 @@
 tbl_uvregression <- function(data, method, y = NULL, x = NULL, method.args = NULL,
                              formula = "{y} ~ {x}",
                              exponentiate = FALSE, label = NULL,
-                             include = NULL, exclude = NULL,
+                             include = everything(), exclude = NULL,
                              hide_n = FALSE, show_single_row = NULL, conf.level = NULL,
                              estimate_fun = NULL, pvalue_fun = NULL, show_yesno = NULL,
                              tidy_fun = NULL) {

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -101,6 +101,19 @@ tbl_uvregression <- function(data, method, y = NULL, x = NULL, method.args = NUL
     )
   }
 
+  if (!rlang::quo_is_null(rlang::enquo(exclude))) {
+    lifecycle::deprecate_warn(
+      "1.2.5",
+      "gtsummary::tbl_uvregression(exclude = )",
+      "tbl_uvregression(include = )",
+      details = paste0(
+        "The `include` argument accepts quoted and unquoted expressions similar\n",
+        "`dplyr::select()`. To exclude variable, use the minus sign.\n",
+        "For example, `include = -c(age, stage)`"
+      )
+    )
+  }
+
   # setting defaults -----------------------------------------------------------
   pvalue_fun <-
     pvalue_fun %||%

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -108,7 +108,7 @@ tbl_uvregression <- function(data, method, y = NULL, x = NULL, method.args = NUL
       "tbl_uvregression(include = )",
       details = paste0(
         "The `include` argument accepts quoted and unquoted expressions similar\n",
-        "`dplyr::select()`. To exclude variable, use the minus sign.\n",
+        "to `dplyr::select()`. To exclude variable, use the minus sign.\n",
         "For example, `include = -c(age, stage)`"
       )
     )

--- a/R/utils-add_p.R
+++ b/R/utils-add_p.R
@@ -25,11 +25,6 @@ assign_test <- function(data, var, var_summary_type, by_var, test, group) {
 }
 
 assign_test_one <- function(data, var, var_summary_type, by_var, test, group) {
-  # if the 'by' variable is null, no tests will be performed
-  if (is.null(by_var)) {
-    return(NA_character_)
-  }
-
   # if user specifed test to be performed, do that test.
   if (!is.null(test[[var]])) {
     return(test[[var]])

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,9 +5,12 @@ coverage:
   round: up
   precision: 0
 
-status:
-  project:
-    default:
-      enabled: yes
-      target: 90
+  status:
+    project:                   # measuring the overall project coverage
+      default:                 # context, you can create multiple ones with custom titles
+        enabled: yes           # must be yes|true to enable this status
+        target: 90             # specify the target coverage for each commit status
+                               #   option: "auto" (must increase from parent commit or pull request base)
+                               #   option: "X%" a static target percentage to hit
+        threshold: null        # allowed to drop X% and still result in a "success" commit status
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,3 +17,4 @@ coverage:
     patch:
       default:
         target: 50
+        threshold: null

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,12 +5,9 @@ coverage:
   round: up
   precision: 0
 
-  status:
-    project:
-      default:
-        target: auto
-        threshold: 1%
-    patch:
-      default:
-        target: auto
-        threshold: 50%
+status:
+  project:
+    default:
+      enabled: yes
+      target: 90
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,6 @@ coverage:
                                #   option: "X%" a static target percentage to hit
         threshold: null        # allowed to drop X% and still result in a "success" commit status
 
+    patch:
+      default:
+        target: 50

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,14 +10,14 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.4.9004",
+  "version": "1.2.4.9005",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
-    "version": "3.6.2",
+    "version": "3.6.1",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 3.6.2 (2019-12-12)",
+  "runtimePlatform": "R version 3.6.1 (2019-07-05)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -431,7 +431,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1545.664KB",
+  "fileSize": "1546.022KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/man/add_global_p.Rd
+++ b/man/add_global_p.Rd
@@ -20,7 +20,7 @@ Output from \code{tbl_regression} and \code{tbl_uvregression} objects supported.
 
 If a needed class of model is not supported by
 \link[car:Anova]{car::Anova}, please create an
-\href{https://github.com/ddsjoberg/gtsummary/issues}{issue} to request support.
+\href{https://github.com/ddsjoberg/gtsummary/issues}{GitHub Issue} to request support.
 }
 
 \seealso{

--- a/man/add_global_p.Rd
+++ b/man/add_global_p.Rd
@@ -19,7 +19,7 @@ Output from \code{tbl_regression} and \code{tbl_uvregression} objects supported.
 \section{Note}{
 
 If a needed class of model is not supported by
-\link[car:Anova]{car::Anova}, please create an
+\link[car:Anova]{car::Anova}, please create a
 \href{https://github.com/ddsjoberg/gtsummary/issues}{GitHub Issue} to request support.
 }
 

--- a/man/add_global_p.tbl_regression.Rd
+++ b/man/add_global_p.tbl_regression.Rd
@@ -17,8 +17,10 @@
 \item{x}{Object with class \code{tbl_regression} from the
 \link{tbl_regression} function}
 
-\item{include}{Character vector or tidyselect function indicating
-variables to include global p-values}
+\item{include}{Variables to calculate global p-value for. Input may be a vector of
+quoted or unquoted variable names. tidyselect and gtsummary select helper
+functions are also accepted. Default is \code{NULL}, which adds global p-values
+for all categorical and interaction terms.}
 
 \item{keep}{Logical argument indicating whether to also retain the individual
 p-values in the table output for each level of the categorical variable.
@@ -38,8 +40,8 @@ This function uses \link[car:Anova]{car::Anova} with argument
 \section{Note}{
 
 If a needed class of model is not supported by
-\link[car:Anova]{car::Anova}, please create an
-\href{https://github.com/ddsjoberg/gtsummary/issues}{issue} to request support.
+\link[car:Anova]{car::Anova}, please create a
+\href{https://github.com/ddsjoberg/gtsummary/issues}{GitHub Issue} to request support.
 }
 
 \section{Example Output}{

--- a/man/add_global_p.tbl_regression.Rd
+++ b/man/add_global_p.tbl_regression.Rd
@@ -4,13 +4,21 @@
 \alias{add_global_p.tbl_regression}
 \title{Adds the global p-value for categorical variables}
 \usage{
-\method{add_global_p}{tbl_regression}(x, include = NULL, keep = FALSE, terms = NULL, ...)
+\method{add_global_p}{tbl_regression}(
+  x,
+  include = x$table_body$variable[x$table_body$var_type \%in\% c("categorical",
+    "interaction")],
+  keep = FALSE,
+  terms = NULL,
+  ...
+)
 }
 \arguments{
 \item{x}{Object with class \code{tbl_regression} from the
 \link{tbl_regression} function}
 
-\item{include}{Character vector or tidyselect function indicating variables to include global p-values}
+\item{include}{Character vector or tidyselect function indicating
+variables to include global p-values}
 
 \item{keep}{Logical argument indicating whether to also retain the individual
 p-values in the table output for each level of the categorical variable.

--- a/man/add_global_p.tbl_regression.Rd
+++ b/man/add_global_p.tbl_regression.Rd
@@ -4,22 +4,13 @@
 \alias{add_global_p.tbl_regression}
 \title{Adds the global p-value for categorical variables}
 \usage{
-\method{add_global_p}{tbl_regression}(
-  x,
-  include = NULL,
-  exclude = NULL,
-  keep = FALSE,
-  terms = NULL,
-  ...
-)
+\method{add_global_p}{tbl_regression}(x, include = NULL, keep = FALSE, terms = NULL, ...)
 }
 \arguments{
 \item{x}{Object with class \code{tbl_regression} from the
 \link{tbl_regression} function}
 
 \item{include}{Character vector or tidyselect function indicating variables to include global p-values}
-
-\item{exclude}{Character vector or tidyselect function indicating variables to exclude global p-values}
 
 \item{keep}{Logical argument indicating whether to also retain the individual
 p-values in the table output for each level of the categorical variable.

--- a/man/add_p.Rd
+++ b/man/add_p.Rd
@@ -9,7 +9,7 @@ add_p(
   test = NULL,
   pvalue_fun = NULL,
   group = NULL,
-  include = NULL,
+  include = everything(),
   exclude = NULL
 )
 }
@@ -51,8 +51,8 @@ the test argument is \code{"lme4"}). Default is \code{NULL}.  If specified,
 the row associated with this variable is omitted from the summary table.}
 
 \item{include}{Variables to include in output. Input may be a vector of
-quoted or unquoted variable names. tidyselect and gtsummary select helper
-functions are also accepted. Default is \code{NULL}, which prints all variables.}
+quoted variable names, unquoted variable names, or tidyselect select helper
+functions. Default is \code{everything()}.}
 
 \item{exclude}{DEPRECATED}
 }

--- a/man/add_p.Rd
+++ b/man/add_p.Rd
@@ -46,7 +46,7 @@ and return a string that is the rounded/formatted p-value (e.g.
 \code{purrr::partial(style_pvalue, digits = 2)}).}
 
 \item{group}{Column name (unquoted or quoted) of an ID or grouping variable.
-The column can be used calculate p-values with correlated data (e.g. when
+The column can be used to calculate p-values with correlated data (e.g. when
 the test argument is \code{"lme4"}). Default is \code{NULL}.  If specified,
 the row associated with this variable is omitted from the summary table.}
 

--- a/man/add_p.Rd
+++ b/man/add_p.Rd
@@ -45,14 +45,16 @@ and return a string that is the rounded/formatted p-value (e.g.
 \code{pvalue_fun = function(x) style_pvalue(x, digits = 2)} or equivalently,
 \code{purrr::partial(style_pvalue, digits = 2)}).}
 
-\item{group}{Column name of an ID or grouping variable. The column can be
-used calculate p-values with correlated data (e.g. when the test argument
-is \code{"lme4"}). Default is \code{NULL}.  If specified,
+\item{group}{Column name (unquoted or quoted) of an ID or grouping variable.
+The column can be used calculate p-values with correlated data (e.g. when
+the test argument is \code{"lme4"}). Default is \code{NULL}.  If specified,
 the row associated with this variable is omitted from the summary table.}
 
-\item{include}{Character vector or tidyselect function indicating variables to include from output.}
+\item{include}{Variables to include in output. Input may be a vector of
+quoted or unquoted variable names. tidyselect and gtsummary select helper
+functions are also accepted. Default is \code{NULL}, which prints all variables.}
 
-\item{exclude}{Character vector or tidyselect function indicating variables to exclude from output.}
+\item{exclude}{DEPRECATED}
 }
 \value{
 A \code{tbl_summary} object

--- a/man/as_gt.Rd
+++ b/man/as_gt.Rd
@@ -10,13 +10,14 @@ as_gt(x, include = NULL, exclude = NULL, omit = NULL)
 \item{x}{Object created by a function from the gtsummary package
 (e.g. \link{tbl_summary} or \link{tbl_regression})}
 
-\item{include}{Character vector or tidyselect function naming gt commands to include in printing.
-Default is \code{NULL}, which utilizes all commands in \code{x$gt_calls}.}
+\item{include}{Commands to include in output. Input may be a vector of
+quoted or unquoted names. tidyselect and gtsummary select helper
+functions are also accepted.
+Default is \code{NULL}, which includes all commands in \code{x$gt_calls}.}
 
-\item{exclude}{Character vector or tidyselect function naming gt commands to exclude in printing.
-Default is \code{NULL}.}
+\item{exclude}{DEPRECATED.}
 
-\item{omit}{DEPRECATED. Argument is synonymous with \code{exclude}
+\item{omit}{DEPRECATED.
 vector of named gt commands to omit. Default is \code{NULL}}
 }
 \value{

--- a/man/as_gt.Rd
+++ b/man/as_gt.Rd
@@ -4,7 +4,7 @@
 \alias{as_gt}
 \title{Convert gtsummary object to a gt_tbl object}
 \usage{
-as_gt(x, include = NULL, exclude = NULL, omit = NULL)
+as_gt(x, include = everything(), exclude = NULL, omit = NULL)
 }
 \arguments{
 \item{x}{Object created by a function from the gtsummary package
@@ -13,7 +13,7 @@ as_gt(x, include = NULL, exclude = NULL, omit = NULL)
 \item{include}{Commands to include in output. Input may be a vector of
 quoted or unquoted names. tidyselect and gtsummary select helper
 functions are also accepted.
-Default is \code{NULL}, which includes all commands in \code{x$gt_calls}.}
+Default is \code{everything()}, which includes all commands in \code{x$gt_calls}.}
 
 \item{exclude}{DEPRECATED.}
 

--- a/man/as_kable.Rd
+++ b/man/as_kable.Rd
@@ -10,11 +10,12 @@ as_kable(x, include = NULL, exclude = NULL, ...)
 \item{x}{Object created by a function from the gtsummary package
 (e.g. \link{tbl_summary} or \link{tbl_regression})}
 
-\item{include}{Character vector  or tidyselect function naming kable commands to include in printing.
-Default is \code{NULL}, which utilizes all commands in \code{x$kable_calls}.}
+\item{include}{Commands to include in output. Input may be a vector of
+quoted or unquoted names. tidyselect and gtsummary select helper
+functions are also accepted.
+Default is \code{NULL}, which includes all commands in \code{x$kable_calls}.}
 
-\item{exclude}{Character vector  or tidyselect function naming kable commands to exclude in printing.
-Default is \code{NULL}.}
+\item{exclude}{DEPRECATED}
 
 \item{...}{Additional arguments passed to \link[knitr:kable]{knitr::kable}}
 }

--- a/man/as_kable.Rd
+++ b/man/as_kable.Rd
@@ -4,7 +4,7 @@
 \alias{as_kable}
 \title{Convert to knitr_kable object}
 \usage{
-as_kable(x, include = NULL, exclude = NULL, ...)
+as_kable(x, include = everything(), exclude = NULL, ...)
 }
 \arguments{
 \item{x}{Object created by a function from the gtsummary package
@@ -13,7 +13,7 @@ as_kable(x, include = NULL, exclude = NULL, ...)
 \item{include}{Commands to include in output. Input may be a vector of
 quoted or unquoted names. tidyselect and gtsummary select helper
 functions are also accepted.
-Default is \code{NULL}, which includes all commands in \code{x$kable_calls}.}
+Default is \code{everything()}, which includes all commands in \code{x$kable_calls}.}
 
 \item{exclude}{DEPRECATED}
 

--- a/man/as_tibbleS3.Rd
+++ b/man/as_tibbleS3.Rd
@@ -10,17 +10,17 @@
 \alias{as_tibble.tbl_survival}
 \title{Convert gtsummary object to tibble}
 \usage{
-\method{as_tibble}{tbl_summary}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
+\method{as_tibble}{tbl_summary}(x, include = everything(), col_labels = TRUE, exclude = NULL, ...)
 
-\method{as_tibble}{tbl_regression}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
+\method{as_tibble}{tbl_regression}(x, include = everything(), col_labels = TRUE, exclude = NULL, ...)
 
-\method{as_tibble}{tbl_uvregression}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
+\method{as_tibble}{tbl_uvregression}(x, include = everything(), col_labels = TRUE, exclude = NULL, ...)
 
-\method{as_tibble}{tbl_merge}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
+\method{as_tibble}{tbl_merge}(x, include = everything(), col_labels = TRUE, exclude = NULL, ...)
 
-\method{as_tibble}{tbl_stack}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
+\method{as_tibble}{tbl_stack}(x, include = everything(), col_labels = TRUE, exclude = NULL, ...)
 
-\method{as_tibble}{tbl_survival}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
+\method{as_tibble}{tbl_survival}(x, include = everything(), col_labels = TRUE, exclude = NULL, ...)
 }
 \arguments{
 \item{x}{Object created by a function from the gtsummary package
@@ -29,7 +29,7 @@
 \item{include}{Commands to include in output. Input may be a vector of
 quoted or unquoted names. tidyselect and gtsummary select helper
 functions are also accepted.
-Default is \code{NULL}, which includes all commands in \code{x$kable_calls}.}
+Default is \code{everything()}, which includes all commands in \code{x$kable_calls}.}
 
 \item{col_labels}{Logical argument adding column labels to output tibble.
 Default is \code{TRUE}.}

--- a/man/as_tibbleS3.Rd
+++ b/man/as_tibbleS3.Rd
@@ -10,30 +10,31 @@
 \alias{as_tibble.tbl_survival}
 \title{Convert gtsummary object to tibble}
 \usage{
-\method{as_tibble}{tbl_summary}(x, include = NULL, exclude = NULL, col_labels = TRUE, ...)
+\method{as_tibble}{tbl_summary}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
 
-\method{as_tibble}{tbl_regression}(x, include = NULL, exclude = NULL, col_labels = TRUE, ...)
+\method{as_tibble}{tbl_regression}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
 
-\method{as_tibble}{tbl_uvregression}(x, include = NULL, exclude = NULL, col_labels = TRUE, ...)
+\method{as_tibble}{tbl_uvregression}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
 
-\method{as_tibble}{tbl_merge}(x, include = NULL, exclude = NULL, col_labels = TRUE, ...)
+\method{as_tibble}{tbl_merge}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
 
-\method{as_tibble}{tbl_stack}(x, include = NULL, exclude = NULL, col_labels = TRUE, ...)
+\method{as_tibble}{tbl_stack}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
 
-\method{as_tibble}{tbl_survival}(x, include = NULL, exclude = NULL, col_labels = TRUE, ...)
+\method{as_tibble}{tbl_survival}(x, include = NULL, col_labels = TRUE, exclude = NULL, ...)
 }
 \arguments{
 \item{x}{Object created by a function from the gtsummary package
 (e.g. \link{tbl_summary} or \link{tbl_regression})}
 
-\item{include}{Character vector or tidyselect function naming kable commands to include in printing.
-Default is \code{NULL}, which utilizes all commands in \code{x$kable_calls}.}
-
-\item{exclude}{Character vector or tidyselect function naming kable commands to exclude in printing.
-Default is \code{NULL}.}
+\item{include}{Commands to include in output. Input may be a vector of
+quoted or unquoted names. tidyselect and gtsummary select helper
+functions are also accepted.
+Default is \code{NULL}, which includes all commands in \code{x$kable_calls}.}
 
 \item{col_labels}{Logical argument adding column labels to output tibble.
 Default is \code{TRUE}.}
+
+\item{exclude}{DEPRECATED}
 
 \item{...}{Not used}
 }

--- a/man/tbl_merge.Rd
+++ b/man/tbl_merge.Rd
@@ -62,7 +62,7 @@ t4 <-
   )
 tbl_merge_ex2 <-
   tbl_merge(tbls = list(t3, t4)) \%>\%
-  as_gt(exclude = "tab_spanner") \%>\%
+  as_gt(include = -tab_spanner) \%>\%
   gt::cols_label(stat_0_1 = gt::md("**Summary Statistics**"))
 }
 }

--- a/man/tbl_regression.Rd
+++ b/man/tbl_regression.Rd
@@ -9,33 +9,33 @@ tbl_regression(
   label = NULL,
   exponentiate = FALSE,
   include = NULL,
-  exclude = NULL,
   show_single_row = NULL,
   conf.level = NULL,
   intercept = FALSE,
   estimate_fun = NULL,
   pvalue_fun = NULL,
+  tidy_fun = NULL,
   show_yesno = NULL,
-  tidy_fun = NULL
+  exclude = NULL
 )
 }
 \arguments{
 \item{x}{Regression model object}
 
 \item{label}{List of formulas specifying variables labels,
-e.g. \code{list("age" ~ "Age, yrs", "ptstage" ~ "Path T Stage")}}
+e.g. \code{list(age ~ "Age, yrs", stage ~ "Path T Stage")}}
 
 \item{exponentiate}{Logical indicating whether to exponentiate the
 coefficient estimates. Default is \code{FALSE}.}
 
-\item{include}{Character vector or tidyselect function indicating variables to include from output.}
-
-\item{exclude}{Character vector or tidyselect function indicating variables to exclude from output.}
+\item{include}{Variables to include in output. Input may be a vector of
+quoted or unquoted variable names. tidyselect and gtsummary select helper
+functions are also accepted. Default is \code{NULL}, which prints all variables.}
 
 \item{show_single_row}{By default categorical variables are printed on
 multiple rows.  If a variable is binary (e.g. Yes/No) and you wish to print
-the regression coefficient on a single row, include the variable name here,
-e.g. \code{show_single_row = c("var1", "var2")}}
+the regression coefficient on a single row, include the variable name(s)
+here--quoted and unquoted variable name accepted.}
 
 \item{conf.level}{Must be strictly greater than 0 and less than 1.
 Defaults to 0.95, which corresponds to a 95 percent confidence interval.}
@@ -54,11 +54,13 @@ and return a string that is the rounded/formatted p-value (e.g.
 \code{pvalue_fun = function(x) style_pvalue(x, digits = 2)} or equivalently,
 \code{purrr::partial(style_pvalue, digits = 2)}).}
 
-\item{show_yesno}{deprecated}
-
 \item{tidy_fun}{Option to specify a particular tidier function if the
 model is not a \link[=tidy_vetted]{vetted model} or you need to implement a
 custom method. Default is \code{NULL}}
+
+\item{show_yesno}{DEPRECATED}
+
+\item{exclude}{DEPRECATED}
 }
 \value{
 A \code{tbl_regression} object

--- a/man/tbl_regression.Rd
+++ b/man/tbl_regression.Rd
@@ -8,7 +8,7 @@ tbl_regression(
   x,
   label = NULL,
   exponentiate = FALSE,
-  include = NULL,
+  include = everything(),
   show_single_row = NULL,
   conf.level = NULL,
   intercept = FALSE,
@@ -29,8 +29,8 @@ e.g. \code{list(age ~ "Age, yrs", stage ~ "Path T Stage")}}
 coefficient estimates. Default is \code{FALSE}.}
 
 \item{include}{Variables to include in output. Input may be a vector of
-quoted or unquoted variable names. tidyselect and gtsummary select helper
-functions are also accepted. Default is \code{NULL}, which prints all variables.}
+quoted variable names, unquoted variable names, or tidyselect select helper
+functions. Default is \code{everything()}.}
 
 \item{show_single_row}{By default categorical variables are printed on
 multiple rows.  If a variable is binary (e.g. Yes/No) and you wish to print

--- a/man/tbl_summary.Rd
+++ b/man/tbl_summary.Rd
@@ -22,15 +22,15 @@ tbl_summary(
 \arguments{
 \item{data}{A data frame}
 
-\item{by}{A column name in data.
+\item{by}{A column name (quoted or unquoted) in \code{data}.
 Summary statistics will be calculated separately for each level of the \code{by}
 variable (e.g. \code{by = trt}). If \code{NULL}, summary statistics
 are calculated using all observations.}
 
 \item{label}{List of formulas specifying variables labels,
-e.g. \code{list(vars(age) ~ "Age, yrs", vars(ptstage) ~ "Path T Stage")}.  If a
-variable's label is not specified here, the
-function will take the label attribute (\code{attr(data$age, "label")}).  If
+e.g. \code{list(age ~ "Age, yrs", stage ~ "Path T Stage")}.  If a
+variable's label is not specified here, the label attribute
+(\code{attr(data$age, "label")}) is used.  If
 attribute label is \code{NULL}, the variable name will be used.}
 
 \item{statistic}{List of formulas specifying types of summary statistics to
@@ -44,11 +44,11 @@ places to round continuous summary statistics. If not specified,
 When multiple statistics are displayed for a single variable, supply a vector
 rather than an integer.  For example, if the
 statistic being calculated is \code{"{mean} ({sd})"} and you want the mean rounded
-to 1 decimal place, and the SD to 2 use \code{digits = list("age" ~ c(1, 2))}.}
+to 1 decimal place, and the SD to 2 use \code{digits = list(age ~ c(1, 2))}.}
 
 \item{type}{List of formulas specifying variable types. Accepted values
 are \code{c("continuous", "categorical", "dichotomous")},
-e.g. \code{type = list(starts_with(age) ~ "continuous", "female" ~ "dichotomous")}.
+e.g. \code{type = list(starts_with(age) ~ "continuous", female ~ "dichotomous")}.
 If type not specified for a variable, the function
 will default to an appropriate summary type.  See below for details.}
 
@@ -104,7 +104,7 @@ of formulas (e.g. \code{statistic}, \code{type}, \code{digits}, \code{value}, \c
 
 The statistic argument specifies the statistics presented in the table. The
 input is a list of formulas that specify the statistics to report. For example,
-\code{statistic = list("age" ~ "{mean} ({sd})")} would report the mean and
+\code{statistic = list(age ~ "{mean} ({sd})")} would report the mean and
 standard deviation for age; \code{statistic = list(all_continuous() ~ "{mean} ({sd})")}
 would report the mean and standard deviation for all continuous variables.
 A statistic name that appears between curly brackets
@@ -137,9 +137,9 @@ tbl_summary will do its best to guess the type.  Dichotomous variables
 are categorical variables that are displayed on a single row in the
 output table, rather than one row per level of the variable.
 Variables coded as TRUE/FALSE, 0/1, or yes/no are assumed to be dichotomous,
-and the TRUE, 1, and yes rows
-will be displayed.  Otherwise, the value to display must be specified in
-the \code{value} argument, e.g. \code{value = list("varname" ~ "level to show")}
+and the TRUE, 1, and yes rows are displayed.
+Otherwise, the value to display must be specified in
+the \code{value} argument, e.g. \code{value = list(varname ~ "level to show")}
 }
 
 \section{Example Output}{

--- a/man/tbl_uvregression.Rd
+++ b/man/tbl_uvregression.Rd
@@ -13,7 +13,7 @@ tbl_uvregression(
   formula = "{y} ~ {x}",
   exponentiate = FALSE,
   label = NULL,
-  include = NULL,
+  include = everything(),
   exclude = NULL,
   hide_n = FALSE,
   show_single_row = NULL,
@@ -55,8 +55,8 @@ coefficient estimates. Default is \code{FALSE}.}
 e.g. \code{list(age ~ "Age, yrs", stage ~ "Path T Stage")}}
 
 \item{include}{Variables to include in output. Input may be a vector of
-quoted or unquoted variable names. tidyselect and gtsummary select helper
-functions are also accepted. Default is \code{NULL}, which prints all variables.}
+quoted variable names, unquoted variable names, or tidyselect select helper
+functions. Default is \code{everything()}.}
 
 \item{exclude}{DEPRECATED}
 

--- a/man/tbl_uvregression.Rd
+++ b/man/tbl_uvregression.Rd
@@ -52,18 +52,20 @@ random intercept model, the formula may be \code{formula = "{y} ~ {x} + (1 | gea
 coefficient estimates. Default is \code{FALSE}.}
 
 \item{label}{List of formulas specifying variables labels,
-e.g. \code{list("age" ~ "Age, yrs", "ptstage" ~ "Path T Stage")}}
+e.g. \code{list(age ~ "Age, yrs", stage ~ "Path T Stage")}}
 
-\item{include}{Character vector or tidyselect function indicating variables to include from output.}
+\item{include}{Variables to include in output. Input may be a vector of
+quoted or unquoted variable names. tidyselect and gtsummary select helper
+functions are also accepted. Default is \code{NULL}, which prints all variables.}
 
-\item{exclude}{Character vector or tidyselect function indicating variables to exclude from output.}
+\item{exclude}{DEPRECATED}
 
 \item{hide_n}{Hide N column. Default is \code{FALSE}}
 
 \item{show_single_row}{By default categorical variables are printed on
 multiple rows.  If a variable is binary (e.g. Yes/No) and you wish to print
-the regression coefficient on a single row, include the variable name here,
-e.g. \code{show_single_row = c("var1", "var2")}}
+the regression coefficient on a single row, include the variable name(s)
+here--quoted and unquoted variable name accepted.}
 
 \item{conf.level}{Must be strictly greater than 0 and less than 1.
 Defaults to 0.95, which corresponds to a 95 percent confidence interval.}
@@ -79,7 +81,7 @@ and return a string that is the rounded/formatted p-value (e.g.
 \code{pvalue_fun = function(x) style_pvalue(x, digits = 2)} or equivalently,
 \code{purrr::partial(style_pvalue, digits = 2)}).}
 
-\item{show_yesno}{deprecated}
+\item{show_yesno}{DEPRECATED}
 
 \item{tidy_fun}{Option to specify a particular tidier function if the
 model is not a \link[=tidy_vetted]{vetted model} or you need to implement a

--- a/tests/testthat/test-add_p.R
+++ b/tests/testthat/test-add_p.R
@@ -31,8 +31,22 @@ test_that("add_p works well", {
     tbl_summary(mtcars, by = am) %>%
       add_p(test = list(
         vars(mpg) ~ "t.test",
-        vars(hp) ~ "kruskal.test"
+        disp ~ "aov",
+        cyl ~ "chisq.test.no.correct"
       )),
     NA
+  )
+})
+
+test_that("add_p defaults to clustered data with `group=` arg", {
+  expect_error(
+    add_p_lme4 <-
+      tbl_summary(trial[c("trt","death","age", "stage")], by = death) %>%
+      add_p(group = trt),
+    NA
+  )
+  expect_equal(
+    add_p_lme4$meta_data$stat_test,
+    c("lme4", "lme4")
   )
 })

--- a/tests/testthat/test-tbl_uvregression.R
+++ b/tests/testthat/test-tbl_uvregression.R
@@ -26,7 +26,7 @@ test_that("geeglm: no errors/warnings with standard use", {
         id = response,
         corstr = "exchangeable"
       ),
-      exclude = "response"
+      include = -response
     ), NA)
   expect_warning(
     tbl_uvregression(
@@ -37,7 +37,7 @@ test_that("geeglm: no errors/warnings with standard use", {
         id = response,
         corstr = "exchangeable"
       ),
-      exclude = "response"
+      include = -response
     ), NA)
 })
 
@@ -121,7 +121,6 @@ test_that("glmer: no errors/warnings with standard use", {
         label = "cyl" ~ "No. Cylinders",
         hide_n = TRUE,
         include = c("am", "gear", "hp", "cyl"),
-        exclude = c("hp")
       ), NA
   )
   expect_warning(
@@ -133,7 +132,6 @@ test_that("glmer: no errors/warnings with standard use", {
         formula = "{y} ~ {x} + (1 | gear)",
         method.args = list(family = binomial),
         include = c("am", "gear", "hp", "cyl"),
-        exclude = c("hp")
       ), NA
   )
 })

--- a/vignettes/gallery.Rmd
+++ b/vignettes/gallery.Rmd
@@ -105,7 +105,7 @@ t2 <- trial %>%
 
 # merging the 3 tables together, and adding additional gt formatting
 tbl_merge(list(t0, t1, t2)) %>%
-  as_gt(exclude = "tab_spanner") %>%
+  as_gt(include = -tab_spanner) %>%
   # hiding repeated summary columns
   cols_hide(columns = vars(stat_1_2, stat_2_2, stat_1_3, stat_2_3)) %>%
   # adding spanning headers for summary stats and pvalues
@@ -171,7 +171,7 @@ gt_eventn <-
 tbl_merge(list(gt_eventn, gt_model)) %>%
   bold_labels() %>%
   italicize_levels() %>%
-  as_gt(exclude = "tab_spanner")
+  as_gt(include = -tab_spanner)
 ```
 
 ---
@@ -215,7 +215,7 @@ gt_sum <-
 
 tbl_merge(list(gt_sum, tbl_reg))  %>%
   modify_header(estimate_2 = md("**Difference**")) %>%
-  as_gt(exclude = "tab_spanner")
+  as_gt(include = -tab_spanner)
 ```
 
 ---

--- a/vignettes/tbl_regression.Rmd
+++ b/vignettes/tbl_regression.Rmd
@@ -227,14 +227,14 @@ If the user does not want a specific {gt} function to run, any {gt} call can be 
 
 ```{r as_gt2, eval=FALSE}
 tbl_regression(m1, exponentiate = TRUE) %>%
-  as_gt(exclude = "tab_footnote")
+  as_gt(include = -tab_footnote)
 ```
 
 ```{r as_gt1, echo=FALSE}
 # this code chunk only works if gt is installed
 if (requireNamespace("gt", quietly = TRUE)) {
   tbl_regression(m1, exponentiate = TRUE) %>%
-    as_gt(exclude = "tab_footnote")
+    as_gt(include = -tab_footnote)
 }
 ```
 

--- a/vignettes/tbl_summary.Rmd
+++ b/vignettes/tbl_summary.Rmd
@@ -302,7 +302,7 @@ After the `as_gt()` function is run, additional formatting may be added to the t
 
 ```{r as_gt2, eval=FALSE}
 tbl_summary(trial2, by = trt) %>%
-  as_gt(exclude = "tab_footnote") %>%
+  as_gt(include = -tab_footnote) %>%
   gt::tab_spanner(label = gt::md("**Treatment Group**"),
                   columns = gt::starts_with("stat_"))
 ```
@@ -311,7 +311,7 @@ tbl_summary(trial2, by = trt) %>%
 # this code chunk only works if gt is installed
 if (requireNamespace("gt", quietly = TRUE)) {
   tbl_summary(trial2, by = trt) %>%
-    as_gt(exclude = "tab_footnote") %>%
+    as_gt(include = -tab_footnote) %>%
     gt::tab_spanner(label = gt::md("**Treatment Group**"),
                     columns = gt::starts_with("stat_"))
 }


### PR DESCRIPTION
**What changes are proposed in this pull request?**
The `exclude=` argument, used throughout the package has been deprecated.  PR also includes various updates to function documentation.

**If there is an GitHub issue associated with this pull request, please provide link.**
#331

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

