### PR TITLE
add assert_package() function

### DIFF
--- a/R/add_global_p.R
+++ b/R/add_global_p.R
@@ -18,12 +18,7 @@
 
 add_global_p <- function(x, ...) {
   # must have car package installed to use this function
-  if (!requireNamespace("car", quietly = TRUE)) {
-    stop(paste0(
-      "The 'car' package is required for 'add_global_p'.\n",
-      "Install with install.packages('car')"
-    ), call. = FALSE)
-  }
+  assert_package("car", "add_global_p")
   UseMethod("add_global_p")
 }
 

--- a/R/as_flextable.R
+++ b/R/as_flextable.R
@@ -49,12 +49,7 @@ as_flextable <- function(x, ...) {
 as_flextable.gtsummary <- function(x, include = everything(), return_calls = FALSE,
                          strip_md_bold = TRUE, ...) {
   # must have flextable package installed to use this function -----------------
-  if (!requireNamespace("flextable", quietly = TRUE)) {
-    stop(paste0(
-      "The 'flextable' package is required for 'as_flextable'.\n",
-      "Install with install.packages('flextable')"
-    ), call. = FALSE)
-  }
+  assert_package("flextable", "as_flextable")
 
   # stripping markdown asterisk ------------------------------------------------
   if (strip_md_bold == TRUE) {

--- a/R/as_kable_extra.R
+++ b/R/as_kable_extra.R
@@ -22,12 +22,7 @@
 as_kable_extra <- function(x, include = everything(), return_calls = FALSE,
                            strip_md_bold = TRUE, ...) {
   # must have kableExtra package installed to use this function ----------------
-  if (!requireNamespace("kableExtra", quietly = TRUE)) {
-    stop(paste0(
-      "The 'kableExtra' package is required for 'as_kable_extra'.\n",
-      "Install with install.packages('kableExtra')"
-    ), call. = FALSE)
-  }
+  assert_package("kableExtra", "as_kable_extra")
 
   # stripping markdown asterisk ------------------------------------------------
   if (strip_md_bold == TRUE) {

--- a/R/utils-as.R
+++ b/R/utils-as.R
@@ -1,0 +1,19 @@
+
+#' Check that a package is installed, stopping otherwise
+#'
+#' @param pkg Package required
+#' @param fn Calling function from the user perspective
+#'
+#' @return Returns NULL or not at all.
+#'
+#' @noRd
+#' @keywords internal
+#' @author David Hugh-Jones
+assert_package <- function(pkg, fn) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+    stop(glue::glue(
+      "The '{pkg}' package is required for '{fn}'.\n",
+      "Install with install.packages('{pkg}')"
+    ), call. = FALSE)
+  }
+}


### PR DESCRIPTION
**What changes are proposed in this pull request?**

Housekeeping. Replaces boilerplate requireNamespace() code with a single assert_package(pkg, fun) utility function.

**If there is an GitHub issue associated with this pull request, please provide link.**


--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

