### PR TITLE
bug fix when a single categorical summary stat is passed for a contin…

### DIFF
--- a/R/utils-tbl_summary.R
+++ b/R/utils-tbl_summary.R
@@ -901,10 +901,12 @@ summarize_continuous <- function(data, variable, by, stat_display, summary_type)
     if (!is.null(by)) {
       df_stats <- tibble(
         by = unique(data[[by]]) %>% sort(),
-        variable = variable
+        variable = variable,
+        stat_display = .env$stat_display
       )
     }
-    else df_stats <- tibble(variable = variable)
+    else df_stats <- tibble(variable = variable,
+                            stat_display = .env$stat_display)
     return(df_stats)
   }
 

--- a/tests/testthat/test-tbl_summary.R
+++ b/tests/testthat/test-tbl_summary.R
@@ -528,3 +528,20 @@ test_that("tbl_summary(digits=) tests with fn inputs", {
   )
 
 })
+
+
+test_that("tbl_summary() continuous vars with cat summary vars only", {
+  expect_error(
+    tbl1 <- trial %>% select(age) %>% tbl_summary(statistic = age ~ "{N_obs}"),
+    NA
+  )
+  expect_equal(tbl1$table_body$stat_0, c("200", "11"))
+
+  expect_error(
+    tbl2 <- trial %>% select(age, trt) %>% tbl_summary(by = trt, statistic = age ~ "{N_obs}"),
+    NA
+  )
+  expect_equal(tbl2$meta_data$df_stats %>% pluck(1, "N_obs"), c(98, 102),
+               check.attributes = FALSE)
+
+})


### PR DESCRIPTION
This code will now run properly:

```r
trial %>% 
  select(age) %>% 
  tbl_summary(statistic = age ~ "{N_obs}")
```


--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update NEWS.md with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parantheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

