### PR TITLE
Use markdown by default in huxtable header rows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.4.1.9005
+Version: 1.4.1.9006
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* The `as_hux_table()` function previously stripped markdown old syntax from column headers and spanning headers. The output now uses markdown syntax in the headers by default utilizing `huxtable::set_markdown()` (#885)
+
 * Variables passed in the `tbl_svysummary(by=)` argument will now automatically be added to `include=`. (#925)
 
 * Bold and italic requests are now ignored for kableExtra output. These are carried out via markdown syntax, which is not supported by {kableExtra} (#917)
@@ -10,7 +12,7 @@
 
 * Fix allowing for factor vectors to be passed in `tbl_stack(group_header=)`. (#908)
 
-* Updated arguments y= and x= in `tbl_uvregression()` to allow for non-standard names (#912)
+* Updated arguments `y=` and `x=` in `tbl_uvregression()` to allow for non-standard names (#912)
 
 # gtsummary 1.4.1
 

--- a/R/as_flex_table.R
+++ b/R/as_flex_table.R
@@ -31,7 +31,6 @@
 #' @inheritParams as_tibble.gtsummary
 #' @param strip_md_bold When TRUE, all double asterisk (markdown language for
 #' bold weight) in column labels and spanning headers are removed.
-#' Default is TRUE
 #' @export
 #' @return A {flextable} object
 #' @family gtsummary output types

--- a/R/as_hux_table.R
+++ b/R/as_hux_table.R
@@ -11,12 +11,14 @@
 #'
 #' 1. `huxtable::huxtable()`
 #' 1. `huxtable::insert_row()` to insert header rows
-#' 1. `huxtable::align()` to set column alignment
 #' 1. `huxtable::set_left_padding()` to indent variable levels
 #' 1. `huxtable::add_footnote()` to add table footnotes and source notes
 #' 1. `huxtable::set_bold()` to bold cells
 #' 1. `huxtable::set_italic()` to italicize cells
+#' 1. `huxtable::set_top_border()` add horizontal line (when indicated)
 #' 1. `huxtable::set_na_string()` to use an em-dash for missing numbers
+#' 1. `huxtable::set_markdown()` use markdown for header rows
+#' 1. `huxtable::set_align()` to set column alignment
 #'
 #' Any one of these commands may be omitted using the `include=` argument.
 #'
@@ -35,7 +37,7 @@
 #' @export
 
 as_hux_table <- function(x, include = everything(), return_calls = FALSE,
-                         strip_md_bold = TRUE) {
+                         strip_md_bold = FALSE) {
   assert_package("huxtable", "as_hux_table()")
 
   # running pre-conversion function, if present --------------------------------
@@ -319,6 +321,13 @@ table_styling_to_huxtable_calls <- function(x, ...) {
       )
     )
   )
+
+  # set_markdown ---------------------------------------------------------------
+  header_rows <- switch(any_spanning_header, 1:2) %||% 1L
+  huxtable_calls[["set_markdown"]] <-
+    list(set_markdown = expr(huxtable::set_markdown(row = !!header_rows,
+                                                    col = huxtable::everywhere,
+                                                    value = TRUE)))
 
   # align ----------------------------------------------------------------------
   df_align <-

--- a/man/as_flex_table.Rd
+++ b/man/as_flex_table.Rd
@@ -24,8 +24,7 @@ Default is \code{everything()}.}
 as a list of expressions.}
 
 \item{strip_md_bold}{When TRUE, all double asterisk (markdown language for
-bold weight) in column labels and spanning headers are removed.
-Default is TRUE}
+bold weight) in column labels and spanning headers are removed.}
 }
 \value{
 A {flextable} object

--- a/man/as_hux_table.Rd
+++ b/man/as_hux_table.Rd
@@ -8,7 +8,7 @@ as_hux_table(
   x,
   include = everything(),
   return_calls = FALSE,
-  strip_md_bold = TRUE
+  strip_md_bold = FALSE
 )
 }
 \arguments{
@@ -24,8 +24,7 @@ Default is \code{everything()}.}
 as a list of expressions.}
 
 \item{strip_md_bold}{When TRUE, all double asterisk (markdown language for
-bold weight) in column labels and spanning headers are removed.
-Default is TRUE}
+bold weight) in column labels and spanning headers are removed.}
 }
 \value{
 A {huxtable} object
@@ -43,12 +42,14 @@ it to a huxtable and formats the table with the following huxtable functions:
 \enumerate{
 \item \code{huxtable::huxtable()}
 \item \code{huxtable::insert_row()} to insert header rows
-\item \code{huxtable::align()} to set column alignment
 \item \code{huxtable::set_left_padding()} to indent variable levels
 \item \code{huxtable::add_footnote()} to add table footnotes and source notes
 \item \code{huxtable::set_bold()} to bold cells
 \item \code{huxtable::set_italic()} to italicize cells
+\item \code{huxtable::set_top_border()} add horizontal line (when indicated)
 \item \code{huxtable::set_na_string()} to use an em-dash for missing numbers
+\item \code{huxtable::set_markdown()} use markdown for header rows
+\item \code{huxtable::set_align()} to set column alignment
 }
 
 Any one of these commands may be omitted using the \verb{include=} argument.

--- a/man/as_kable_extra.Rd
+++ b/man/as_kable_extra.Rd
@@ -25,8 +25,7 @@ Default is \code{everything()}.}
 as a list of expressions.}
 
 \item{strip_md_bold}{When TRUE, all double asterisk (markdown language for
-bold weight) in column labels and spanning headers are removed.
-Default is TRUE}
+bold weight) in column labels and spanning headers are removed.}
 
 \item{...}{Additional arguments passed to \link[knitr:kable]{knitr::kable}}
 }

--- a/renv.lock
+++ b/renv.lock
@@ -1052,6 +1052,13 @@
       "Repository": "CRAN",
       "Hash": "8974a907200fc9948d636fe7d85ca9fb"
     },
+    "miniUI": {
+      "Package": "miniUI",
+      "Version": "0.1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fec5f52652d60615fdb3957b3d74324a"
+    },
     "minqa": {
       "Package": "minqa",
       "Version": "1.2.4",
@@ -1583,6 +1590,20 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "f2e17ba09737e2e7e2ec40fc1f9b6e08"
+    },
+    "testthat": {
+      "Package": "testthat",
+      "Version": "3.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3624827fc69a7ef793a67b36edb4db90"
+    },
+    "textshaping": {
+      "Package": "textshaping",
+      "Version": "0.3.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6bb7e974b464fe72f192e51b4dab67f2"
     },
     "tibble": {
       "Package": "tibble",

--- a/renv.lock
+++ b/renv.lock
@@ -60,10 +60,10 @@
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.3-3",
+      "Version": "1.3-4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "df57c82e79600601287edfdcef92c2d6"
+      "Hash": "4ed05e9c9726267e4a5872e09c04587c"
     },
     "MatrixModels": {
       "Package": "MatrixModels",
@@ -221,10 +221,10 @@
     },
     "broom": {
       "Package": "broom",
-      "Version": "0.7.6",
+      "Version": "0.7.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "06015476250468fc013c30022118ce3a"
+      "Hash": "2368dde18d8ef1ca933e7e2eea3ece57"
     },
     "broom.helpers": {
       "Package": "broom.helpers",
@@ -529,10 +529,10 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.3.3",
+      "Version": "3.3.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3eb6477d01eb5bbdc03f7d5f70f2733e"
+      "Hash": "53ed0e82132d7f6ade8428f494d175e1"
     },
     "gh": {
       "Package": "gh",
@@ -596,13 +596,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "9ace652bffef34af558eb5d70903ac2f"
-    },
-    "here": {
-      "Package": "here",
-      "Version": "1.0.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "24b224366f9c2e7534d2344d10d59211"
     },
     "highr": {
       "Package": "highr",
@@ -758,13 +751,6 @@
       "Repository": "CRAN",
       "Hash": "e055d75b424a33fdc8904e5f81263789"
     },
-    "lubridate": {
-      "Package": "lubridate",
-      "Version": "1.7.10",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "1ebfdc8a3cfe8fe19184f5481972b092"
-    },
     "magrittr": {
       "Package": "magrittr",
       "Version": "2.0.1",
@@ -820,13 +806,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "26fa77e707223e1ce042b2b5d09993dc"
-    },
-    "miniUI": {
-      "Package": "miniUI",
-      "Version": "0.1.1.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "fec5f52652d60615fdb3957b3d74324a"
     },
     "minqa": {
       "Package": "minqa",
@@ -893,10 +872,10 @@
     },
     "openxlsx": {
       "Package": "openxlsx",
-      "Version": "4.2.3",
+      "Version": "4.2.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "2253a430965e222d11a2f9277cd34c2e"
+      "Hash": "f1b1ca1254ccb485dccc9c0dc65a2c36"
     },
     "parameters": {
       "Package": "parameters",
@@ -1110,10 +1089,10 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.8",
+      "Version": "2.9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f518ba47713f92d0d603eec7c6888faf"
+      "Hash": "912c09266d5470516df4df7a303cde92"
     },
     "roxygen2": {
       "Package": "roxygen2",
@@ -1264,10 +1243,10 @@
     },
     "testthat": {
       "Package": "testthat",
-      "Version": "3.0.2",
+      "Version": "3.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "495e0434d9305716b6a87031570ce109"
+      "Hash": "3624827fc69a7ef793a67b36edb4db90"
     },
     "tibble": {
       "Package": "tibble",
@@ -1376,10 +1355,10 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.23",
+      "Version": "0.24",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "791a57f43c887111490851dcd166d344"
+      "Hash": "88cdb9779a657ad80ad942245fffba31"
     },
     "xml2": {
       "Package": "xml2",


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* huxtable previously stripped markdown old syntax from column headers and spanning headers. The output now uses markdown syntax in the headers by default using `huxtable::set_markdown()` (#885)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #885

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update NEWS.md with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parantheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

