### PR TITLE
Coerce cols to character in as_tibble()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.3.0.9010
+Version: 1.3.0.9011
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gtsummary (development version)
 
-* All columns in `as_tibble()` are now styled and converted to character. Previoulsy, styling was applied to most columns, but there were a few that relied on default printing for the type of underlying data.  This was ok to rely on this default behavior for `as_kable()`, but with the introduction of `as_flextable()` we needed to style and format each column to character. Potential to break some code in edge cases. (#493)  
+* All columns in `as_tibble()` are now styled and converted to character. Previously, styling was applied to most columns, but there were a few that relied on default printing for the type of underlying data.  This was ok to rely on this default behavior for `as_kable()`, but with the introduction of `as_flextable()` we needed to style and format each column to character. Potential to break some code in edge cases. (#493)  
 
 * Messaging about statistical methods used has been added for `add_global_p()`, `add_q()`, and `combine_terms()`. (#471)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* All columns in `as_tibble()` are now styled and converted to character. Previoulsy, styling was applied to most columns, but there were a few that relied on default printing for the type of underlying data.  This was ok to rely on this default behavior for `as_kable()`, but with the introduction of `as_flextable()` we needed to style and format each column to character. Potential to break some code in edge cases. (#493)  
+
 * Messaging about statistical methods used has been added for `add_global_p()`, `add_q()`, and `combine_terms()`. (#471)
 
 * Bug fix for `bold_p()`. The bold_p() function now works correctly and no longer makes p>0.9 bold when using as_tibble for kable print engine. (#489)

--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -133,10 +133,18 @@ table_header_to_tibble_calls <- function(x, col_labels =  TRUE) {
     ~ expr(mutate_at(vars(!!!syms(df_fmt$column[[.x]])), !!df_fmt$fmt_fun[[.x]]))
   )
 
-  # cols_hide ------------------------------------------------------------------
+  # converting all cols to character...
+  # this is important for some output types, e.g. as_flextable, so missing don't
+  # display as NA
   cols_to_keep <-
     dplyr::filter(table_header, .data$hide == FALSE) %>%
     pull(.data$column)
+
+  tibble_calls[["fmt"]] <-
+    c(tibble_calls[["fmt"]], list(expr(mutate_at(!!!syms(cols_to_keep), as.character))))
+
+  # cols_hide ------------------------------------------------------------------
+  # cols_to_keep object created above in fmt section
   tibble_calls[["cols_hide"]] <- expr(dplyr::select(!!!syms(cols_to_keep)))
 
   # cols_label -----------------------------------------------------------------

--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -141,7 +141,7 @@ table_header_to_tibble_calls <- function(x, col_labels =  TRUE) {
     pull(.data$column)
 
   tibble_calls[["fmt"]] <-
-    c(tibble_calls[["fmt"]], list(expr(mutate_at(!!!syms(cols_to_keep), as.character))))
+    c(tibble_calls[["fmt"]], list(expr(mutate_at(vars(!!!syms(cols_to_keep)), as.character))))
 
   # cols_hide ------------------------------------------------------------------
   # cols_to_keep object created above in fmt section


### PR DESCRIPTION
**What changes are proposed in this pull request?**
All columns in `as_tibble()` are now styled and converted to character. Previoulsy, styling was applied to most columns, but there were a few that relied on default printing for the type of underlying data.  This was ok to rely on this default behavior for `as_kable()`, but with the introduction of `as_flextable()` we needed to style and format each column to character. Potential to break some code in edge cases. (#493)  

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #493 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [x] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

