### PR TITLE
added check for missing p-values in combine terms

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.6.9002
+Version: 1.2.6.9003
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/R/combine_terms.R
+++ b/R/combine_terms.R
@@ -108,7 +108,7 @@ combine_terms <- function(x, formula_update, label = NULL, ...) {
   # extracting p-value from anova object ---------------------------------------
   df_anova <- as_tibble(anova) %>%
     select(starts_with("Pr(>"),  starts_with("P(>"))
-  # if not column was selected, print error
+  # if no column was selected, print error
   if (ncol(df_anova) == 0) {
     stop(paste(
       "The output from `anova()` did not contain a p-value.\n",
@@ -121,6 +121,11 @@ combine_terms <- function(x, formula_update, label = NULL, ...) {
   anova_p <- df_anova %>%
     slice(n()) %>%
     pull()
+
+  # if no p-value returned in p-value column
+  if (is.na(anova_p)) {
+    stop("The output from `anova()` did not contain a p-value.", call. = FALSE)
+  }
 
   # tbl'ing the new model object -----------------------------------------------
   # getting call from original tbl_regression call, and updating with new model object

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.6.9002",
+  "version": "1.2.6.9003",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -430,9 +430,9 @@
       "sameAs": "https://CRAN.R-project.org/package=usethis"
     }
   ],
-  "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
-  "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "2750.065KB",
+  "releaseNotes": "https://github.com/jflynn264/gtsummary/blob/master/NEWS.md",
+  "readme": "https://github.com/jflynn264/gtsummary/blob/master/README.md",
+  "fileSize": "2749.795KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/tests/testthat/test-combine_terms.R
+++ b/tests/testthat/test-combine_terms.R
@@ -130,6 +130,21 @@ test_that("error catching working properly", {
       combine_terms(formula = . ~ . -marker, label = c("marker", "marker2")),
     "*"
   )
+
+  # there is no pvalue returned by anova in this model
+  expect_error(
+    lm(mpg ~ disp + am * factor(cyl), data = mtcars) %>%
+      tbl_regression() %>%
+      combine_terms(. ~ . - am),
+    "*"
+  )
+
+  expect_error(
+    glm(am ~ disp + factor(cyl), data = mtcars, family = binomial) %>%
+      tbl_regression() %>%
+      combine_terms(. ~ . - disp),
+    "*"
+  )
 })
 
 # Confirm map/apply situation works


### PR DESCRIPTION
**What changes are proposed in this pull request?**
This PR adds a check to ensure `anova()` returns a p-value.

**If there is an GitHub issue associated with this pull request, please provide link.**
#401 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. 
- [ ] Update `gt_sha` in `data-raw/gt_sha.R` AND run the file.
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

