### PR TITLE
tbl_regression interaction updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.3.0.9001
+Version: 1.3.0.9002
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Updated handling for interaction terms in `tbl_regression()`. Interaction terms may now be specified in the `show_single_row=` and `label=` arguments. (#451, #452)
+
 * Updated the gtsummary core script, `utils-gtsummary_core.R`, to refer to all non-base R functions with the `pkg::` prefix, so other packages that copy the file don't need to import the same functions as {gtsummary} in the NAMESPACE. Now they just need to depend on the same packages. (#454)
 
 # gtsummary 1.3.0

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.3.0.9000",
+  "version": "1.3.0.9002",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -476,7 +476,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "3088.61KB",
+  "fileSize": "3088.984KB",
   "contIntegration": [
     "https://travis-ci.org/ddsjoberg/gtsummary",
     "https://ci.appveyor.com/project/ddsjoberg/gtsummary",

--- a/tests/testthat/test-tbl_regression.R
+++ b/tests/testthat/test-tbl_regression.R
@@ -145,3 +145,29 @@ test_that("Testing lme4 results", {
 })
 
 
+test_that("Interaction modifications", {
+  # no error with interaction
+  expect_error(
+    tbl_i <- lm(age ~ factor(response) * marker, trial) %>%
+      tbl_regression(
+        show_single_row = `factor(response):marker`,
+        label = `factor(response):marker` ~ "Interaction"
+      ),
+    NA
+  )
+
+  # checking modifications to table
+  expect_equal(
+    dplyr::filter(tbl_i$table_body, variable == "factor(response):marker") %>%
+      dplyr::pull(label),
+    "Interaction"
+  )
+
+  expect_equal(
+    dplyr::filter(tbl_i$table_body, variable == "factor(response):marker") %>%
+      nrow(),
+    1L
+  )
+})
+
+


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Previously, it was not possible to change the interaction label. It was always `"Variable 1 Label * Variable 2 Label"`. But now, the interaction label can be updated.

Moreover, the `show_single_row=` argument ignored interaction terms, and now that is remedied.

Need to check the update works for multiple model types, and does not break any existing labeling/showing on a single row.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #451 
closes #452 

```r
lm(age ~ factor(response) * marker, trial) %>%
  tbl_regression(
    show_single_row = `factor(response):marker`,
    label = list(
      `factor(response)` ~ "Tumor Response",
      `factor(response):marker` ~ "Interaction"
    )
  )
```
![image](https://user-images.githubusercontent.com/26774684/79674417-09183f80-81b1-11ea-9f63-052c5750ff13.png)

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

