### PR TITLE
`style_ratio()` rounding bug near one #651

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.3.4.9003
+Version: 1.3.4.9004
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Fixed `style_ratio()` bug where there were rounding errors near one (#651)
+
 * There was an environments bug when evaluating the LHS of the formula inputs. In some complex situations, a stored character vector of column names could not properly evaluate (#604)
 
 * Fixed `style_sigfig()` bug where there were rounding errors near thresholds (#638)

--- a/R/style_ratio.R
+++ b/R/style_ratio.R
@@ -24,7 +24,7 @@
 #'   style_ratio()
 style_ratio <- function(x, digits = 2, big.mark = NULL, decimal.mark = NULL, ...) {
   ifelse(
-    abs(x) < 1,
+    round(abs(x), digits = digits - 1) < 1,
     style_sigfig(x, digits = digits, big.mark = big.mark, decimal.mark = decimal.mark, ...),
     style_sigfig(x, digits = digits + 1, big.mark = big.mark, decimal.mark = decimal.mark, ...)
   )

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,14 +10,13 @@
   "codeRepository": "https://github.com/ddsjoberg/gtsummary",
   "issueTracker": "https://github.com/ddsjoberg/gtsummary/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.3.4.9002",
+  "version": "1.3.4.9004",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
-    "version": "3.6.3",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 3.6.3 (2020-02-29)",
+  "runtimePlatform": "R version 4.0.2 (2020-06-22)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -513,7 +512,7 @@
   ],
   "releaseNotes": "https://github.com/ddsjoberg/gtsummary/blob/master/NEWS.md",
   "readme": "https://github.com/ddsjoberg/gtsummary/blob/master/README.md",
-  "fileSize": "2308.1KB",
+  "fileSize": "15344.853KB",
   "contIntegration": "https://codecov.io/gh/ddsjoberg/gtsummary?branch=master",
   "developmentStatus": "https://www.tidyverse.org/lifecycle/#maturing",
   "relatedLink": [
@@ -532,6 +531,8 @@
     "summary-statistics",
     "reproducible-research",
     "reproducibility",
-    "regression-models"
+    "regression-models",
+    "tableone",
+    "table1"
   ]
 }

--- a/tests/testthat/test-style_ratio.R
+++ b/tests/testthat/test-style_ratio.R
@@ -1,0 +1,18 @@
+context("test-style_ratio")
+testthat::skip_on_cran()
+
+test_that("correct rounding near one", {
+
+  expect_equal(
+    style_ratio(c(0.99, 0.999, 1.1)),
+    c("0.99", "1.00", "1.10")
+  )
+
+  expect_false(
+    style_ratio(0.99) == "1.0"
+  )
+
+})
+
+
+


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Prior to update, `style_ratio()` didn't accurately round values near one.
``` r
library(gtsummary)

c(0.99, 1.1) %>%
  style_ratio()
#> [1] "1.0"  "1.10"
```

After the bug fix, it's all good.

``` r
library(gtsummary)

c(0.99, 0.999,  1.1) %>%
  style_ratio()
#> [1] "0.99" "1.00" "1.10"
```

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #651

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN=true)` and begin in a fresh R session without any packages loaded. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] NEWS.md has been updated with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parantheses at the end update (see NEWS.md for examples).
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

