### PR TITLE
Updating deprecation message for `modify_*()` functions

### DIFF
--- a/R/add_difference.R
+++ b/R/add_difference.R
@@ -37,7 +37,7 @@ add_difference <- function(x, ...) {
 #'   Default is
 #'   `list(c(all_continuous(), all_categorical(FALSE)) ~ label_style_sigfig(), all_categorical() ~ \(x) paste0(style_sigfig(x, scale = 100), "%"))`
 #' @param conf.level (`numeric`)\cr
-#'  a scalar in `⁠(0, 1`)⁠ indicating the confidence level. Default is 0.95
+#'   a scalar in the interval `(0, 1)` indicating the confidence level. Default is 0.95
 #' @inheritParams  add_p.tbl_summary
 #'
 #' @export

--- a/R/add_difference.tbl_svysummary.R
+++ b/R/add_difference.tbl_svysummary.R
@@ -18,7 +18,7 @@
 #'   Default is
 #'   `list(c(all_continuous(), all_categorical(FALSE)) ~ label_style_sigfig(), all_categorical() ~ \(x) paste0(style_sigfig(x, scale = 100), "%"))`
 #' @param conf.level (`numeric`)\cr
-#'  a scalar in `⁠(0, 1`)⁠ indicating the confidence level. Default is 0.95
+#'   a scalar in the interval `(0, 1)` indicating the confidence level. Default is 0.95
 #' @inheritParams  add_p.tbl_summary
 #'
 #' @export

--- a/R/modify.R
+++ b/R/modify.R
@@ -301,7 +301,7 @@ show_header_names <- function(x = NULL, include_example = TRUE, quiet = NULL) {
 
 .deprecate_modify_update_and_quiet_args <- function(dots, update, quiet, calling_fun) {
   # deprecated arguments
-  if (!missing(update)) {
+  if (!missing(update) || (!is_empty(dots) && is.list(dots[[1]]))) {
     lifecycle::deprecate_warn(
       "2.0.0", glue("gtsummary::{calling_fun}(update=)"),
       details =
@@ -309,7 +309,11 @@ show_header_names <- function(x = NULL, include_example = TRUE, quiet = NULL) {
             Dynamic dots allow for syntax like `{calling_fun}(!!!list(...))`."),
       env = get_cli_abort_call()
     )
-    dots <- c(dots, update)
+
+    if (!is_empty(dots) && is.list(dots[[1]])) dots <- c(dots[-1], dots[[1]]) # styler: off
+    if (!missing(update)) dots <- c(dots, update) # styler: off
+
+    dots
   }
   if (!missing(quiet)) {
     lifecycle::deprecate_warn(

--- a/man/add_difference.tbl_summary.Rd
+++ b/man/add_difference.tbl_summary.Rd
@@ -45,7 +45,7 @@ For example, add an argument for all t-tests, use
 \code{test.args = all_tests("t.test") ~ list(var.equal = TRUE)}.}
 
 \item{conf.level}{(\code{numeric})\cr
-a scalar in \verb{⁠(0, 1})⁠ indicating the confidence level. Default is 0.95}
+a scalar in the interval \verb{(0, 1)} indicating the confidence level. Default is 0.95}
 
 \item{include}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
 Variables to include in output. Default is \code{everything()}.}

--- a/man/add_difference.tbl_svysummary.Rd
+++ b/man/add_difference.tbl_svysummary.Rd
@@ -45,7 +45,7 @@ For example, add an argument for all t-tests, use
 \code{test.args = all_tests("t.test") ~ list(var.equal = TRUE)}.}
 
 \item{conf.level}{(\code{numeric})\cr
-a scalar in \verb{⁠(0, 1})⁠ indicating the confidence level. Default is 0.95}
+a scalar in the interval \verb{(0, 1)} indicating the confidence level. Default is 0.95}
 
 \item{include}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
 Variables to include in output. Default is \code{everything()}.}

--- a/tests/testthat/test-modify_header.R
+++ b/tests/testthat/test-modify_header.R
@@ -3,15 +3,44 @@
 test_that("modify_header(update,quiet) are deprecated", {
   lifecycle::expect_deprecated(
     tbl_summary(trial, include = marker) |>
-      modify_header(update = list(label = "Variable"))
-  )
-  lifecycle::expect_deprecated(
-    tbl_summary(trial, include = marker) |>
       modify_header(list(label = "Variable"))
   )
+
+  # THIS ONE FAILS LOCALLY UNLESS I RUN ALL THE TESTS WITH THE 'Test' BUTTON
+  lifecycle::expect_deprecated(
+    tbl_summary(trial, include = marker) |>
+      modify_header(update = list(label = "Variable"))
+  )
+
   lifecycle::expect_deprecated(
     tbl_summary(trial, include = marker) |>
       modify_header(quiet = FALSE)
+  )
+})
+
+
+test_that("modify_header(update) are deprecated and still work", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+  expect_equal(
+    tbl_summary(trial, include = marker) |>
+      modify_header(list(label = "Variable")) |>
+      getElement("table_styling") |>
+      getElement("header"),
+    tbl_summary(trial, include = marker) |>
+      modify_header(label = "Variable") |>
+      getElement("table_styling") |>
+      getElement("header")
+  )
+
+  expect_equal(
+    tbl_summary(trial, include = marker) |>
+      modify_header(update = list(label = "Variable")) |>
+      getElement("table_styling") |>
+      getElement("header"),
+    tbl_summary(trial, include = marker) |>
+      modify_header(label = "Variable") |>
+      getElement("table_styling") |>
+      getElement("header")
   )
 })
 

--- a/tests/testthat/test-modify_header.R
+++ b/tests/testthat/test-modify_header.R
@@ -7,6 +7,10 @@ test_that("modify_header(update,quiet) are deprecated", {
   )
   lifecycle::expect_deprecated(
     tbl_summary(trial, include = marker) |>
+      modify_header(list(label = "Variable"))
+  )
+  lifecycle::expect_deprecated(
+    tbl_summary(trial, include = marker) |>
       modify_header(quiet = FALSE)
   )
 })

--- a/tests/testthat/test-show_header_names.R
+++ b/tests/testthat/test-show_header_names.R
@@ -1,3 +1,5 @@
+skip_on_os("windows")
+
 test_that("show_header_names() works", {
   expect_snapshot(
     tbl_summary(trial, include = age, by = trt, missing = "no") |>


### PR DESCRIPTION
**What changes are proposed in this pull request?**
We've deprecated the `modify_*(update)` argument. This was previously the first argument and has been moved to the end. So previously, `modify_header(list(label = "Variable"))` was the same as `modify_header( update = list(label = "Variable"))`.

But now that argument is position matched to the dots (`...`), and `list(label = "Variable")` is not how the the dots want the argument passed. The dots want to see `modify_header(label = "Variable")`.

We are updating the deprecation notice to check the value of the first position matched argument to ensure it follows the updated structure.

Thank you @ayogasekaram for flagging!

**If there is an GitHub issue associated with this pull request, please provide link.**


--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

