### PR TITLE
Bug fix where fmt_funs from tbl_uvregression were being ignored

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.3.4.9007
+Version: 1.3.4.9008
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,28 +1,36 @@
 # gtsummary (development version)
 
-* Add footnote to overall column
-  - Adding the footnote from the stat columns describing the statistics presented to the overall column (#643)
-  - Moved the nevent column to after the N column when add_nevent() is called on a tbl_regression() object (#439)
-
-* gtsummary themes updates
-  - Add `theme_gtsummary_mean_sd()` theme to report mean and SD by default and use t-tests and ANOVA in `add_p()` (#654)
-  - Added first draft of the NEJM theme
-  - Added the mid-point decimal separator for the Lancet theme
-
-* New function `add_glance_source_note` adds the statistics returned in broom::glance() as a source note on a `tbl_regression` (#434)
-
-* Fixed `style_ratio()` bug where there were rounding errors near one (#651)
-
-* There was an environments bug when evaluating the LHS of the formula inputs. In some complex situations, a stored character vector of column names could not properly evaluate (#604)
-
-* Fixed `style_sigfig()` bug where there were rounding errors near thresholds (#638)
-
-* Exporting the `modify_table_header()` function, which is an advanced-use function used to make modifications to the `.$table_header` object to update printing instructions for the gtsummary object.
+### New Functionality
 
 * New summary type `continuous2` allows adding labelled statistic rows to tables in `tbl_summary()` and `tbl_svysummary()`. You can report several lines of statistics with this type. (#620)
     - The `all_continuous()` function now selects summary types `continuous` and `continuous2` by default.
     - Added `all_continuous2()` function for selecting summary type `continuous2` exclusively.
     - Added `theme_gtsummary_continuous2()` to make `continuous2` the default summary type for all continuous variables.
+
+* New function `add_glance_source_note()` adds the statistics returned in `broom::glance()` as a source note on a `tbl_regression()` (#434)
+
+* Exporting the `modify_table_header()` function, which is an advanced-use function used to make modifications to the `.$table_header` object to update printing instructions for the gtsummary object.
+
+### Bug Fixes
+
+* Bug fix where `estimate_fun=` and `pvalue_fun=` were not being passed to `tbl_regression()` in `tbl_uvregression()`
+
+* There was an environments bug when evaluating the LHS of the formula inputs. In some complex situations, a stored character vector of column names could not properly evaluate (#604)
+
+* Fixed `style_ratio()` bug where there were rounding errors near one (#651)
+
+* Fixed `style_sigfig()` bug where there were rounding errors near thresholds (#638)
+
+* Adding the footnote from the stat columns describing the statistics presented to the overall column (#643)
+
+### Other Updates
+
+* Moved the nevent column to after the N column when add_nevent() is called on a tbl_regression() object (#439)
+
+* gtsummary themes updates
+  - Add `theme_gtsummary_mean_sd()` theme to report mean and SD by default and use t-tests and ANOVA in `add_p()` (#654)
+  - Added first draft of the NEJM theme
+  - Added the mid-point decimal separator for the Lancet theme
 
 # gtsummary 1.3.4
 

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -252,7 +252,9 @@ tbl_uvregression <- function(data, method, y = NULL, x = NULL, method.args = NUL
             label = label,
             include = .y, # only include the covariate of interest in output
             show_single_row = intersect(.y, show_single_row),
-            tidy_fun = tidy_fun
+            tidy_fun = tidy_fun,
+            estimate_fun = estimate_fun,
+            pvalue_fun = pvalue_fun
           )
         )
       )
@@ -272,7 +274,9 @@ tbl_uvregression <- function(data, method, y = NULL, x = NULL, method.args = NUL
                 conf.level = conf.level,
                 include = x,
                 show_single_row = show_single_row,
-                tidy_fun = tidy_fun
+                tidy_fun = tidy_fun,
+                estimate_fun = estimate_fun,
+                pvalue_fun = pvalue_fun
               )
             tbl_uv$table_body$variable <- y
             tbl_uv$table_body$var_type <- NA_character_

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -26,8 +26,8 @@ Lifecycle
 lm
 lme
 logLik
-magrittr
 mL
+NEJM
 nevent
 ng
 ORCID

--- a/tests/testthat/test-add_glance_source_note.R
+++ b/tests/testthat/test-add_glance_source_note.R
@@ -1,0 +1,17 @@
+context("test-add_glance_source_note")
+testthat::skip_on_cran()
+
+
+test_that("add_glance_source_note: no errors/warnings with standard use", {
+
+  expect_error(
+    lm(age ~ marker + grade, trial) %>%
+      tbl_regression() %>%
+      add_glance_source_note(
+        label = list(df  ~ "Degrees of Freedom", sigma ~ "\U03C3"),
+        fmt_fun = df ~ style_number,
+        include = c(r.squared, AIC, sigma, df)
+      ),
+    NA
+  )
+})

--- a/tests/testthat/test-tbl_uvregression.R
+++ b/tests/testthat/test-tbl_uvregression.R
@@ -254,3 +254,19 @@ test_that("tbl_uvregression creates errors with bad inputs", {
     NULL
   )
 })
+
+
+test_that("tbl_uvregression estimate_fun and pvalue_fun respected", {
+  tbl_fmt <- tbl_uvregression(
+    data = lung %>% select(age, inst),
+    method = lm,
+    y = age,
+    pvalue_fun = ~style_pvalue(.x, digits = 3),
+    estimate_fun = ~style_number(.x, digits = 3)
+  )
+
+  expect_equivalent(
+    tbl_fmt %>% as_tibble(col_labels = FALSE) %>% purrr::map_chr(I),
+    c("inst", "227", "0.001", "-0.143, 0.144", "0.993")
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
The arguments `estimate_fun` and `pvalue_fun` were being ignored in `tbl_uvregression()` due to a bug where they were not being passed to `tbl_uvregression()`

**If there is an GitHub issue associated with this pull request, please provide link.**


--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [x] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [x] If a new function was added, function included in `_pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN=true)` and begin in a fresh R session without any packages loaded. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] NEWS.md has been updated with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parantheses at the end update (see NEWS.md for examples).
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

