### PR TITLE
389 data subset bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.6.9001
+Version: 1.2.6.9002
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Bug fix when data frame passed to `tbl_summary()` with a single column (#389)
+
 * Update add_p() custom p-value description to NOT require double escape characters for quotes (#361)
 
 # gtsummary 1.2.6

--- a/R/tidyselect_to_list.R
+++ b/R/tidyselect_to_list.R
@@ -167,7 +167,7 @@ tidyselect_to_string <- function(...data..., ...meta_data... = NULL,
 
   tryCatch({
     result <-
-      rlang::call2(dplyr::select, .data = ...data...[0, ], !!!dots_enquo) %>%
+      rlang::call2(dplyr::select, .data = ...data...[0, , drop = FALSE], !!!dots_enquo) %>%
       rlang::eval_tidy() %>%
       colnames()
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.6.9000",
+  "version": "1.2.6.9002",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -432,7 +432,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "2749.911KB",
+  "fileSize": "2750.065KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/tests/testthat/test-tbl_summary.R
+++ b/tests/testthat/test-tbl_summary.R
@@ -365,3 +365,13 @@ test_that("tbl_summary-all missing data does not cause error", {
     c("stat_1", "stat_2", "stat_3")
   )
 })
+
+
+test_that("tbl_summary-no error when *data frame* with single column passed", {
+  expect_error(
+    trial["trt"] %>%
+      as.data.frame() %>%
+      tbl_summary(label = trt ~ "TREATMENT GROUP"),
+    NA
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Bug fix when a data frame with one column was passed to `tbl_summary()`

**If there is an GitHub issue associated with this pull request, please provide link.**
#389 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, function included in `pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. 
- [x] Update `gt_sha` in `data-raw/gt_sha.R` AND run the file.
- [x] R CMD Check runs without errors, warnings, and notes
- [x] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

