### PR TITLE
Improving error messaging in `as_gt()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.5.2.9017
+Version: 1.5.2.9018
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@
   
 ### Other Updates
 
+* Improved error messaging the functions `as_gt()`, `as_kable()`, `as_flex_table()`, `as_hux_table()` when an object that is not class 'gtsummary' is passed. (#1188)
+
 * New function `as_hux_xlsx()` added to export a formatted {gtsummary} table directly to Excel.
 * Deprecated the `as_huxtable(strip_md_bold=)`  as {huxtable} now recognizes the markdown syntax and there is no reason to remove the markdown syntax.
 * Added `huxtable::set_header_rows()` to the `as_hux_table()` stack.

--- a/R/add_difference.R
+++ b/R/add_difference.R
@@ -65,9 +65,8 @@ add_difference <- function(x, test = NULL, group = NULL,
                            pvalue_fun = NULL, estimate_fun = NULL) {
   # checking inputs ------------------------------------------------------------
   updated_call_list <- c(x$call_list, list(add_difference = match.call()))
-  if (!inherits(x, c("tbl_summary", "tbl_svysummary"))) {
-    stop("`x=` must be class 'tbl_summary' or 'tbl_svysummary'", call. = FALSE)
-  }
+  .assert_class(x, c("tbl_sudmmary", "tbl_svysummary"))
+
   if (is.null(x$by) || nrow(x$df_by) != 2) {
     stop("'tbl_summary'/'tbl_svysummary' object must have a `by=` value with exactly two levels", call. = FALSE)
   }

--- a/R/add_difference.R
+++ b/R/add_difference.R
@@ -65,7 +65,7 @@ add_difference <- function(x, test = NULL, group = NULL,
                            pvalue_fun = NULL, estimate_fun = NULL) {
   # checking inputs ------------------------------------------------------------
   updated_call_list <- c(x$call_list, list(add_difference = match.call()))
-  .assert_class(x, c("tbl_sudmmary", "tbl_svysummary"))
+  .assert_class(x, c("tbl_summary", "tbl_svysummary"))
 
   if (is.null(x$by) || nrow(x$df_by) != 2) {
     stop("'tbl_summary'/'tbl_svysummary' object must have a `by=` value with exactly two levels", call. = FALSE)

--- a/R/add_glance.R
+++ b/R/add_glance.R
@@ -85,6 +85,7 @@ NULL
 add_glance_table <- function(x, include = everything(), label = NULL,
                              fmt_fun = NULL, glance_fun = NULL) {
   updated_call_list <- c(x$call_list, list(add_glance_table = match.call()))
+  .assert_class(x, c("tbl_regression"))
 
   # default glance() function --------------------------------------------------
   glance_fun <- glance_fun %||% .default_glance_fun(x)
@@ -142,6 +143,7 @@ add_glance_source_note <- function(x, include = everything(), label = NULL,
                                    text_interpret = c("md", "html"),
                                    sep1 = " = ", sep2 = "; ") {
   updated_call_list <- c(x$call_list, list(add_glance_source_note = match.call()))
+  .assert_class(x, c("tbl_regression"))
 
   # default glance() function --------------------------------------------------
   glance_fun <- glance_fun %||% .default_glance_fun(x)

--- a/R/add_q.R
+++ b/R/add_q.R
@@ -52,9 +52,7 @@ add_q <- function(x, method = "fdr", pvalue_fun = NULL, quiet = NULL) {
 
   # checking inputs ------------------------------------------------------------
   # checking class of x
-  if (!inherits(x, "gtsummary")) {
-    stop("`x=` must be a gtsummary obejct.", call. = FALSE)
-  }
+  .assert_class(x, "gtsummary")
 
   # checking input table has a p.value column
   if (!"p.value" %in% names(x$table_body)) {

--- a/R/add_significance_stars.R
+++ b/R/add_significance_stars.R
@@ -76,9 +76,8 @@ add_significance_stars <- function(x, pattern = "{estimate}{stars}",
                                    thresholds = c(0.001, 0.01, 0.05),
                                    hide_ci = TRUE, hide_p = TRUE, hide_se = FALSE) {
   # checking inputs ------------------------------------------------------------
-  if (!inherits(x, "tbl_regression") && !inherits(x, "tbl_uvregression")) {
-    abort("x=` must be a 'tbl_regression' or 'tbl_uvregression' object.")
-  }
+  .assert_class(x, c("tbl_regression", "tbl_uvregression"))
+
   thresholds <- sort(thresholds, decreasing = TRUE) %>% unique()
   if (any(!dplyr::between(thresholds, 0L, 1L))) {
     abort("All thresholds must be between 0 and 1.")

--- a/R/add_stat.R
+++ b/R/add_stat.R
@@ -131,11 +131,7 @@
 add_stat <- function(x, fns, location = NULL, ...) {
   updated_call_list <- c(x$call_list, list(add_stat = match.call()))
   # checking inputs ------------------------------------------------------------
-  if (!inherits(x, c("tbl_summary", "tbl_svysummary", "tbl_continuous"))) {
-    paste("Argument `x=` must be of class 'tbl_summary', 'tbl_svysummary',",
-          "or 'tbl_continuous'") %>%
-      abort()
-  }
+  .assert_class(x, c("tbl_summary", "tbl_svysummary", "tbl_continuous"))
 
   # deprecated arguments -------------------------------------------------------
   dots <- rlang::dots_list(...)

--- a/R/add_stat_label.R
+++ b/R/add_stat_label.R
@@ -87,9 +87,7 @@
 add_stat_label <- function(x, location = NULL, label = NULL) {
   updated_call_list <- c(x$call_list, list(add_stat_label = match.call()))
   # checking inputs ------------------------------------------------------------
-  if (!(inherits(x, "tbl_summary") | inherits(x, "tbl_svysummary"))) {
-    stop("`x=` must be class `tbl_summary` or `tbl_svysummary`", call. = FALSE)
-  }
+  .assert_class(x, c("tbl_summary", "tbl_svysummary"))
 
   # if `add_stat_label()` already run, return unmodified -----------------------
   if ("add_stat_label" %in% names(x$call_list)) {

--- a/R/add_vif.R
+++ b/R/add_vif.R
@@ -37,9 +37,8 @@
 add_vif <- function(x, statistic = NULL, estimate_fun = NULL) {
   updated_call_list <- c(x$call_list, list(add_vif = match.call()))
   # checking inputs ------------------------------------------------------------
-  if (!inherits(x, "tbl_regression")) {
-    stop("`x=` must be class 'tbl_regression'")
-  }
+  .assert_class(x, "tbl_regression")
+
   assert_package("car", "add_vif()")
   estimate_fun <- estimate_fun %||% style_sigfig %>% gts_mapper("add_vif(estimate_fun=)")
 

--- a/R/as_flex_table.R
+++ b/R/as_flex_table.R
@@ -48,6 +48,7 @@
 #' \if{html}{\figure{as_flex_table_ex1.png}{options: width=60\%}}
 as_flex_table <- function(x, include = everything(), return_calls = FALSE,
                           strip_md_bold = TRUE) {
+  .assert_class(x, "gtsummary")
   # checking flextable installation --------------------------------------------
   assert_package("flextable", "as_flex_table()")
 

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -37,6 +37,7 @@
 
 as_gt <- function(x, include = everything(), return_calls = FALSE, ...,
                   exclude = NULL) {
+  .assert_class(x, "gtsummary")
   # making list of commands to include -----------------------------------------
   if (!rlang::quo_is_null(rlang::enquo(exclude))) {
     lifecycle::deprecate_stop(

--- a/R/as_hux_table.R
+++ b/R/as_hux_table.R
@@ -31,6 +31,7 @@ NULL
 #' @rdname as_hux_table
 as_hux_table <- function(x, include = everything(), return_calls = FALSE,
                          strip_md_bold = FALSE) {
+  .assert_class(x, "gtsummary")
   assert_package("huxtable", "as_hux_table()")
   if (!isFALSE(strip_md_bold)) {
     lifecycle::deprecate_warn(
@@ -81,6 +82,7 @@ as_hux_table <- function(x, include = everything(), return_calls = FALSE,
 #' @export
 #' @rdname as_hux_table
 as_hux_xlsx <- function(x, file, include = everything(), bold_header_rows = TRUE) {
+  .assert_class(x, "gtsummary")
   assert_package("openxlsx", fn = "as_hux_xlsx()")
 
   # save list of expressions to run --------------------------------------------

--- a/R/as_kable.R
+++ b/R/as_kable.R
@@ -26,6 +26,7 @@
 #'   as_kable()
 as_kable <- function(x, ..., include = everything(), return_calls = FALSE,
                      exclude = NULL) {
+  .assert_class(x, "gtsummary")
   # DEPRECATION notes ----------------------------------------------------------
   if (!rlang::quo_is_null(rlang::enquo(exclude))) {
     lifecycle::deprecate_stop(

--- a/R/as_kable_extra.R
+++ b/R/as_kable_extra.R
@@ -114,6 +114,7 @@ as_kable_extra <- function(x,
                            addtl_fmt = TRUE,
                            return_calls = FALSE) {
   # must have kableExtra package installed to use this function ----------------
+  .assert_class(x, "gtsummary")
   assert_package("kableExtra", "as_kable_extra()")
 
   # running pre-conversion function, if present --------------------------------

--- a/R/bold_italicise_labels_levels.R
+++ b/R/bold_italicise_labels_levels.R
@@ -26,9 +26,7 @@ NULL
 bold_labels <- function(x) {
   updated_call_list <- c(x$call_list, list(bold_labels = match.call()))
   # input checks ---------------------------------------------------------------
-  if (!inherits(x, "gtsummary")) {
-    stop("Class of 'x' must be 'gtsummary'", call. = FALSE)
-  }
+  .assert_class(x, "gtsummary")
 
   # bold labels ----------------------------------------------------------------
   x <-
@@ -49,9 +47,7 @@ bold_labels <- function(x) {
 bold_levels <- function(x) {
   updated_call_list <- c(x$call_list, list(bold_levels = match.call()))
   # input checks ---------------------------------------------------------------
-  if (!inherits(x, "gtsummary")) {
-    stop("Class of 'x' must be 'gtsummary'", call. = FALSE)
-  }
+  .assert_class(x, "gtsummary")
 
   # bold levels ----------------------------------------------------------------
   x <-
@@ -73,9 +69,7 @@ bold_levels <- function(x) {
 italicize_labels <- function(x) {
   updated_call_list <- c(x$call_list, list(italicize_labels = match.call()))
   # input checks ---------------------------------------------------------------
-  if (!inherits(x, "gtsummary")) {
-    stop("Class of 'x' must be 'gtsummary'", call. = FALSE)
-  }
+  .assert_class(x, "gtsummary")
 
   # italicize labels -----------------------------------------------------------
   x <-
@@ -97,9 +91,7 @@ italicize_labels <- function(x) {
 italicize_levels <- function(x) {
   updated_call_list <- c(x$call_list, list(italicize_levels = match.call()))
   # input checks ---------------------------------------------------------------
-  if (!inherits(x, "gtsummary")) {
-    stop("Class of 'x' must be 'gtsummary'", call. = FALSE)
-  }
+  .assert_class(x, "gtsummary")
 
   # italicize levels -----------------------------------------------------------
   x <-

--- a/R/bold_p.R
+++ b/R/bold_p.R
@@ -36,10 +36,7 @@
 bold_p <- function(x, t = 0.05, q = FALSE) {
   updated_call_list <- c(x$call_list, list(bold_p = match.call()))
   # checking inputs ------------------------------------------------------------
-  # checking class of x
-  if (!inherits(x, "gtsummary")) {
-    stop("`x=` must be a gtsummary object.", call. = FALSE)
-  }
+  .assert_class(x, "gtsummary")
 
   # checking input table has a p.value column
   if (q == FALSE && !"p.value" %in% names(x$table_body)) {

--- a/R/combine_terms.R
+++ b/R/combine_terms.R
@@ -45,6 +45,8 @@
 combine_terms <- function(x, formula_update, label = NULL, quiet = NULL, ...) {
   assert_package("survival", "combine_terms()") # required for survreg() models
   updated_call_list <- c(x$call_list, list(combine_terms = match.call()))
+  .assert_class(x, "tbl_regression")
+
   # setting defaults -----------------------------------------------------------
   quiet <- quiet %||% get_theme_element("pkgwide-lgl:quiet") %||% FALSE
 

--- a/R/modify.R
+++ b/R/modify.R
@@ -107,6 +107,7 @@ NULL
 modify_header <- function(x, update = NULL, ..., text_interpret = c("md", "html"),
                           quiet = NULL, stat_by = NULL) {
   updated_call_list <- c(x$call_list, list(modify_header = match.call()))
+  .assert_class(x, "gtsummary")
   # setting defaults -----------------------------------------------------------
   quiet <- quiet %||% get_theme_element("pkgwide-lgl:quiet") %||% FALSE
   text_interpret <- match.arg(text_interpret)
@@ -161,9 +162,7 @@ modify_footnote <- function(x, update = NULL, ..., abbreviation = FALSE,
                             text_interpret = c("md", "html"), quiet = NULL) {
   updated_call_list <- c(x$call_list, list(modify_footnote = match.call()))
   # checking inputs ------------------------------------------------------------
-  if (!inherits(x, "gtsummary")) {
-    stop("Argument `x=` must be an object with 'gtsummary' class", call. = FALSE)
-  }
+  .assert_class(x, "gtsummary")
 
   # setting defaults -----------------------------------------------------------
   quiet <- quiet %||% get_theme_element("pkgwide-lgl:quiet") %||% FALSE
@@ -208,9 +207,8 @@ modify_spanning_header <- function(x, update = NULL, ...,
                                    text_interpret = c("md", "html"), quiet = NULL) {
   updated_call_list <- c(x$call_list, list(modify_spanning_header = match.call()))
   # checking inputs ------------------------------------------------------------
-  if (!inherits(x, "gtsummary")) {
-    stop("Argument `x=` must be an object with 'gtsummary' class", call. = FALSE)
-  }
+  .assert_class(x, "gtsummary")
+
   # setting defaults -----------------------------------------------------------
   quiet <- quiet %||% get_theme_element("pkgwide-lgl:quiet") %||% FALSE
 
@@ -247,7 +245,7 @@ modify_spanning_header <- function(x, update = NULL, ...,
 #' @export
 modify_caption <- function(x, caption, text_interpret = c("md", "html")) {
   # checking inputs ------------------------------------------------------------
-  if (!inherits(x, "gtsummary")) abort("`x=` must be class 'gtsummary'.")
+  .assert_class(x, "gtsummary")
   if (!rlang::is_string(caption)) abort("`caption=` must be a string.")
   text_interpret <- match.arg(text_interpret)
   updated_call_list <- c(x$call_list, list(modify_caption = match.call()))
@@ -274,9 +272,7 @@ show_header_names <- function(x = NULL, include_example = TRUE, quiet = NULL) {
   quiet <- quiet %||% get_theme_element("pkgwide-lgl:quiet") %||% FALSE
 
   # checking input -------------------------------------------------------------
-  if (!inherits(x, "gtsummary")) {
-    stop("Pass a 'gtsummary' object in `x=` to print current column names and headers.")
-  }
+  .assert_class(x, "gtsummary")
 
   df_cols <-
     x$table_styling$header %>%

--- a/R/modify_cols_merge.R
+++ b/R/modify_cols_merge.R
@@ -60,7 +60,7 @@
 #' \if{html}{\figure{modify_cols_merge_ex2.png}{options: width=41\%}}
 modify_cols_merge <- function(x, pattern, rows = NULL) {
   # check inputs ---------------------------------------------------------------
-  if (!inherits(x, "gtsummary")) abort("`x=` must be class 'gtsummary'")
+  .assert_class(x, "gtsummary")
   if (!rlang::is_string(pattern)) abort("`pattern=` must be a string.")
   updated_call_list <- c(x$call_list, list(modify_column_hide = match.call()))
 

--- a/R/modify_column_alignment.R
+++ b/R/modify_column_alignment.R
@@ -16,6 +16,7 @@
 #'   modify_column_alignment(columns = everything(), align = "left")
 
 modify_column_alignment <- function(x, columns, align = c("left", "right", "center")) {
+  .assert_class(x, "gtsummary")
   updated_call_list <- c(x$call_list, list(modify_column_hide = match.call()))
   align <- match.arg(align)
 

--- a/R/modify_column_hide.R
+++ b/R/modify_column_hide.R
@@ -25,6 +25,7 @@ NULL
 #' @seealso Review [list, formula, and selector syntax][syntax] used throughout gtsummary
 #' @export
 modify_column_hide <- function(x, columns) {
+  .assert_class(x, "gtsummary")
   updated_call_list <- c(x$call_list, list(modify_column_hide = match.call()))
   x <-
     modify_table_styling(
@@ -40,6 +41,7 @@ modify_column_hide <- function(x, columns) {
 #' @rdname modify_column_hide
 #' @export
 modify_column_unhide <- function(x, columns) {
+  .assert_class(x, "gtsummary")
   updated_call_list <- c(x$call_list, list(modify_column_unhide = match.call()))
   x <-
     modify_table_styling(

--- a/R/modify_fmt_fun.R
+++ b/R/modify_fmt_fun.R
@@ -33,6 +33,8 @@
 
 modify_fmt_fun <- function(x, update, rows = NULL) {
   updated_call_list <- c(x$call_list, list(modify_column_unhide = match.call()))
+  .assert_class(x, "gtsummary")
+
   # converting update arg to a tidyselect list ---------------------------------
   update <-
     .formula_list_to_named_list(

--- a/R/modify_table_body.R
+++ b/R/modify_table_body.R
@@ -49,7 +49,7 @@
 #' @export
 #' @family Advanced modifiers
 modify_table_body <- function(x, fun, ...) {
-  if (!inherits(x, "gtsummary")) stop("`x=` must be class 'gtsummary'", call. = FALSE)
+  .assert_class(x, "gtsummary")
   updated_call_list <- c(x$call_list, list(modify_table_body = match.call()))
 
   # execute function on x$table_body -------------------------------------------

--- a/R/modify_table_styling.R
+++ b/R/modify_table_styling.R
@@ -94,7 +94,8 @@ modify_table_styling <- function(x,
                                  cols_merge_pattern = NULL) {
   updated_call_list <- c(x$call_list, list(modify_table_styling = match.call()))
   # checking inputs ------------------------------------------------------------
-  if (!inherits(x, "gtsummary")) stop("`x=` must be class 'gtsummary'", call. = FALSE)
+  .assert_class(x, "gtsummary")
+
   if (is.null(x$table_styling)) x <- .convert_table_header_to_styling(x)
   text_interpret <- match.arg(text_interpret) %>% {
     paste0("gt::", .)

--- a/R/remove_row_type.R
+++ b/R/remove_row_type.R
@@ -28,7 +28,7 @@ remove_row_type <- function(x, variables = everything(),
                             type = c("header", "reference", "missing")) {
   updated_call_list <- c(x$call_list, list(remove_row_type = match.call()))
   # check inputs ---------------------------------------------------------------
-  if (!inherits(x, "gtsummary")) abort("Argument `x=` must be class 'gtsummary'")
+  .assert_class(x, "gtsummary")
   type <- match.arg(type)
 
   # convert variables input to character variable names ------------------------

--- a/R/separate_p_footnotes.R
+++ b/R/separate_p_footnotes.R
@@ -26,7 +26,8 @@
 
 separate_p_footnotes <- function(x) {
   # check inputs ---------------------------------------------------------------
-  if (!inherits(x, "gtsummary") || !"p.value" %in% names(x$table_body))
+  .assert_class(x, "gtsummary")
+  if (!"p.value" %in% names(x$table_body))
     stop("`x=` must be a gtsummary table with a p-value column.", call. = FALSE)
   if (!"stat_test_lbl" %in% names(x$meta_data))
     stop("The `x$meta_data` data frame must have a column called 'stat_test_lbl'.")

--- a/R/sort_filter_p.R
+++ b/R/sort_filter_p.R
@@ -41,9 +41,7 @@ sort_p <- function(x, q = FALSE) {
   updated_call_list <- c(x$call_list, list(sort_p = match.call()))
   # checking inputs ------------------------------------------------------------
   # checking class of x
-  if (!inherits(x, "gtsummary")) {
-    stop("`x=` must be a gtsummary obejct.", call. = FALSE)
-  }
+  .assert_class(x, "gtsummary")
 
   # checking input table has a p.value column
   if (q == FALSE && !"p.value" %in% names(x$table_body)) {
@@ -82,10 +80,7 @@ sort_p <- function(x, q = FALSE) {
 filter_p <- function(x, q = FALSE, t = 0.05) {
   updated_call_list <- c(x$call_list, list(filter_p = match.call()))
   # checking inputs ------------------------------------------------------------
-  # checking class of x
-  if (!inherits(x, "gtsummary")) {
-    stop("`x=` must be a gtsummary obejct.", call. = FALSE)
-  }
+  .assert_class(x, "gtsummary")
 
   # checking input table has a p.value column
   if (q == FALSE && !"p.value" %in% names(x$table_body)) {

--- a/R/utils-misc.R
+++ b/R/utils-misc.R
@@ -75,9 +75,16 @@ gts_mapper <- function(x, context) {
           "{.emph soon} be removed from {.pkg gtsummary}.\nThe functionality",
           "has been migrated to a function argument or a gtsummary theme.",
           "\n{.url https://www.danieldsjoberg.com/gtsummary/articles/themes.html}") %>%
-    cli::cli_alert_danger()
+      cli::cli_alert_danger()
   }
   getOption(x, default = default)
+}
+
+.assert_class <- function(x, class) {
+  if (!inherits(x, class)) {
+    glue("Expecting object of class '{class}'") %>%
+      stop(call. = FALSE)
+  }
 }
 
 

--- a/R/utils-misc.R
+++ b/R/utils-misc.R
@@ -82,7 +82,7 @@ gts_mapper <- function(x, context) {
 
 .assert_class <- function(x, class) {
   if (!inherits(x, class)) {
-    glue("Expecting object of class '{class}'") %>%
+    glue("Expecting object of class {quoted_list(class)}") %>%
       stop(call. = FALSE)
   }
 }

--- a/R/utils-misc.R
+++ b/R/utils-misc.R
@@ -80,9 +80,11 @@ gts_mapper <- function(x, context) {
   getOption(x, default = default)
 }
 
-.assert_class <- function(x, class) {
+.assert_class <- function(x, class, arg_name = "x") {
   if (!inherits(x, class)) {
-    glue("Expecting object of class {quoted_list(class)}") %>%
+    cls_clps <-
+      glue::glue_collapse(shQuote(class, type = "csh"), sep = ", ", last = ", or ")
+    glue("Error in argument '{arg_name}='. Expecting object of class {cls_clps}") %>%
       stop(call. = FALSE)
   }
 }

--- a/tests/testthat/test-as_gt.R
+++ b/tests/testthat/test-as_gt.R
@@ -28,6 +28,7 @@ test_that("tbl_survfit", {
   fit1 <- survfit(Surv(ttdeath, death) ~ trt, trial)
 
   expect_error(tbl_survfit(fit1, times = c(12, 24), label_header = "**{time} Months**") %>% as_gt(), NA)
+  expect_error(as_gt(fit1))
 })
 
 test_that("indent2", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Improved error messaging the functions `as_gt()`, `as_kable()`, `as_flex_table()`, `as_hux_table()` when an object that is not class 'gtsummary' is passed. (#1188)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1188

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

