### PR TITLE
bug fix for ordered factors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,7 @@
 
 * Bug fix when data frame passed to `tbl_summary()` with a single column (#389)
 
-* In `tbl_summary()` passing an ordered factor in the `by=` argument no longer causes as error.
+* In `tbl_summary()` passing an ordered factor in the `by=` argument no longer causes as error. (#453)
 
 # gtsummary 1.2.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@
 
 * Bug fix when data frame passed to `tbl_summary()` with a single column (#389)
 
+* In `tbl_summary()` passing an ordered factor in the `by=` argument no longer causes as error.
+
 # gtsummary 1.2.6
 
 * Bug fix for random effects regression model where coefficients were not exponentiated when requested.  Using `broom.mixed::tidy()` rather than `broom::tidy()` resolved issue.

--- a/R/tbl_summary.R
+++ b/R/tbl_summary.R
@@ -158,6 +158,11 @@ tbl_summary <- function(data, by = NULL, label = NULL, statistic = NULL,
   tbl_summary_data_checks(data)
   data <- data %>% ungroup()
 
+  # removing orderered class from factor by variables --------------------------
+  if (!is.null(by) && inherits(data[[by]], "ordered") && inherits(data[[by]], "factor")) {
+    data[[by]] <- factor(data[[by]], ordered = FALSE)
+  }
+
   # deleting obs with missing by values ----------------------------------------
   # saving variable labels
   if (!is.null(by) && sum(is.na(data[[by]])) > 0) {

--- a/tests/testthat/test-tbl_summary.R
+++ b/tests/testthat/test-tbl_summary.R
@@ -375,3 +375,13 @@ test_that("tbl_summary-no error when *data frame* with single column passed", {
     NA
   )
 })
+
+
+test_that("tbl_summary-no error when by variable is ordered factor", {
+  expect_error(
+    trial %>%
+      dplyr::mutate(grade = as.ordered(grade)) %>%
+      tbl_summary(by=grade),
+    NA
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
 In `tbl_summary()` passing an ordered factor in the `by=` argument no longer causes as error.
Reported by @ahinton-mmc
**If there is an GitHub issue associated with this pull request, please provide link.**


--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

