### PR TITLE
added include arg to tbl_summary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.3.0.9007
+Version: 1.3.0.9008
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Added `include=` argument to `tbl_summary()`. (#477)
+
 * Bug fix for `as_flextable()`. (#482)
   - Added a formatting function to all numeric columns to force conversion to character.
   - Spanning headers were being printed in alphabetical order! Update to preserve the ordering.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gtsummary (development version)
 
-* Added `include=` argument to `tbl_summary()`. (#477)
+* Added `include=` argument to `tbl_summary()`. The preferred syntax for p-values with correlated data is now `tbl_summary(..., include = -group_var) %>% add_p(group = group_var)`. The group variable is now no longer removed from the table summary. (#477)
 
 * Bug fix for `as_flextable()`. (#482)
   - Added a formatting function to all numeric columns to force conversion to character.

--- a/R/add_overall.R
+++ b/R/add_overall.R
@@ -32,7 +32,8 @@ add_overall <- function(x, last = FALSE) {
 
   # removing 'by' variable from data
   # (so it won't show up in the overall tbl_summary)
-  x_copy$inputs[["data"]] <- x$inputs[["data"]] %>% select(-c(x[["by"]]))
+  x_copy$inputs[["data"]] <- select(x$inputs[["data"]], -x[["by"]])
+  x_copy$inputs$include <- x_copy$inputs$include %>% setdiff(x[["by"]])
 
   # replacing the function call by variable to NULL to get results overall
   x_copy$inputs[["by"]] <- NULL

--- a/R/add_p.R
+++ b/R/add_p.R
@@ -125,12 +125,15 @@ add_p.tbl_summary <- function(x, test = NULL, pvalue_fun = NULL,
   # group argument -------------------------------------------------------------
   if (!is.null(group)) {
     # checking group is in the data frame
-    if (!group %in% x$meta_data$variable) {
+    if (!group %in% names(x$inputs$data)) {
       stop(glue("'{group}' is not a column name in the input data frame."), call. = FALSE)
     }
-    # dropping group variable from table_body and meta_data
-    x$table_body <- x$table_body %>% filter(.data$variable != group)
-    x$meta_data <- x$meta_data %>% filter(.data$variable != group)
+    if (group %in% x$meta_data$variable) {
+      rlang::inform(glue::glue(
+        "The `group=` variable is no longer auto-removed from the summary table as of v1.3.1.\n",
+        "The following syntax is now preferred:\n",
+        "tbl_summary(..., include = -{group}) %>% add_p(..., group = {group})"))
+    }
   }
 
   # setting defaults -----------------------------------------------------------

--- a/R/add_p.R
+++ b/R/add_p.R
@@ -115,10 +115,10 @@ add_p.tbl_summary <- function(x, test = NULL, pvalue_fun = NULL,
   group <- var_input_to_string(data = x$inputs$data,
                                select_input = !!rlang::enquo(group),
                                arg_name = "group", select_single = TRUE)
-  include <- var_input_to_string(data = x$inputs$data,
+  include <- var_input_to_string(data = select(x$inputs$data, any_of(x$meta_data$variable)),
                                  select_input = !!rlang::enquo(include),
                                  arg_name = "include")
-  exclude <- var_input_to_string(data = x$inputs$data,
+  exclude <- var_input_to_string(data = select(x$inputs$data, any_of(x$meta_data$variable)),
                                  select_input = !!rlang::enquo(exclude),
                                  arg_name = "exclude")
 
@@ -159,8 +159,8 @@ add_p.tbl_summary <- function(x, test = NULL, pvalue_fun = NULL,
   # test -----------------------------------------------------------------------
   # parsing into a named list
   test <- tidyselect_to_list(
-    x$inputs$data, test,
-    .meta_data = x$meta_data, arg_name = "test"
+    select(x$inputs$data, any_of(x$meta_data$variable)),
+    test, .meta_data = x$meta_data, arg_name = "test"
   )
 
   # checking pvalue_fun are functions
@@ -260,6 +260,7 @@ footnote_add_p <- function(meta_data) {
 #'
 #' \Sexpr[results=rd, stage=render]{lifecycle::badge("experimental")}
 #' Calculate and add a p-value comparing the two variables in the cross table.
+#' Missing values are *not* included in p-value calculations.
 #'
 #' @param x Object with class `tbl_cross` from the [tbl_cross] function
 #' @param pvalue_fun Function to round and format p-value.

--- a/R/add_stat_label.R
+++ b/R/add_stat_label.R
@@ -59,7 +59,7 @@ add_stat_label <- function(x, location = NULL, label = NULL) {
   # stat_label default
   stat_label <- as.list(x$meta_data$stat_label) %>% set_names(x$meta_data$variable)
   # converting input to named list
-  label <- tidyselect_to_list(x$inputs$data, label,
+  label <- tidyselect_to_list(x$inputs$data[x$meta_data$variable], label,
                               .meta_data = x$meta_data, arg_name = "label")
   # updating the default values with values in label
   stat_label <- imap(stat_label, ~label[[.y]] %||% .x)

--- a/R/tbl_summary.R
+++ b/R/tbl_summary.R
@@ -145,8 +145,8 @@ tbl_summary <- function(data, by = NULL, label = NULL, statistic = NULL,
                         digits = NULL, type = NULL, value = NULL,
                         missing = NULL, missing_text = NULL, sort = NULL,
                         percent = NULL, include = everything(), group = NULL) {
-  # enqou ----------------------------------------------------------------------
-  include <- rlang::enquo(include)
+  # eval -----------------------------------------------------------------------
+  include <- select(data, {{ include }}) %>% names()
 
   # setting defaults from gtsummary theme --------------------------------------
   label <- label %||% get_theme_element("tbl_summary-arg:label")

--- a/R/tbl_summary.R
+++ b/R/tbl_summary.R
@@ -45,6 +45,7 @@
 #' e.g. `sort = list(everything() ~ "frequency")`
 #' @param percent Indicates the type of percentage to return. Must be one of
 #' `"column"`, `"row"`, or `"cell"`. Default is `"column"`.
+#' @param include variables to include in the summary table. Default is `everything()`
 #' @param group DEPRECATED. Migrated to [add_p]
 #'
 #' @section select helpers:
@@ -143,7 +144,9 @@
 tbl_summary <- function(data, by = NULL, label = NULL, statistic = NULL,
                         digits = NULL, type = NULL, value = NULL,
                         missing = NULL, missing_text = NULL, sort = NULL,
-                        percent = NULL, group = NULL) {
+                        percent = NULL, include = everything(), group = NULL) {
+  # enqou ----------------------------------------------------------------------
+  include <- rlang::enquo(include)
 
   # setting defaults from gtsummary theme --------------------------------------
   label <- label %||% get_theme_element("tbl_summary-arg:label")
@@ -207,12 +210,13 @@ tbl_summary <- function(data, by = NULL, label = NULL, statistic = NULL,
   tbl_summary_inputs <- as.list(environment())
 
   # removing variables with unsupported variable types from data ---------------
+  data <- select(data, !!include)
   classes_expected <- c("character", "factor", "numeric", "logical", "integer", "difftime")
   var_to_remove <-
     map_lgl(data, ~ class(.x) %in% classes_expected %>% any()) %>%
     discard(. == TRUE) %>%
     names()
-  data <- dplyr::select(data, -var_to_remove)
+  data <- select(data, -var_to_remove)
   if (length(var_to_remove) > 0) {
     message(glue(
       "Column(s) {glue_collapse(paste(sQuote(var_to_remove)), sep = ', ', last = ', and ')} ",

--- a/R/utils-add_p.R
+++ b/R/utils-add_p.R
@@ -183,7 +183,8 @@ add_p_test_wilcox.test <- function(data, variable, by, ...) {
   if (length(unique(data[[by]])) > 2) {
     stop("Wilcoxon rank-sum test cannot be calculated with more than 2 groups")
   }
-  result$p <- stats::kruskal.test(data[[variable]], as.factor(data[[by]]))$p.value
+  result$p <- stats::wilcox.test(data[[variable]],
+                                 as.numeric(as.factor(data[[by]])))$p.value
   result$test <- "Wilcoxon rank-sum test"
   result
 }

--- a/R/utils-add_p.R
+++ b/R/utils-add_p.R
@@ -97,8 +97,7 @@ assign_test_one <- function(data, var, var_summary_type, by_var, test, group, en
 
   # unless by_var has >2 levels, then return NA with a message
   if (!is.null(group) & length(unique(data[[by_var]])) > 2) {
-    message(paste0(var, ": P-value calculation for correlated data when by variables have >2 levels is not currently supported"))
-    return(NULL)
+    stop(glue("{var}: There is not default test for correlated data when `by=` variable has >2 levels."))
   }
 
   # for continuous data, default to non-parametric tests

--- a/R/utils-tbl_summary.R
+++ b/R/utils-tbl_summary.R
@@ -421,7 +421,11 @@ tbl_summary_input_checks <- function(data, by, label, type, value, statistic,
   tbl_summary_data_checks(data)
 
   # by -------------------------------------------------------------------------
-  # no checks for by argument
+  if (!is.null(by) && !by %in% names(data)) {
+    stop(glue(
+      "`by = '{by}'` is not a column in `data=`. Did you misspell the column name, ",
+      "or omit the column with the `include=` argument?"), call. = FALSE)
+  }
 
   # type -----------------------------------------------------------------------
   if (!is.null(type) & is.null(names(type))) { # checking names for deprecated named list input

--- a/man/add_p.tbl_cross.Rd
+++ b/man/add_p.tbl_cross.Rd
@@ -25,6 +25,7 @@ in the \{gt\} table source notes rather than a column.}
 \description{
 \Sexpr[results=rd, stage=render]{lifecycle::badge("experimental")}
 Calculate and add a p-value comparing the two variables in the cross table.
+Missing values are \emph{not} included in p-value calculations.
 }
 \section{Example Output}{
 

--- a/man/tbl_summary.Rd
+++ b/man/tbl_summary.Rd
@@ -16,6 +16,7 @@ tbl_summary(
   missing_text = NULL,
   sort = NULL,
   percent = NULL,
+  include = everything(),
   group = NULL
 )
 }
@@ -70,6 +71,8 @@ e.g. \code{sort = list(everything() ~ "frequency")}}
 
 \item{percent}{Indicates the type of percentage to return. Must be one of
 \code{"column"}, \code{"row"}, or \code{"cell"}. Default is \code{"column"}.}
+
+\item{include}{variables to include in the summary table. Default is \code{everything()}}
 
 \item{group}{DEPRECATED. Migrated to \link{add_p}}
 }

--- a/tests/testthat/test-add_p.R
+++ b/tests/testthat/test-add_p.R
@@ -2,6 +2,11 @@ context("test-add_p.tbl_summary")
 
 test_that("add_p creates output without error/warning", {
   expect_error(
+    tbl_summary(trial, by = grade) %>% add_p(),
+    NA
+  )
+
+  expect_error(
     tbl_summary(mtcars, by = am) %>% add_p(),
     NA
   )
@@ -33,15 +38,27 @@ test_that("add_p creates output without error/warning", {
 
   expect_error(
     tbl_summary(trial, by = trt, include = -response) %>%
-      add_p(test = everything() ~ "lme4", group = response),
+      add_p(group = response),
     NA
+  )
+
+  expect_message(
+    tbl_summary(trial, by = trt) %>%
+      add_p(test = everything() ~ "lme4", group = response),
+    "*"
   )
 })
 
-test_that("add_p creates errors when non-function in input", {
+test_that("add_p creates errors with bad args", {
   expect_error(
     tbl_summary(mtcars, by = am) %>%
       add_p(pvalue_fun = mtcars),
+    "*"
+  )
+
+  expect_error(
+    tbl_summary(trial, by = grade, include = -response) %>%
+      add_p(group = response),
     "*"
   )
 })

--- a/tests/testthat/test-add_p.R
+++ b/tests/testthat/test-add_p.R
@@ -32,7 +32,7 @@ test_that("add_p creates output without error/warning", {
   )
 
   expect_error(
-    tbl_summary(trial, by = trt) %>%
+    tbl_summary(trial, by = trt, include = -response) %>%
       add_p(test = everything() ~ "lme4", group = response),
     NA
   )

--- a/tests/testthat/test-inline_text.R
+++ b/tests/testthat/test-inline_text.R
@@ -231,7 +231,7 @@ test_that("inline_text.tbl_survfit", {
 test_that("inline_text.tbl_cross", {
   tbl_cross <-
     tbl_cross(trial, row = trt, col = response) %>%
-    add_p()
+    add_p(percent = "cell")
 
   expect_equal(
     inline_text(tbl_cross, row_level = "Drug A", col_level = "1"),

--- a/tests/testthat/test-select_helpers.R
+++ b/tests/testthat/test-select_helpers.R
@@ -1,3 +1,5 @@
+context("test-select_helpers")
+
 test_that("test-select helpers", {
   expect_equal(
     var_input_to_string(mtcars, select_input = vars(hp, mpg)),

--- a/tests/testthat/test-tbl_regression.R
+++ b/tests/testthat/test-tbl_regression.R
@@ -99,7 +99,6 @@ test_that("tbl_regression creates errors when inputs are wrong", {
   )
 })
 
-
 test_that("No errors/warnings when data is labelled using Hmisc", {
   expect_error(tbl_regression(cox_hmisclbl), NA)
   expect_warning(tbl_regression(cox_hmisclbl), NA)

--- a/tests/testthat/test-tbl_regression.R
+++ b/tests/testthat/test-tbl_regression.R
@@ -79,6 +79,7 @@ test_that("tbl_regression creates errors when non-function in input", {
   )
 })
 
+
 test_that("tbl_regression creates errors when inputs are wrong", {
   expect_error(
     tbl_regression(mod_lm_interaction, label = "Age"),

--- a/tests/testthat/test-tbl_summary_input_checks.R
+++ b/tests/testthat/test-tbl_summary_input_checks.R
@@ -45,4 +45,18 @@ test_that("input check", {
     tbl_summary(trial %>% select(-everything())),
     "*"
   )
+  expect_error(
+    tbl_summary(trial, by = trt, include = -trt),
+    "*"
+  )
+  expect_error(
+    tbl_summary(trial, type = is.character),
+    "*"
+  )
+
+  expect_error(
+    tbl_summary(trial, digits = list(is.character)),
+    "*"
+  )
+
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
The `include=` argument has been added to `tbl_summary()`. This largely affects `add_p()`, where users no longer need to include a `group=` variable in the summary table before `add_p()`.  This is the new preferred syntax:
```r
tbl_summary(trial, include = -response) %>% 
  add_p(group = response)
```

The response column will not be included in the summary table, but is available as a grouping variable in `add_p()`

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #477 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, function included in `pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

