### PR TITLE
add_p fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.3.0.9003
+Version: 1.3.0.9004
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # gtsummary (development version)
 
+* Handling of passed custom p-value functions in `add_p.tbl_summary()` has been improved with more careful handling of the environments from which the functions were passed. Other related updates were also made:
+    - Users may pass their custom p-value function as a quoted string or bare.
+    - The basic functions for calculating p-values, such as `t.test()` can now be passed directly e.g. `test = age ~ t.test`. We now perform a check match check for functions passed. If it is passed, we replace it with our internal version that returns the p-value and assigns the test name.
+    - If a user passes a custom function, and it's not the proper form (i.e. a named list return object) AND the function returns a single numeric value, we assume that is the p-value and it's added to the gtsummary table.
+
 * `add_stat_label()` function updated with `location=` and `label=` arguments to change the location of the statistic labels and to modify the text of the labels. (#467)
 
 * `tbl_stack()` function added the `group_header=` argument that groups the stacked tables and adds a horizontal header row between them. (#468)

--- a/R/utils-add_p.R
+++ b/R/utils-add_p.R
@@ -10,8 +10,8 @@
 #' @keywords internal
 #' @author Daniel D. Sjoberg
 
-assign_test <- function(data, var, var_summary_type, by_var, test, group) {
-  map2_chr(
+assign_test <- function(data, var, var_summary_type, by_var, test, group, env) {
+  map2(
     var, var_summary_type,
     ~ assign_test_one(
       data = data,
@@ -19,44 +19,108 @@ assign_test <- function(data, var, var_summary_type, by_var, test, group) {
       var_summary_type = .y,
       by_var = by_var,
       test = test,
-      group = group
+      group = group,
+      env = env
     )
   )
 }
 
-assign_test_one <- function(data, var, var_summary_type, by_var, test, group) {
-  # if user specifed test to be performed, do that test.
-  if (!is.null(test[[var]])) {
-    return(test[[var]])
+# test_match_to_fn -------------------------------------------------------------
+# little function to return the function from the shortcut name,
+# this is a helper function for assign_test_one()
+test_match_to_fn <- function(x, env) {
+  if (is.null(x)) return(NULL)
+
+  # lookup table
+  df_lookup <-
+    tibble::tribble(
+      ~fun_chr, ~fun_base_r, ~fun_add_p,
+      "t.test", stats::t.test, add_p_test_t.test,
+      "aov", stats::aov, add_p_test_aov,
+      "kruskal.test", stats::kruskal.test, add_p_test_kruskal.test,
+      "wilcox.test", stats::wilcox.test, add_p_test_wilcox.test,
+      "chisq.test", stats::chisq.test, add_p_test_chisq.test,
+      "chisq.test.no.correct", NULL, add_p_test_chisq.test.no.correct,
+      "fisher.test", stats::fisher.test, add_p_test_fisher.test,
+      "lme4", NULL, add_p_test_lme4
+    )
+
+  # if string was passed, match `fun_chr`
+  if (rlang::is_string(x) && x %in% df_lookup$fun_chr) {
+      return(df_lookup$fun_add_p[df_lookup$fun_chr %in% x] %>% pluck(1))
   }
 
+  # if fn was passed, match `fun_base_r`
+  if (rlang::is_function(x)) {
+    lgl <- map_lgl(df_lookup$fun_base_r, function(fn) identical(fn, x))
+    if (any(lgl))
+      return(df_lookup$fun_add_p[lgl] %>% pluck(1))
+  }
+
+  # if the input is a function, return it
+  if (rlang::is_function(x)) return(x)
+
+  # if the user passed a string, return the function that is the string
+  if (rlang::is_string(x))
+    return(rlang::parse_expr(x) %>% rlang::eval_tidy(env = env))
+
+  # if not a match, return NULL
+  return(NULL)
+}
+
+# assign_test_one() ------------------------------------------------------------
+assign_test_one <- function(data, var, var_summary_type, by_var, test, group, env) {
+  # if user specifed test to be performed, do that test. -----------------------
+  # matching an internal test by name or base R function match
+  # or returning the appropriate test based on what is passed
+  test_func <- test_match_to_fn(test[[var]], env = env)
+  if (!is.null(test_func)) return(test_func)
+
+  # if no test supplied, setting defaults --------------------------------------
   # if group variable supplied, fit a random effects model
   if (!is.null(group) & length(unique(data[[by_var]])) == 2) {
     if (var_summary_type == "continuous") {
-      return(getOption("gtsummary.add_p.test.continuous.group_by2", default = "lme4"))
+
+      test_func <-
+        getOption("gtsummary.add_p.test.continuous.group_by2", default = "lme4") %>%
+        test_match_to_fn()
+      return(test_func)
     }
     if (var_summary_type %in% c("categorical", "dichotomous")) {
-      return(getOption("gtsummary.add_p.test.categorical.group_by2", default = "lme4"))
+      test_func <-
+        getOption("gtsummary.add_p.test.categorical.group_by2", default = "lme4") %>%
+        test_match_to_fn()
+      return(test_func)
     }
   }
 
   # unless by_var has >2 levels, then return NA with a message
   if (!is.null(group) & length(unique(data[[by_var]])) > 2) {
-    message(paste0(var, ": P-value calculation for clustered data when by variables have >2 levels is not currently supported"))
-    return(NA_character_)
+    message(paste0(var, ": P-value calculation for correlated data when by variables have >2 levels is not currently supported"))
+    return(NULL)
   }
 
   # for continuous data, default to non-parametric tests
   if (var_summary_type == "continuous" & length(unique(data[[by_var]])) == 2) {
-    return(getOption("gtsummary.add_p.test.continuous_by2", default = "wilcox.test"))
+    test_func <-
+      getOption("gtsummary.add_p.test.continuous_by2", default = "wilcox.test") %>%
+      test_match_to_fn()
+    return(test_func)
   }
   if (var_summary_type == "continuous") {
-    return(getOption("gtsummary.add_p.test.continuous", default = "kruskal.test"))
+    test_func <-
+      getOption("gtsummary.add_p.test.continuous", default = "kruskal.test") %>%
+      test_match_to_fn()
+    return(test_func)
   }
 
   # if all obs are missing, assigning chisq
-  if (length(data[[var]]) == sum(is.na(data[[var]])))
-    return(getOption("gtsummary.add_p.test.categorical", default = "chisq.test"))
+  if (length(data[[var]]) == sum(is.na(data[[var]]))) {
+    test_func <-
+      getOption("gtsummary.add_p.test.categorical", default = "chisq.test") %>%
+      test_match_to_fn()
+    return(test_func)
+  }
 
   # calculate expected counts
   min_exp <-
@@ -73,9 +137,15 @@ assign_test_one <- function(data, var, var_summary_type, by_var, test, group) {
 
   # if expected counts >= 5 for all cells, chisq, otherwise Fishers exact
   if (min_exp >= 5) {
-    return(getOption("gtsummary.add_p.test.categorical", default = "chisq.test"))
+    test_func <-
+      getOption("gtsummary.add_p.test.categorical", default = "chisq.test") %>%
+      test_match_to_fn()
+    return(test_func)
   }
-  return(getOption("gtsummary.add_p.test.categorical.low_count", default = "fisher.test"))
+  test_func <-
+    getOption("gtsummary.add_p.test.categorical.low_count", default = "fisher.test") %>%
+    test_match_to_fn()
+  return(test_func)
 }
 
 
@@ -183,22 +253,9 @@ add_p_test_safe <- function(data, variable, by, group, test, include = NULL, typ
   tryCatch(
     withCallingHandlers(
       {
-        test_func <- switch(
-          test,
-          t.test = add_p_test_t.test,
-          aov = add_p_test_aov,
-          kruskal.test = add_p_test_kruskal.test,
-          wilcox.test = add_p_test_wilcox.test,
-          chisq.test = add_p_test_chisq.test,
-          chisq.test.no.correct = add_p_test_chisq.test.no.correct,
-          fisher.test = add_p_test_fisher.test,
-          lme4 = add_p_test_lme4
-        ) %||% # if not an internal test, then resolving to function name supplied
-          test
-
         # initializing to NA
         pval <- NA_real_
-        pval <- do.call(test_func, list(
+        pval <- do.call(test, list(
           data = data, variable = variable,
           by = by, group = group, test = test,
           type = type
@@ -207,16 +264,15 @@ add_p_test_safe <- function(data, variable, by, group, test, include = NULL, typ
       # printing warning and errors as message
       warning = function(w) {
         message(glue(
-          "Warning in 'add_p()' for variable '{variable}' ",
-          "and test '{test}':\n ", as.character(w)
+          "Warning in 'add_p()' for variable '{variable}':\n ", as.character(w)
         ))
         invokeRestart("muffleWarning")
       }
     ),
     error = function(e) {
       message(glue(
-        "There was an error in 'add_p()' for variable '{variable}' ",
-        "and test '{test}', p-value omitted:\n", as.character(e)
+        "There was an error in 'add_p()' for variable '{variable}', ",
+        "p-value omitted:\n", as.character(e)
       ))
       return(NULL)
     }

--- a/R/utils-gtsummary_core.R
+++ b/R/utils-gtsummary_core.R
@@ -322,7 +322,7 @@ tidyselect_to_list <- function(.data, x, .meta_data = NULL,
                                    arg_name = arg_name,
                                    select_single = select_single)
 
-        rhs <- rlang::f_rhs(x) %>% eval()
+        rhs <- rlang::f_rhs(x) %>% rlang::eval_tidy(env = rlang::f_env(x))
 
         # converting rhs and lhs into a named list
         purrr::map(lhs, ~ list(rhs) %>% rlang::set_names(.x)) %>%

--- a/tests/testthat/test-add_p.R
+++ b/tests/testthat/test-add_p.R
@@ -11,6 +11,27 @@ test_that("add_p creates output without error/warning", {
   )
 
   expect_error(
+    trial %>%
+      tbl_summary(by = trt) %>%
+      add_p(),
+    NA
+  )
+
+  expect_warning(
+    trial %>%
+      tbl_summary(by = trt) %>%
+      add_p(),
+    NA
+  )
+
+  expect_message(
+    trial %>%
+      tbl_summary(by = trt) %>%
+      add_p(),
+    NA
+  )
+
+  expect_error(
     tbl_summary(trial, by = trt) %>%
       add_p(test = everything() ~ "lme4", group = response),
     NA
@@ -36,22 +57,42 @@ test_that("add_p works well", {
       )),
     NA
   )
-})
 
-test_that("add_p defaults to clustered data with `group=` arg", {
   expect_error(
-    add_p_lme4 <-
-      tbl_summary(trial[c("trt","death","age", "stage")], by = death) %>%
-      add_p(group = trt),
+    tbl_summary(mtcars, by = am) %>%
+      add_p(test = list(
+        vars(mpg) ~ t.test,
+        disp ~ aov
+      )),
     NA
   )
-  expect_equal(
-    add_p_lme4$meta_data$stat_test,
-    c("lme4", "lme4")
+})
+
+test_that("add_p with custom p-value function", {
+  my_mcnemar <- function(data, variable, by, ...) {
+    result <- list()
+    result$p <- stats::mcnemar.test(data[[variable]], data[[by]])$p.value
+    result$test <- "McNemar's test"
+    result
+  }
+
+  expect_error(
+    trial[c("response", "trt")] %>%
+      tbl_summary(by = trt) %>%
+      add_p(test = response ~ "my_mcnemar"),
+    NA
+  )
+
+  expect_error(
+    trial[c("response", "trt")] %>%
+      tbl_summary(by = trt) %>%
+      add_p(test = response ~ my_mcnemar),
+    NA
   )
 })
 
 
+# test-add_p.tbl_cross----------------------------------------------------------
 context("test-add_p.tbl_cross")
 
 test_that("add_p.tbl_cross", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
We've always had issues when users utilized custom p-value functions in `add_p.tbl_summary()`. After looking into it, it seems the problem was some careless programming that led to ambiguous environment searching for the user's custom function.

I've gone through the function and made the environments explicit, and I think it's solved the problem.  I've also made the following updates
- Users can pass their custom p-value function as a quoted string or bare.
- The basic functions for calculating pvalues, such as `t.test()` can now be passed directly.  We now perform a check match check for functions passed. If it is passed, we replace it with our version that returns the p-value and assigns the test name, e.g. `test = age ~ t.test`
- If a user passes a custom function, and it's not the proper form (i.e. a named list return) AND the function returns a single numeric value, we assume that is the p-value and it's added to the gtsummary table.

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

