### PR TITLE
added new messaging arg to with theme fn

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.6.0.9011
+Version: 1.6.0.9012
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # gtsummary (development version)
 
-* Swapped `gt::fmt_missing()` for `gt::sub_missing()`. (#1257)
+* Added argument `with_gtsummary_theme(msg_ignored_elements=)` argument. Use this argument to message users if any theme elements will be overwritten and therefore ignored inside the `with_gtsummary_theme()` call. (#1266)
+
+* Swapped `gt::fmt_missing()` for `gt::sub_missing()` as the former is now deprecated. (#1257)
 
 * Updates to labels and default formatting functions of unweighted statistics presented in `tbl_svysummary()`. (#1253)
 

--- a/R/tbl_survfit.R
+++ b/R/tbl_survfit.R
@@ -276,7 +276,7 @@ tbl_survfit.data.frame <- function(x, y, include = everything(), ...) {
   if (!inherits(y_surv, "Surv")) {
     paste(
       "Together, the data frame in `x=`, and the survival outcome in `y=`",
-      "must construct `Surv` oject, e.g. `with(trial, Surv(ttdeath, death))`"
+      "must construct `Surv` object, e.g. `with(trial, Surv(ttdeath, death))`"
     ) %>%
       stringr::str_wrap() %>%
       stop(call. = FALSE)

--- a/man/set_gtsummary_theme.Rd
+++ b/man/set_gtsummary_theme.Rd
@@ -14,7 +14,12 @@ reset_gtsummary_theme()
 
 get_gtsummary_theme()
 
-with_gtsummary_theme(x, expr, env = rlang::caller_env())
+with_gtsummary_theme(
+  x,
+  expr,
+  env = rlang::caller_env(),
+  msg_ignored_elements = NULL
+)
 
 check_gtsummary_theme(x)
 }
@@ -27,6 +32,10 @@ check_gtsummary_theme(x)
 \item{expr}{Expression to be evaluated with the theme specified in \verb{x=} loaded}
 
 \item{env}{The environment in which to evaluate \verb{expr=}}
+
+\item{msg_ignored_elements}{Default is NULL with no message printed. Pass a string
+that will be printed with \code{cli::cli_alert_info()}. The \code{"{elements}"}
+object contains vector of theme elements that will be overwritten and ignored.}
 }
 \description{
 \lifecycle{maturing}

--- a/tests/testthat/test-set_gtsummary_theme.R
+++ b/tests/testthat/test-set_gtsummary_theme.R
@@ -224,6 +224,19 @@ test_that("setting themes", {
   expect_message(check_gtsummary_theme(list("not_a_theme" = 5)))
   expect_message(check_gtsummary_theme(list("style_number-arg:decimal.mark" = ".")), "*Looks good*")
 
+  # check the message is printed in with_gtsummary_theme()
+  reset_gtsummary_theme()
+  list("tbl_summary-str:continuous_stat" = "{median}") %>%
+    set_gtsummary_theme()
+
+  expect_message(
+    with_gtsummary_theme(
+      x = list("tbl_summary-str:continuous_stat" = "{mean}"),
+      expr = tbl_summary(trial, include = age) %>% as_kable(),
+      msg_ignored_elements = "Theme element(s) {.val {elements}} is/are utilized internally and were ignored."
+    ),
+    "*utilized internally*"
+  )
 })
 
 reset_gtsummary_theme()

--- a/tests/testthat/test-set_gtsummary_theme.R
+++ b/tests/testthat/test-set_gtsummary_theme.R
@@ -235,7 +235,7 @@ test_that("setting themes", {
       expr = tbl_summary(trial, include = age) %>% as_kable(),
       msg_ignored_elements = "Theme element(s) {.val {elements}} is/are utilized internally and were ignored."
     ),
-    "*utilized internally*"
+    "*continuous_stat*"
   )
 })
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Added argument `with_gtsummary_theme(msg_ignored_elements=)` argument. Use this argument to message users if any theme elements will be overwritten and therefore ignored inside the `with_gtsummary_theme()` call.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1266
closes #1265

``` r
library(gtsummary)

list("tbl_summary-str:continuous_stat" = "{median}") %>%
  set_gtsummary_theme()

with_gtsummary_theme(
  x = list("tbl_summary-str:continuous_stat" = "{mean}"),
  expr = tbl_summary(trial, include = age) %>% as_kable(),
  msg_ignored_elements = "Theme element(s) {.val {elements}} is/are utilized internally and were ignored."
)
#> ℹ Theme element(s) "tbl_summary-str:continuous_stat" is/are utilized internally and were ignored.
```

| **Characteristic** | **N = 200** |
|:-------------------|:-----------:|
| Age                |     47      |
| Unknown            |     11      |

<sup>Created on 2022-06-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

