### PR TITLE
Continuous2 theme bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.3.5.9002
+Version: 1.3.5.9003
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Bug fix when a default statistic is set using themes for `"continuous2"` variables that has length larger than one
+
 * Added function `modify_table_body()` allowing users to more easily make changes to gtsummary tables
 
 * The tidying and preparation of `tbl_regression()` tables are now being performed by the new package {broom.helpers} (#636, #607)

--- a/R/utils-tbl_summary.R
+++ b/R/utils-tbl_summary.R
@@ -110,19 +110,19 @@ assign_stat_display <- function(variable, summary_type, stat_display) {
   stat_display <-
     map2(
       variable, summary_type,
-      ~ case_when(
-        .y == "continuous" ~
-          stat_display[[.x]] %||%
-          get_theme_element("tbl_summary-str:continuous_stat") %||%
-          "{median} ({p25}, {p75})",
-        .y == "continuous2" ~
-          stat_display[[.x]] %||%
-          get_theme_element("tbl_summary-str:continuous_stat") %||%
-          "{median} ({p25}, {p75})",
-        .y %in% c("categorical", "dichotomous") ~
-          stat_display[[.x]] %||%
-          get_theme_element("tbl_summary-str:categorical_stat") %||%
-          "{n} ({p}%)"
+      ~switch(.y,
+              "continuous" = stat_display[[.x]] %||%
+                get_theme_element("tbl_summary-str:continuous_stat") %||%
+                "{median} ({p25}, {p75})",
+              "continuous2" = stat_display[[.x]] %||%
+                get_theme_element("tbl_summary-str:continuous_stat") %||%
+                "{median} ({p25}, {p75})",
+              "categorical" = stat_display[[.x]] %||%
+                get_theme_element("tbl_summary-str:categorical_stat") %||%
+                "{n} ({p}%)",
+              "dichotomous" = stat_display[[.x]] %||%
+                get_theme_element("tbl_summary-str:categorical_stat") %||%
+                "{n} ({p}%)"
       )
     )
 

--- a/tests/testthat/test-set_gtsummary_theme.R
+++ b/tests/testthat/test-set_gtsummary_theme.R
@@ -39,4 +39,19 @@ test_that("setting themes", {
   expect_error(
     get_theme_element("not_a_theme_element"),
     "*")
+
+  # setting a continuous2 default stat
+  list(
+    "tbl_summary-str:default_con_type" = "continuous2",
+    "tbl_summary-str:continuous_stat" = c("{median} ({p25} - {p75})", "{mean} ({sd})"),
+    "tbl_summary-str:categorical_stat" = "{n} / {N} ({p}%)"
+  ) %>%
+    set_gtsummary_theme()
+
+  expect_error(tbl_theme <- tbl_summary(trial[c("trt", "age")]), NA)
+  expect_equal(tbl_theme$meta_data$stat_display,
+               list("{n} / {N} ({p}%)", c("{median} ({p25} - {p75})", "{mean} ({sd})")))
+  reset_gtsummary_theme()
 })
+
+


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Bug fix when a default statistic is set using themes for `"continuous2"` variables that has length larger than one

**If there is an GitHub issue associated with this pull request, please provide link.**
First reported here: https://stackoverflow.com/questions/64528291/set-theme-for-categorical-and-continuous-variables-in-gtsummary-package-for-tbl

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN=true)` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] NEWS.md has been updated with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parantheses at the end update (see NEWS.md for examples).
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] When the branch is ready to be merged into master, increment the version number using `usethis::use_version(which = "dev")`, run `codemetar::write_codemeta()`, approve, and merge the PR.

