### PR TITLE
typo fixes to theme doc + vignette

### DIFF
--- a/R/theme_gtsummary.R
+++ b/R/theme_gtsummary.R
@@ -24,9 +24,10 @@
 #'   - `"flextable"` sets the flextable package as the default print engine
 #'   - `"kable_extra"` sets the kableExtra package as the default print engine
 #'   - `"huxtable"` sets the huxtable package as the default print engine
+#'
 #' Use `reset_gtsummary_theme()` to restore the default settings
 #'
-#' Review the [themes vignette](http://www.danieldsjoberg.com/gtsummary/dev/articles/rmarkdown.html)
+#' Review the [themes vignette](http://www.danieldsjoberg.com/gtsummary/dev/articles/themes.html)
 #' to create your own themes.
 #' @examples
 #' # Setting JAMA theme for gtsummary

--- a/man/theme_gtsummary.Rd
+++ b/man/theme_gtsummary.Rd
@@ -52,11 +52,12 @@ Use the \code{\link[=set_gtsummary_theme]{set_gtsummary_theme()}} function to se
 \item \code{"flextable"} sets the flextable package as the default print engine
 \item \code{"kable_extra"} sets the kableExtra package as the default print engine
 \item \code{"huxtable"} sets the huxtable package as the default print engine
-Use \code{reset_gtsummary_theme()} to restore the default settings
 }
 }
 
-Review the \href{http://www.danieldsjoberg.com/gtsummary/dev/articles/rmarkdown.html}{themes vignette}
+Use \code{reset_gtsummary_theme()} to restore the default settings
+
+Review the \href{http://www.danieldsjoberg.com/gtsummary/dev/articles/themes.html}{themes vignette}
 to create your own themes.
 }
 

--- a/vignettes/themes.Rmd
+++ b/vignettes/themes.Rmd
@@ -21,12 +21,12 @@ df_theme_elements <-
   
 ```
 
-It's possible to set themes it gtsummary.
+It's possible to set themes in {gtsummary}.
 The themes control many aspects of how a table is printed.
 Function defaults can be controlled with themes, as well as other aspects that are not modifiable with function arguments.
 
-The {gtsummary} comes with a few themes, and we welcome user-contributed themes as well!
-Our focus is tables that are ready for publication and encourage themes that assist in that process; for example, the `theme_gtsummary_journal(journal = "jama")` theme sets defaults that align with the published guidelines from the *Journal of the American Medical Association*---*JAMA*.
+The {gtsummary} package comes with a few themes, and we welcome user-contributed themes as well!
+Our focus is tables that are ready for publication and encourage themes that assist in that process; for example, the `theme_gtsummary_journal(journal = "jama")` theme sets defaults that align with the [published guidelines](https://jamanetwork.com/journals/jama/pages/instructions-for-authors#SecTables) from the *Journal of the American Medical Association*---*JAMA*.
 The defaults in {gtsummary} were written to align with the reporting guidelines for *European Urology*, *The Journal of Urology*, *Urology*, and the *British Journal of Urology International*.
 
 ## Setting Themes


### PR DESCRIPTION
Minor typo and wording changes to the new theme_gtsummary documentation and theme vignette. 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch 
- [ ] NEWS.md has been updated under the heading "`# gtsummary (development version)`"?
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] If a new function was added, function included in `pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

