### PR TITLE
Try catch for tidiers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.4.9003
+Version: 1.2.4.9004
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* In the regression modeling functions `tbl_regression()` and `tbl_uvregression()`, the users are presented an informative error message when the tidier fails (e.g. `broom::tidy()`) alerting them to the location of the error so they may address the issue (#337, #338)
+
 * Package-wide update allowing arguments that accept variable names to accept bare/symbol inputs, character inputs, stored character inputs, and tidyselect helpers.  When passing a single variable, the `vars()` function wrapper is no longer required. #250
 
     ```r

--- a/R/utils-tbl_regression.R
+++ b/R/utils-tbl_regression.R
@@ -27,46 +27,65 @@ tidy_wrap <- function(x, exponentiate, conf.level, tidy_fun) {
   mixed_classes <- c("lmerMod", "glmerMod")
   if (is.null(tidy_fun)) {
     if (class(x)[1] %in% mixed_classes) { # can add other classes later. Need exact subclass.
-      tidy_bit <- broom.mixed::tidy(
+      tryCatch({
+        tidy_bit <- broom.mixed::tidy(
         x,
         exponentiate = exponentiate,
         conf.level = conf.level, conf.int = TRUE, effects = "fixed"
       )
+      },
+      error = function(e) {
+        usethis::ui_oops(paste0(
+          "There was an error calling {usethis::ui_code('broom.mixed::tidy(x, conf.int = TRUE, effects = \"fixed\")')},\n",
+          "which is required for gtsummary to print the model summary.\n",
+          "See error message below. \n"
+        ))
+        stop(as.character(e), call. = FALSE)
+      }
+      )
     }
 
     if (!(class(x)[1] %in% mixed_classes)) {
-      tidy_bit <- broom::tidy(
+      tryCatch({
+        tidy_bit <- broom::tidy(
         x,
         exponentiate = exponentiate,
         conf.level = conf.level, conf.int = TRUE
+      )
+      },
+      error = function(e) {
+        usethis::ui_oops(paste0(
+          "There was an error calling {usethis::ui_code('broom::tidy(x, conf.int = TRUE)')},\n",
+          "which is required for gtsummary to print the model summary.\n",
+          "See error message below. \n"
+        ))
+        stop(as.character(e), call. = FALSE)
+      }
       )
     }
 
     # deleting scale parameters from survreg objects
     if (class(x)[1] == "survreg") {
-      return(
-        tidy_bit %>%
-          filter(!!parse_expr('term != "Log(scale)"'))
-      )
+      tidy_bit %>%
+        filter(!!parse_expr('term != "Log(scale)"'))
     }
   }
 
   # if user specified a tidier use it here.
   if (!is.null(tidy_fun)) {
-    tryCatch(
-      {
+    tryCatch({
         tidy_bit <- do.call(
           tidy_fun,
           args = list(x,
             exponentiate = exponentiate,
-            conf.level = conf.level, conf.int = T
+            conf.level = conf.level, conf.int = TRUE
           )
         )
       },
       error = function(e) {
         usethis::ui_oops(paste0(
           "There was an error calling {usethis::ui_code('tidy_fun')}.\n",
-          "Most likely, this is because the argument passed in {usethis::ui_code('tidy_fun = ')} \n",
+          "Most likely, this is because the argument passed in {usethis::ui_code('tidy_fun=')} \n",
           "was\nmisspelled, does not exist, is not compatible with your object, \n",
           "or was missing necessary arguments. See error message below. \n"
         ))

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,14 +10,14 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.4.9003",
+  "version": "1.2.4.9004",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
-    "version": "3.6.1",
+    "version": "3.6.2",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 3.6.1 (2019-07-05)",
+  "runtimePlatform": "R version 3.6.2 (2019-12-12)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -431,7 +431,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "1543.899KB",
+  "fileSize": "1545.664KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -2,3 +2,4 @@ library(testthat)
 library(gtsummary)
 
 test_check("gtsummary")
+options(usethis.quiet = TRUE)


### PR DESCRIPTION
**What changes are proposed in this pull request?**

`tryCatch()` statements now surround the calls to the `tidy()` functions.  If the tidier produces an error, the user is alerted of the problem (rather than making it look like a gtsummary problem)

**If there is an GitHub issue associated with this pull request, please provide link.**
#338, #337


--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

