### PR TITLE
fixes for flextable output

### DIFF
--- a/R/add_nevent.R
+++ b/R/add_nevent.R
@@ -111,6 +111,12 @@ add_nevent.tbl_regression <- function(x, ...) {
     left_join(x$table_header, by = "column") %>%
     table_header_fill_missing()
 
+  # adding a format function to the N event column
+  x$table_header <- table_header_fmt_fun(
+    x$table_header,
+    nevent = function(x) ifelse(is.na(x), NA_character_, sprintf("%.0f", x))
+  )
+
   x$call_list <- c(x$call_list, list(add_nevent = match.call()))
 
   x
@@ -183,6 +189,11 @@ add_nevent.tbl_uvregression <- function(x, ...) {
     table_header_fill_missing()
   x <- modify_header_internal(x, nevent = "**Event N**")
 
+  # adding a format function to the N event column
+  x$table_header <- table_header_fmt_fun(
+    x$table_header,
+    nevent = function(x) ifelse(is.na(x), NA_character_, sprintf("%.0f", x))
+  )
 
   x
 }

--- a/R/as_flextable.R
+++ b/R/as_flextable.R
@@ -95,11 +95,11 @@ table_header_to_flextable_calls <- function(x, ...) {
     ungroup()
 
   # tibble ---------------------------------------------------------------------
-  # getting flextable calls
+  # flextable doesn't use the markdown language `__` or `**`
+  # to bold and italicize text, so removing them here
   flextable_calls <-
-    table_header_to_tibble_calls(x = x, col_labels = FALSE)
-  flextable_calls[["tab_style_bold"]] <- NULL
-  flextable_calls[["tab_style_italic"]] <- NULL
+    as_tibble(x, return_calls = TRUE,
+              include = -c("cols_label", "tab_style_bold", "tab_style_italic"))
 
   # flextable ------------------------------------------------------------------
   flextable_calls[["flextable"]] <- expr(flextable::flextable())
@@ -127,7 +127,8 @@ table_header_to_flextable_calls <- function(x, ...) {
                                       " ",
                                       .data$spanning_header)) %>%
       group_by(.data$spanning_header) %>%
-      dplyr::summarise(width = n()) %>%
+      mutate(width = n()) %>%
+      distinct() %>%
       ungroup()
 
     flextable_calls[["add_header_row"]] <- expr(

--- a/R/as_kable.R
+++ b/R/as_kable.R
@@ -80,8 +80,7 @@ table_header_to_kable_calls <- function(x, ...) {
   table_header <- x$table_header
   dots <- rlang::enexprs(...)
 
-  kable_calls <-
-    table_header_to_tibble_calls(x = x, col_labels = FALSE)
+  kable_calls <- as_tibble(x, return_calls = TRUE, include = -c("cols_label"))
 
   # fmt_missing ----------------------------------------------------------------
   kable_calls[["fmt_missing"]] <- expr(dplyr::mutate_all(~ifelse(is.na(.), "", .)))

--- a/R/as_kable_extra.R
+++ b/R/as_kable_extra.R
@@ -67,8 +67,7 @@ table_header_to_kable_extra_calls <- function(x, ...) {
   table_header <- x$table_header
 
   # getting kable calls
-  kable_extra_calls <-
-    table_header_to_kable_calls(x = x, ...)
+  kable_extra_calls <- as_kable(x = x, return_calls = TRUE, ...)
 
   # add_indent -----------------------------------------------------------------
   tab_style_indent <-

--- a/R/tbl_regression.R
+++ b/R/tbl_regression.R
@@ -233,6 +233,13 @@ tbl_regression <- function(x, label = NULL, exponentiate = FALSE,
     table_header_fill_missing() %>%
     table_header_fmt_fun(estimate = estimate_fun)
 
+  if ("N" %in% names(table_body)) {
+    table_header <-
+      table_header_fmt_fun(
+        table_header,
+        N = function(x) ifelse(is.na(x), NA_character_, sprintf("%.0f", x))
+      )
+  }
   if ("p.value" %in% names(table_body)) {
     table_header <- table_header_fmt_fun(table_header, p.value = pvalue_fun)
   }

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -288,6 +288,13 @@ tbl_uvregression <- function(data, method, y = NULL, x = NULL, method.args = NUL
             # only display N on label row
             tbl$table_body$N <- ifelse(tbl$table_body$row_type == "label",
                                        tbl$table_body$N, NA)
+
+            # adding a format function to the N column
+            tbl$table_header <- table_header_fmt_fun(
+              tbl$table_header,
+              N = function(x) ifelse(is.na(x), NA_character_, sprintf("%.0f", x))
+            )
+
             tbl
           }
         )


### PR DESCRIPTION
**What changes are proposed in this pull request?**
@moleps noted formatting issues with some columns using `as_flextable()`.  This PR addresses the formatting problems.
1. flextable handles missing values for numeric and character columns differently. Numeric missing prints `NA`, and character `""`. In gtsummary that were printed as numeric columns because the default looked good (all columns were integers).  Added a formatting function to those columns to force conversion to character.
1. Spanning headers were being printed in alphabetical order! Update to preserve the ordering.

**If there is an GitHub issue associated with this pull request, please provide link.**
#482 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

