### PR TITLE
fix when column has a blank header

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result
     Tables
-Version: 1.6.3.9003
+Version: 1.6.3.9004
 Authors@R: 
     c(person(given = "Daniel D.",
              family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Fix for `as_flex_table()` when the header is blank. (#1406)
+
 * Fix in `tbl_summary()` that now allows for column vectors to be named within a data frame. (#1403)
 
 * Now allowing for mixed-class numeric types in `tbl_summary()`, such that `inline_text()` will not throw an error when the pattern argument is specified.

--- a/R/as_flex_table.R
+++ b/R/as_flex_table.R
@@ -448,6 +448,7 @@ table_styling_to_flextable_calls <- function(x, ...) {
             return(.x)
           }
         ) %>%
+        {switch(!rlang::is_empty(.), .) %||% ""} %>%
         {rlang::expr(flextable::compose(part = !!part, i = !!i, j = !!j, value = flextable::as_paragraph(!!!.)))}
     }
   )

--- a/tests/testthat/test-as_flex_table.R
+++ b/tests/testthat/test-as_flex_table.R
@@ -65,6 +65,14 @@ test_that("tbl_merge/tbl_stack", {
   expect_warning(as_flex_table(tbl_merge_ex1), NA)
 })
 
+test_that("tbl_cross", {
+  expect_error(
+    tbl_cross(trial, row = trt, col = response) %>%
+      as_flex_table(),
+    NA
+  )
+})
+
 test_that("indent2", {
   expect_error(
     trial %>%


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fix for `as_flex_table()` when the header is blank. (#1406)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1406

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If an update was made to `tbl_summary()`, was the same change implemented for `tbl_svysummary()`?
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

