### PR TITLE
Bold and italic requests are now ignored for kableExtra output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.4.1.9003
+Version: 1.4.1.9004
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Bold and italic requests are now ignored for kableExtra output. These are carried out via markdown syntax, which is not supported by {kableExtra} (#917)
+
 * Bug fix for `add_p.tbl_cross(pvalue_fun=)`; argument was being ignored.
 
 * Updated `style_pvalue` to format p-values slightly larger than 1 and slightly lower than 0 (due to imprecise numeric storage). (#907)

--- a/R/as_kable_extra.R
+++ b/R/as_kable_extra.R
@@ -100,8 +100,8 @@ table_styling_to_kable_extra_calls <- function(x, ...) {
     table_styling_to_kable_calls(x = x, ...)
 
   # deleting bold and italics settings
-  if(!is.null(kable_extra_calls$tab_style_bold) ||
-     !is.null(kable_extra_calls$tab_style_italic)){
+  if(!rlang::is_empty(kable_extra_calls$tab_style_bold) ||
+     !rlang::is_empty(kable_extra_calls$tab_style_italic)){
     message("gtsummary does not support bold or italics for kableExtra output.")
 
     # kableExtra doesn't support markdown bold/italics

--- a/R/as_kable_extra.R
+++ b/R/as_kable_extra.R
@@ -97,9 +97,18 @@ as_kable_extra <- function(x, include = everything(), return_calls = FALSE,
 table_styling_to_kable_extra_calls <- function(x, ...) {
   # getting kable calls
   kable_extra_calls <-
-    table_styling_to_kable_calls(x = x, ...) %>%
-    # kableExtra doesn't support makrdown bold/italics
-    purrr::list_modify(tab_style_bold = NULL, tab_style_italic = NULL)
+    table_styling_to_kable_calls(x = x, ...)
+
+  # deleting bold and italics settings
+  if(!is.null(kable_extra_calls$tab_style_bold) ||
+     !is.null(kable_extra_calls$tab_style_italic)){
+    message("gtsummary does not support bold or italics for kableExtra output.")
+
+    # kableExtra doesn't support markdown bold/italics
+    kable_extra_calls <-
+      kable_extra_calls %>%
+      purrr::list_modify(tab_style_bold = NULL, tab_style_italic = NULL)
+  }
 
   # add_indent -----------------------------------------------------------------
   df_indent <-

--- a/R/as_kable_extra.R
+++ b/R/as_kable_extra.R
@@ -2,9 +2,8 @@
 #'
 #' Function converts a gtsummary object to a knitr_kable + kableExtra object.
 #' A user can use this function if they wish to add customized formatting
-#' available via [knitr::kable] and {kableExtra}. Note that {gtsummary}
-#' uses the standard markdown `**` to bold headers, and they may need to be
-#' changed manually with kableExtra output.
+#' available via [knitr::kable] and {kableExtra}. Bold
+#' and italic cells are not supported for {kableExtra} output via gtsummary.
 #'
 #' @inheritParams as_kable
 #' @inheritParams as_flex_table

--- a/R/as_kable_extra.R
+++ b/R/as_kable_extra.R
@@ -97,7 +97,10 @@ as_kable_extra <- function(x, include = everything(), return_calls = FALSE,
 
 table_styling_to_kable_extra_calls <- function(x, ...) {
   # getting kable calls
-  kable_extra_calls <- table_styling_to_kable_calls(x = x, ...)
+  kable_extra_calls <-
+    table_styling_to_kable_calls(x = x, ...) %>%
+    # kableExtra doesn't support makrdown bold/italics
+    purrr::list_modify(tab_style_bold = NULL, tab_style_italic = NULL)
 
   # add_indent -----------------------------------------------------------------
   df_indent <-

--- a/man/as_kable_extra.Rd
+++ b/man/as_kable_extra.Rd
@@ -36,9 +36,8 @@ A {kableExtra} object
 \description{
 Function converts a gtsummary object to a knitr_kable + kableExtra object.
 A user can use this function if they wish to add customized formatting
-available via \link[knitr:kable]{knitr::kable} and {kableExtra}. Note that {gtsummary}
-uses the standard markdown \verb{**} to bold headers, and they may need to be
-changed manually with kableExtra output.
+available via \link[knitr:kable]{knitr::kable} and {kableExtra}. Bold
+and italic cells are not supported for {kableExtra} output via gtsummary.
 }
 \examples{
 if (requireNamespace("kableExtra"))

--- a/renv.lock
+++ b/renv.lock
@@ -60,10 +60,10 @@
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.3-3",
+      "Version": "1.3-4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "df57c82e79600601287edfdcef92c2d6"
+      "Hash": "4ed05e9c9726267e4a5872e09c04587c"
     },
     "MatrixModels": {
       "Package": "MatrixModels",
@@ -193,10 +193,10 @@
     },
     "broom": {
       "Package": "broom",
-      "Version": "0.7.6",
+      "Version": "0.7.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "06015476250468fc013c30022118ce3a"
+      "Hash": "2368dde18d8ef1ca933e7e2eea3ece57"
     },
     "broom.helpers": {
       "Package": "broom.helpers",
@@ -569,13 +569,6 @@
       "Repository": "CRAN",
       "Hash": "9ace652bffef34af558eb5d70903ac2f"
     },
-    "here": {
-      "Package": "here",
-      "Version": "1.0.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "24b224366f9c2e7534d2344d10d59211"
-    },
     "highr": {
       "Package": "highr",
       "Version": "0.9",
@@ -729,13 +722,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "e055d75b424a33fdc8904e5f81263789"
-    },
-    "lubridate": {
-      "Package": "lubridate",
-      "Version": "1.7.10",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "1ebfdc8a3cfe8fe19184f5481972b092"
     },
     "magrittr": {
       "Package": "magrittr",

--- a/tests/testthat/test-as_kable_extra.R
+++ b/tests/testthat/test-as_kable_extra.R
@@ -76,3 +76,37 @@ test_that("indent2", {
     NA
   )
 })
+
+
+test_that("kableExtra message",{
+  expect_message(
+    trial %>%
+      tbl_summary(by = 'trt') %>%
+      bold_labels() %>%
+      bold_levels() %>%
+      italicize_labels() %>%
+      italicize_levels() %>%
+      as_kable_extra()
+  )
+})
+
+test_that("kableExtra message italics",{
+  expect_message(
+    trial %>%
+      tbl_summary(by = 'trt') %>%
+      italicize_labels() %>%
+      italicize_levels() %>%
+      as_kable_extra()
+  )
+})
+
+
+test_that("kableExtra message bold",{
+  expect_message(
+    trial %>%
+      tbl_summary(by = 'trt') %>%
+      bold_labels() %>%
+      bold_levels() %>%
+      as_kable_extra()
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
- Bold and italic requests are now ignored for kableExtra output. These are carried out via markdown syntax, which is not supported by {kableExtra} (#917)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #917

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [x] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [x] If a new function was added, function included in `_pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [x] Update NEWS.md with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parantheses at the end update (see `NEWS.md` for examples).
- [x] Increment the version number using `usethis::use_version(which = "dev")` 
- [x] Run `codemetar::write_codemeta()`
- [x] Run `usethis::use_spell_check()` again
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge".

