### PR TITLE
Added default formatting function for unweighted proportions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.5.2.9012
+Version: 1.5.2.9013
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Added `style_percent()` as the default formatting function for unweighted proportions. (#1181)
+
 * The global options previously available have now been soft deprecated. All documentation of the global options was removed in v1.3.1. (#1085)
 
 * The `as_flextable()` function has been upgraded from a soft to a hard deprecation; use `as_flex_table()` instead.

--- a/R/utils-tbl_summary.R
+++ b/R/utils-tbl_summary.R
@@ -921,7 +921,7 @@ adding_formatting_as_attr <- function(df_stats, data, variable, summary_type,
         ~ switch(is.numeric(.x) & .y %in% percent_stats,
           purrr::partial(style_number, digits = !!.x, scale = 100)
         ) %||%
-          switch(is.numeric(.x) & summary_type %in% c("categorical", "dichotomous") & .y %in% "p",
+          switch(is.numeric(.x) & summary_type %in% c("categorical", "dichotomous") & .y %in% c("p", "p_unweighted"),
             purrr::partial(style_number, digits = !!.x, scale = 100)
           ) %||%
           # all other stats are not scaled

--- a/R/utils-tbl_summary.R
+++ b/R/utils-tbl_summary.R
@@ -968,7 +968,7 @@ adding_formatting_as_attr <- function(df_stats, data, variable, summary_type,
         }
 
         # if the variable is categorical and a percent, use `style_percent`
-        else if (summary_type %in% c("categorical", "dichotomous") & colname %in% "p") {
+        else if (summary_type %in% c("categorical", "dichotomous") & colname %in% c("p", "p_unweighted")) {
           attr(column, "fmt_fun") <- percent_fun
         }
 

--- a/tests/testthat/test-tbl_svysummary.R
+++ b/tests/testthat/test-tbl_svysummary.R
@@ -279,9 +279,9 @@ test_that("tbl_svysummary-all_categorical() use with `type=`", {
   expect_true(
     !"dichotomous" %in%
       (survey::svydesign(data = trial, ids = ~1, weights = ~1) %>%
-        tbl_svysummary(type = all_dichotomous() ~ "categorical") %>%
-        purrr::pluck("meta_data") %>%
-        dplyr::pull(summary_type))
+         tbl_svysummary(type = all_dichotomous() ~ "categorical") %>%
+         purrr::pluck("meta_data") %>%
+         dplyr::pull(summary_type))
   )
 })
 
@@ -537,5 +537,37 @@ test_that("tbl_svysummary() works with date and date/time", {
   expect_error(
     tbl2 <- df_date %>% tbl_svysummary(by = group),
     NA
+  )
+
+
+  # checking that formatting the unweighted proportion works
+  data(api, package = "survey")
+  dstrat <-
+    survey::svydesign(id = ~1, strata = ~stype,
+                      weights = ~pw, data = apistrat, fpc = ~fpc,
+                      variables = apistrat[, c("pcttest", "growth", "awards")])
+  expect_equal(
+    tbl_svysummary(
+      data = dstrat,
+      include = awards,
+      type = awards ~ "categorical",
+      statistic = all_categorical() ~ "{p_unweighted}%",
+      digits = all_categorical() ~ 2
+    ) %>%
+      as_tibble(col_labels = FALSE) %>%
+      dplyr::pull(),
+    c(NA, "43.50%", "56.50%")
+  )
+
+  expect_equal(
+    tbl_svysummary(
+      data = dstrat,
+      include = awards,
+      type = awards ~ "categorical",
+      statistic = all_categorical() ~ "{p_unweighted}%"
+    ) %>%
+      as_tibble(col_labels = FALSE) %>%
+      dplyr::pull(),
+    c(NA, "44%", "56%")
   )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**

* Added `style_percent()` as the default formatting function for unweighted proportions. (#1181)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1181 


--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

