### PR TITLE
Fix in svy Wald test

### DIFF
--- a/R/utils-add_p_tests.R
+++ b/R/utils-add_p_tests.R
@@ -504,7 +504,8 @@ add_p_test_svy.wald.test <- function(data, variable, by, ...) {
     {
       suppressMessages(broom::tidy(.))
     } %>%
-    mutate(method = "Wald test of independence for complex survey samples")
+    mutate(method = "Wald test of independence for complex survey samples") %>%
+    dplyr::mutate(dplyr::across(where(is.matrix), c))
 }
 
 add_p_test_svy.adj.wald.test <- function(data, variable, by, ...) {
@@ -515,7 +516,8 @@ add_p_test_svy.adj.wald.test <- function(data, variable, by, ...) {
     } %>%
     dplyr::mutate_at(vars(.data$statistic, .data$p.value), as.numeric) %>%
     # default saves these cols as a matrix
-    mutate(method = "adjusted Wald test of independence for complex survey samples")
+    mutate(method = "adjusted Wald test of independence for complex survey samples") %>%
+    dplyr::mutate(dplyr::across(where(is.matrix), c))
 }
 
 add_p_test_svy.lincom.test <- function(data, variable, by, ...) {

--- a/tests/testthat/test-add_p.tbl_svysummary.R
+++ b/tests/testthat/test-add_p.tbl_svysummary.R
@@ -161,6 +161,8 @@ test_that("add_p works well", {
     NA
   )
 
+  expect_error(as_flex_table(tbl2), NA)
+
   expect_equal(
     dplyr::filter(tbl2$meta_data, variable == "age")$p.value,
     survey::svyranktest(age ~ response, strial, test = "vanderWaerden")$p.value %>% rlang::set_names(NULL)


### PR DESCRIPTION
**What changes are proposed in this pull request?**

* Fix in `add_p.tbl_svysummary()` when Wald tests were converted to flextable. The survey tidier saved the column as a matrix-column instead of a vector, which was incompatible with flextable output. (#1153)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1153

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

