### PR TITLE
updating as felxtable when spanning header present

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.3.0.9012
+Version: 1.3.0.9013
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,6 +78,7 @@ Suggests:
     Hmisc,
     kableExtra,
     lme4,
+    officer,
     pkgdown,
     rmarkdown,
     scales,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Improved appearance of default `as_flextable()` output (#499)
+
 * Added `tbl_cross(margin=)` argument to control which margins are shown in the output table. (#444)
 
 * The missing values are now included in the calculation of p-values in `tbl_cross()`.

--- a/R/as_flextable.R
+++ b/R/as_flextable.R
@@ -47,7 +47,7 @@ as_flextable <- function(x, ...) {
 #' @rdname as_flextable
 #' @export
 as_flextable.gtsummary <- function(x, include = everything(), return_calls = FALSE,
-                         strip_md_bold = TRUE, ...) {
+                                   strip_md_bold = TRUE, ...) {
   # must have flextable package installed to use this function -----------------
   assert_package("flextable", "as_flextable")
 
@@ -139,10 +139,21 @@ table_header_to_flextable_calls <- function(x, ...) {
       distinct() %>%
       ungroup()
 
-    flextable_calls[["add_header_row"]] <- expr(
-      flextable::add_header_row(
-        values = !!df_header$spanning_header,
-        colwidths = !!df_header$width
+    flextable_calls[["add_header_row"]] <- list(
+      expr(
+        # add the header row with the spanning headers
+        flextable::add_header_row(
+          values = !!df_header$spanning_header,
+          colwidths = !!df_header$width
+        )
+      ),
+      expr(
+        # add border above that matches border below
+        flextable::border(
+          i = 1,
+          border.top = officer::fp_border(width=2),
+          part = "header"
+        )
       )
     )
   }
@@ -176,6 +187,11 @@ table_header_to_flextable_calls <- function(x, ...) {
   flextable_calls[["padding"]] <- map2(
     df_padding$id, df_padding$i_index,
     ~expr(flextable::padding(i = !!.y, j = !!.x, padding.left = 15))
+  )
+
+  # fontsize -------------------------------------------------------------------
+  flextable_calls[["fontsize"]] <- list(
+    expr(flextable::fontsize(part = "header", size = 11))
   )
 
   # autofit --------------------------------------------------------------------

--- a/R/as_flextable.R
+++ b/R/as_flextable.R
@@ -15,6 +15,7 @@
 #' 1. [flextable::add_header_row()], if applicable, to set spanning column header
 #' 1. [flextable::align()] to set column alignment
 #' 1. [flextable::padding()] to indent variable levels
+#' 1. [flextable::fontsize()] to set fotn size
 #' 1. [flextable::autofit()] to estimate the column widths
 #' 1. [flextable::footnote()] to add table footnotes and source notes
 #' 1. [flextable::bold()] to bold cells in data frame

--- a/man/as_flextable.Rd
+++ b/man/as_flextable.Rd
@@ -54,6 +54,7 @@ it to a flextable and formats the table with the following flextable functions.
 \item \code{\link[flextable:add_header_row]{flextable::add_header_row()}}, if applicable, to set spanning column header
 \item \code{\link[flextable:align]{flextable::align()}} to set column alignment
 \item \code{\link[flextable:padding]{flextable::padding()}} to indent variable levels
+\item \code{\link[flextable:fontsize]{flextable::fontsize()}} to set fotn size
 \item \code{\link[flextable:autofit]{flextable::autofit()}} to estimate the column widths
 \item \code{\link[flextable:footnote]{flextable::footnote()}} to add table footnotes and source notes
 \item \code{\link[flextable:bold]{flextable::bold()}} to bold cells in data frame


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Made some updates to the way flextables are printed when there are spanning headers.

**If there is an GitHub issue associated with this pull request, please provide link.**
#499 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

