### PR TITLE
#373 checking for gtsummary class, rather than individual tbl type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.2.6.9003
+Version: 1.2.6.9004
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",
@@ -90,4 +90,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Removed class checking for each type gtsummary table type, and made `tbl_stack()`, `tbl_merge()`, `bold_labels()` (and friends) generic and now check for class gtsummary (#373)
+
 * Bug fix when data frame passed to `tbl_summary()` with a single column (#389)
 
 * Update add_p() custom p-value description to NOT require double escape characters for quotes (#361)

--- a/R/add_overall.R
+++ b/R/add_overall.R
@@ -48,7 +48,8 @@ add_overall <- function(x, last = FALSE) {
     x$table_body %>%
       select(c("row_type", "variable", "label")),
     overall %>%
-      select(c("row_type", "variable", "label"))
+      select(c("row_type", "variable", "label")) %>%
+      as_tibble()
   )) {
     stop("An error occured in 'add_overall()', cannot merge overall statistics")
   }

--- a/R/bold_italicise_labels_levels.R
+++ b/R/bold_italicise_labels_levels.R
@@ -25,14 +25,8 @@ NULL
 #' @export
 bold_labels <- function(x) {
   # input checks ---------------------------------------------------------------
-  if (!class(x)[1] %in% c(
-    "tbl_summary", "tbl_regression", "tbl_uvregression",
-    "tbl_stack", "tbl_merge"
-  ) %>% all()) {
-    stop(paste0(
-      "Class of 'x' must be 'tbl_summary', 'tbl_regression', ",
-      "'tbl_uvregression', 'tbl_stack', or 'tbl_merge'"
-    ))
+  if (!inherits(x, "gtsummary")) {
+    stop("Class of 'x' must be 'gtsummary'", call. = FALSE)
   }
 
   # bold labels ----------------------------------------------------------------
@@ -62,14 +56,8 @@ bold_labels <- function(x) {
 #' @export
 bold_levels <- function(x) {
   # input checks ---------------------------------------------------------------
-  if (!class(x)[1] %in% c(
-    "tbl_summary", "tbl_regression", "tbl_uvregression",
-    "tbl_stack", "tbl_merge"
-  ) %>% all()) {
-    stop(paste0(
-      "Class of 'x' must be 'tbl_summary', 'tbl_regression', ",
-      "'tbl_uvregression', 'tbl_stack', or 'tbl_merge'"
-    ))
+  if (!inherits(x, "gtsummary")) {
+    stop("Class of 'x' must be 'gtsummary'", call. = FALSE)
   }
 
   # bold levels ----------------------------------------------------------------
@@ -100,15 +88,8 @@ bold_levels <- function(x) {
 #' @export
 italicize_labels <- function(x) {
   # input checks ---------------------------------------------------------------
-  if (!class(x)[1] %in%
-    c(
-      "tbl_summary", "tbl_regression", "tbl_uvregression",
-      "tbl_stack", "tbl_merge"
-    ) %>% all()) {
-    stop(paste0(
-      "Class of 'x' must be 'tbl_summary', 'tbl_regression', ",
-      "'tbl_uvregression', 'tbl_stack', or 'tbl_merge'"
-    ))
+  if (!inherits(x, "gtsummary")) {
+    stop("Class of 'x' must be 'gtsummary'", call. = FALSE)
   }
 
   # italicize labels -----------------------------------------------------------
@@ -139,15 +120,8 @@ italicize_labels <- function(x) {
 #' @export
 italicize_levels <- function(x) {
   # input checks ---------------------------------------------------------------
-  if (!class(x)[1] %in% c(
-    "tbl_summary", "tbl_regression", "tbl_uvregression",
-    "tbl_stack", "tbl_merge", "tbl_stack", "tbl_merge"
-  ) %>% all()
-  ) {
-    stop(paste0(
-      "Class of 'x' must be 'tbl_summary', 'tbl_regression', ",
-      "'tbl_uvregression', 'tbl_stack', or 'tbl_merge'"
-    ))
+  if (!inherits(x, "gtsummary")) {
+    stop("Class of 'x' must be 'gtsummary'", call. = FALSE)
   }
 
   # italicize levels -----------------------------------------------------------

--- a/R/tbl_merge.R
+++ b/R/tbl_merge.R
@@ -70,14 +70,9 @@ tbl_merge <- function(tbls, tab_spanner = NULL) {
     stop("Expecting 'tbls' to be a list, e.g. 'tbls = list(tbl1, tbl2)'")
   }
 
-  # checking all inputs are class tbl_regression, tbl_uvregression,
-  # tbl_regression, tbl_summary, or tbl_stack
-  if (!map_chr(tbls, ~class(.x)[1]) %in%
-    c("tbl_regression", "tbl_uvregression", "tbl_summary", "tbl_stack") %>% all()) {
-    stop(paste(
-      "All objects in 'tbls' must be class 'tbl_regression',",
-      "'tbl_uvregression', 'tbl_summary', or 'tbl_stack'"
-    ))
+  # checking all inputs are class gtsummary
+  if (!purrr::every(tbls, ~inherits(.x, "gtsummary"))) {
+    stop("All objects in 'tbls' must be class 'gtsummary'", call. = FALSE)
   }
 
   # at least two objects must be passed
@@ -102,10 +97,9 @@ tbl_merge <- function(tbls, tab_spanner = NULL) {
   # merging tables -------------------------------------------------------------
   # nesting data by variable (one line per variable), and renaming columns with number suffix
   nested_table <- tbls %>%
-    map("table_body") %>%
     imap(function(x, y) {
       # creating a column that is the variable label
-      group_by(x, .data$variable) %>%
+      group_by(x$table_body, .data$variable) %>%
         mutate(
           var_label = ifelse(.data$row_type == "label", .data$label, NA)
         ) %>%

--- a/R/tbl_stack.R
+++ b/R/tbl_stack.R
@@ -76,11 +76,6 @@ tbl_stack <- function(tbls) {
     stop("All objects in 'tbls' must be class 'gtsummary'", call. = FALSE)
   }
 
-  # checking if there are multiple input types
-  if (map_chr(tbls, ~class(.x)[1]) %>% unique() %>% length() > 1) {
-    message("Multiple gtsummary object classes detected. Displayed results default to first input class type.")
-  }
-
   # will return call, and all arguments passed to tbl_stack
   func_inputs <- as.list(environment())
 

--- a/R/tbl_stack.R
+++ b/R/tbl_stack.R
@@ -71,22 +71,9 @@ tbl_stack <- function(tbls) {
     stop("Expecting 'tbls' to be a list, e.g. 'tbls = list(tbl1, tbl2)'")
   }
 
-  # checking all inputs are class tbl_uvregression, tbl_regression, tbl_summary, or tbl_merge
-  if (!map_chr(tbls, ~class(.x)[1]) %in% c(
-    "tbl_regression", "tbl_uvregression",
-    "tbl_summary", "tbl_merge"
-  ) %>% any()) {
-    stop("All objects in 'tbls' must be class 'tbl_regression',
-         'tbl_uvregression', 'tbl_summary', or 'tbl_merge'")
-  }
-
-  # printing message if stacking tbl_summary and regression object
-  if ("tbl_summary" %in% map_chr(tbls, ~class(.x)[1]) &&
-    any(c("tbl_regression", "tbl_uvregression") %in% map_chr(tbls, ~class(.x)[1]))) {
-    message(paste(
-      "You are stacking a gtsummary regression table and a summary table,",
-      "which is not recommended. Consider revising the format of your table."
-    ))
+  # checking all inputs are class gtsummary
+  if (!purrr::every(tbls, ~inherits(.x, "gtsummary"))) {
+    stop("All objects in 'tbls' must be class 'gtsummary'", call. = FALSE)
   }
 
   # checking if there are multiple input types

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.2.6.9003",
+  "version": "1.2.6.9004",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -430,9 +430,9 @@
       "sameAs": "https://CRAN.R-project.org/package=usethis"
     }
   ],
-  "releaseNotes": "https://github.com/jflynn264/gtsummary/blob/master/NEWS.md",
-  "readme": "https://github.com/jflynn264/gtsummary/blob/master/README.md",
-  "fileSize": "2749.795KB",
+  "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
+  "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
+  "fileSize": "2749.551KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/tests/testthat/test-combine_terms.R
+++ b/tests/testthat/test-combine_terms.R
@@ -56,9 +56,9 @@ test_that("combine_terms works without error", {
     glm(response ~ age + marker + sp2marker + sp3marker,
         data = trial %>%
           bind_cols(
-            rcspline.eval(.$marker, nk = 4, inclx = TRUE, norm = 0) %>%
+            rcspline.eval(.$marker, nk = 4, inclx = FALSE, norm = 0) %>%
               as.data.frame() %>%
-              set_names("marker", "sp2marker", "sp3marker")
+              set_names("sp2marker", "sp3marker")
           ) %>%
           filter(complete.cases(.) == TRUE),
         family = "binomial") %>%
@@ -99,9 +99,9 @@ test_that("combine_terms works without error", {
       as.formula("weight ~ Diet + Time + sp2Time + sp3Time"),
       data = ChickWeight %>%
         bind_cols(
-          Hmisc::rcspline.eval(.$Time, nk = 4, inclx = TRUE, norm = 0) %>%
+          Hmisc::rcspline.eval(.$Time, nk = 4, inclx = FALSE, norm = 0) %>%
             as.data.frame() %>%
-            set_names("Time", "sp2Time", "sp3Time")
+            set_names("sp2Time", "sp3Time")
         ),
       family = gaussian,
       id = Chick,


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Removes class checking for each type gtsummary type, and made `tbl_stack()`, `tbl_merge()`, `bold_labels()` (and friends) generic and now just checks for class gtsummary.

Now works with `tbl_ancova()`
```r
tbl_ancova_ex1 <-
  trial %>%
  bstfun::tbl_ancova(y = c("age", "marker"), x = "trt")
tbl_ancova_ex2 <-
  trial %>%
  bstfun::tbl_ancova(y = c("age", "marker"), x = "trt")

tbl_stack(list(tbl_ancova_ex1, tbl_ancova_ex2))
tbl_merge(list(tbl_ancova_ex1, tbl_ancova_ex2))
```
![image](https://user-images.githubusercontent.com/26774684/76586489-5c62e800-64b7-11ea-9af3-3dcb3905e3fe.png)
![image](https://user-images.githubusercontent.com/26774684/76586518-6e448b00-64b7-11ea-9b2c-59c35a042be1.png)


**If there is an GitHub issue associated with this pull request, please provide link.**
#373 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. 
- [ ] Update `gt_sha` in `data-raw/gt_sha.R` AND run the file.
- [x] R CMD Check runs without errors, warnings, and notes
- [x] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

