### PR TITLE
bolding first column (not always label column)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.5.2.9018
+Version: 1.5.2.9019
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@
   
 ### Other Updates
 
+* Functions `bold_labels()`, `bold_levels()`, `italicize_labels()`, and `italicize_levels()` now bold/italicize the first column shown in the table. Previously, the `"label"` column (which is most often the first shown column) was styled.
+
 * Improved error messaging the functions `as_gt()`, `as_kable()`, `as_flex_table()`, `as_hux_table()` when an object that is not class 'gtsummary' is passed. (#1188)
 
 * New function `as_hux_xlsx()` added to export a formatted {gtsummary} table directly to Excel.

--- a/R/bold_italicise_labels_levels.R
+++ b/R/bold_italicise_labels_levels.R
@@ -27,6 +27,10 @@ bold_labels <- function(x) {
   updated_call_list <- c(x$call_list, list(bold_labels = match.call()))
   # input checks ---------------------------------------------------------------
   .assert_class(x, "gtsummary")
+  if (!"row_type" %in% x$table_styling$header$column) {
+    cli::cli_alert_warning("{.code bold_labels()} cannot be used in this context.")
+    return(x)
+  }
 
   # bold labels ----------------------------------------------------------------
   x <-
@@ -48,6 +52,10 @@ bold_levels <- function(x) {
   updated_call_list <- c(x$call_list, list(bold_levels = match.call()))
   # input checks ---------------------------------------------------------------
   .assert_class(x, "gtsummary")
+  if (!"row_type" %in% x$table_styling$header$column) {
+    cli::cli_alert_warning("{.code bold_levels()} cannot be used in this context.")
+    return(x)
+  }
 
   # bold levels ----------------------------------------------------------------
   x <-
@@ -70,6 +78,10 @@ italicize_labels <- function(x) {
   updated_call_list <- c(x$call_list, list(italicize_labels = match.call()))
   # input checks ---------------------------------------------------------------
   .assert_class(x, "gtsummary")
+  if (!"row_type" %in% x$table_styling$header$column) {
+    cli::cli_alert_warning("{.code italicize_labels()} cannot be used in this context.")
+    return(x)
+  }
 
   # italicize labels -----------------------------------------------------------
   x <-
@@ -92,6 +104,10 @@ italicize_levels <- function(x) {
   updated_call_list <- c(x$call_list, list(italicize_levels = match.call()))
   # input checks ---------------------------------------------------------------
   .assert_class(x, "gtsummary")
+  if (!"row_type" %in% x$table_styling$header$column) {
+    cli::cli_alert_warning("{.code italicize_levels()} cannot be used in this context.")
+    return(x)
+  }
 
   # italicize levels -----------------------------------------------------------
   x <-

--- a/R/bold_italicise_labels_levels.R
+++ b/R/bold_italicise_labels_levels.R
@@ -32,7 +32,7 @@ bold_labels <- function(x) {
   x <-
     modify_table_styling(
       x,
-      columns = "label",
+      columns = .first_unhidden_column(x),
       rows = .data$row_type == "label",
       text_format = "bold"
     )
@@ -53,7 +53,7 @@ bold_levels <- function(x) {
   x <-
     modify_table_styling(
       x,
-      columns = "label",
+      columns = .first_unhidden_column(x),
       rows = .data$row_type != "label",
       text_format = "bold"
     )
@@ -75,7 +75,7 @@ italicize_labels <- function(x) {
   x <-
     modify_table_styling(
       x,
-      columns = "label",
+      columns = .first_unhidden_column(x),
       rows = .data$row_type == "label",
       text_format = "italic"
     )
@@ -97,7 +97,7 @@ italicize_levels <- function(x) {
   x <-
     modify_table_styling(
       x,
-      columns = "label",
+      columns = .first_unhidden_column(x),
       rows = .data$row_type != "label",
       text_format = "italic"
     )
@@ -105,4 +105,10 @@ italicize_levels <- function(x) {
   x$call_list <- updated_call_list
 
   x
+}
+
+.first_unhidden_column <- function(x) {
+  x$table_styling$header %>%
+    dplyr::filter(!.data$hide) %>%
+    purrr::pluck("column", 1)
 }


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Functions `bold_labels()`, `bold_levels()`, `italicize_labels()`, and `italicize_levels()` now bold/italicize the first column shown in the table. Previously, the `"label"` column (which is most often the first shown column) was styled.


--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

