### PR TITLE
empty string bug fix for selectors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.3.0.9017
+Version: 1.3.0.9018
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Bug fix for `inline_text.tbl_summary()` when categorical variable contained levels with empty strings.
+
 * Fixed bug where some variables in `tbl_cross()` defaulted to dichotomous instead of showing as categorical (#506)
 
 * New functions `modify_footnote()` and `modify_spanning_header()` give users control over table footnotes and spanning headers. (#464)

--- a/R/utils-tbl_regression.R
+++ b/R/utils-tbl_regression.R
@@ -492,9 +492,10 @@ parse_final_touches <- function(group, group_lbl, single_row, var_type, data, mo
 #' @keywords internal
 vctr_2_tibble <- function(x) {
   n <- length(x)
-  matrix(ncol = n) %>%
-    tibble::as_tibble(.name_repair = "minimal") %>%
-    rlang::set_names(x) %>%
-    dplyr::slice(0)
+  df <- matrix(ncol = n) %>%
+    tibble::as_tibble(.name_repair = "minimal")
+
+  names(df) <- x
+  df[0, , drop = FALSE]
 }
 

--- a/R/vetted_models.R
+++ b/R/vetted_models.R
@@ -35,15 +35,17 @@
 #' capture any arguments you may not need). See below for an example where the
 #' confidence limits for a linear regression model are calculated using Wald's method.
 #' @examples
-#' my_tidy <- function(x, exponentiate =  FALSE, conf.level = 0.95, ...) {
+#' my_tidy <- function(x, exponentiate = FALSE, conf.level = 0.95, ...) {
 #'   tidy <-
 #'     dplyr::bind_cols(
 #'       broom::tidy(x, conf.int = FALSE),
-#'       broom::confint_tidy(x, func = stats::confint.default, conf.level = conf.level)
+#'       # calculate the confidence intervals, and save them in a tibble
+#'       stats::confint.default(x) %>% tibble::as_tibble() %>% rlang::set_names(c("conf.low", "conf.high"))
 #'     )
 #'   # exponentiating, if requested
 #'   if (exponentiate == TRUE)
 #'     tidy <- dplyr::mutate_at(vars(estimate, conf.low, conf.high), exp)
+#'   tidy
 #' }
 #'
 #' lm(age ~ grade + response, trial) %>%

--- a/man/vetted_models.Rd
+++ b/man/vetted_models.Rd
@@ -43,15 +43,17 @@ confidence limits for a linear regression model are calculated using Wald's meth
 }
 
 \examples{
-my_tidy <- function(x, exponentiate =  FALSE, conf.level = 0.95, ...) {
+my_tidy <- function(x, exponentiate = FALSE, conf.level = 0.95, ...) {
   tidy <-
     dplyr::bind_cols(
       broom::tidy(x, conf.int = FALSE),
-      broom::confint_tidy(x, func = stats::confint.default, conf.level = conf.level)
+      # calculate the confidence intervals, and save them in a tibble
+      stats::confint.default(x) \%>\% tibble::as_tibble() \%>\% rlang::set_names(c("conf.low", "conf.high"))
     )
   # exponentiating, if requested
   if (exponentiate == TRUE)
     tidy <- dplyr::mutate_at(vars(estimate, conf.low, conf.high), exp)
+  tidy
 }
 
 lm(age ~ grade + response, trial) \%>\%

--- a/tests/testthat/test-inline_text.R
+++ b/tests/testthat/test-inline_text.R
@@ -81,6 +81,14 @@ test_that("inline_text.tbl_summary: with by -  expect errors", {
   )
 })
 
+test_that("inline_text.tbl_summary: no errors with empty string selection", {
+  trial %>%
+    select(grade) %>%
+    mutate(grade = ifelse(grade == "I", "", as.character(grade))) %>%
+    tbl_summary() %>%
+    inline_text(variable = grade, level = "III")
+})
+
 
 # inline_text.regression tests --------------
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
When there is a level of a variable that is an empty string, we are seeing an error when the variable is then printed using `inline_text.tbl_summary()`.

```r
trial %>%
  select(grade) %>%
  mutate(grade = ifelse(grade == "I", "", as.character(grade))) %>%
  tbl_summary() %>%
  inline_text(variable = grade, level = "II")
```

Also, updated the vetted models example to not use `tidy_confint()` as it is now deprecated.

**If there is an GitHub issue associated with this pull request, please provide link.**

related to #508 (but does not close that issue)
closes #505

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

