### PR TITLE
Update error messaging when bad args are passed to tbl_summary(statistic=)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.3.0.9014
+Version: 1.3.0.9015
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Improved error messaging when invalid statistics are requested in `tbl_summary(statistic=)` (#502)
+
 * The following columns in `tbl_summary()` are now available to print for both continuous and categorical variables: total number of observations `{N_obs}`, number of missing observations `{N_miss}`, number of non-missing observations `{N_nomiss}`, proportion of missing observations `{p_miss}`, proportion of non-missing observations `{p_nomiss}`. (#473)
 
 * Improved appearance of default `as_flextable()` output (#499)

--- a/R/utils-tbl_summary.R
+++ b/R/utils-tbl_summary.R
@@ -947,7 +947,7 @@ df_stats_to_tbl <- function(data, variable, summary_type, by, var_label, stat_di
         "There are 2 common sources for this error.\n",
         "1. You have requested summary statistics meant for continuous\n",
         "   variables for a variable being as summarized as categorical.\n",
-        "   To change the summary type to continuous add the argument\n",
+        "   To change the summary type to continuous, add the argument\n",
         "  `type = list({{variable}} ~ 'continuous')`\n",
         "2. One of the functions or statistics from the `statistic=` argument is not valid.",
         .open = "{{", .close = "}}"

--- a/R/utils-tbl_summary.R
+++ b/R/utils-tbl_summary.R
@@ -939,7 +939,7 @@ df_stats_to_tbl <- function(data, variable, summary_type, by, var_label, stat_di
 
   # calculating the statistic to be displayed in the cell in the table.
   tryCatch(
-    df_stats$statistic <- glue::glue_data(df_stats, stat_display),
+    df_stats$statistic <- glue::glue_data(df_stats, stat_display) %>% as.character(),
     error = function(e) {
       stop(glue(
         "There was an error assembling the summary statistics for '{{variable}}'\n",

--- a/tests/testthat/test-tbl_summary.R
+++ b/tests/testthat/test-tbl_summary.R
@@ -123,6 +123,11 @@ test_that("tbl_summary returns errors with bad inputs", {
     tbl_summary(trial, by = c("trt", "grade")),
     "*"
   )
+
+  expect_error(
+    tbl_summary(trial, statistic = everything() ~ "{mean}"),
+    "*"
+  )
 })
 
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Added an error message when bad stats are requested in `tbl_summary(statistic=)`. For example, requesting a mean for a categorical variable. 

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #502 

``` r
library(gtsummary)
trial %>%
  dplyr::select(grade, trt) %>%
  tbl_summary(statistic = everything() ~ "{mean}")
#> Error: Problem with `mutate()` input `tbl_stats`.
#> x There was an error assembling the summary statistics for 'grade'
#>   with summary type categorical.
#> 
#> There are 2 common sources for this error.
#> 1. You have requested summary statistics meant for continuous
#>    variables for a variable being as summarized as categorical.
#>    To change the summary type to continuous add the argument
#>   `type = list(grade ~ 'continuous')`
#> 2. One of the functions or statistic from the `statistic=` argument is not valid.
#> i Input `tbl_stats` is `pmap(...)`.
```

<sup>Created on 2020-05-20 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] If a new function was added, function included in `pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. 
- [x] R CMD Check runs without errors, warnings, and notes
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

