### PR TITLE
Allow integers in numeric class checks

### DIFF
--- a/R/add_significance_stars.R
+++ b/R/add_significance_stars.R
@@ -82,7 +82,7 @@ add_significance_stars <- function(x,
   # checking inputs ------------------------------------------------------------
   check_not_missing(x)
   check_class(x, "gtsummary")
-  check_class(thresholds, "numeric")
+  check_class(thresholds, c("numeric", "integer"))
   check_range(thresholds, range = c(0, 1), include_bounds = c(TRUE, TRUE))
   check_scalar_logical(hide_ci)
   check_scalar_logical(hide_p)

--- a/R/tbl_survfit.R
+++ b/R/tbl_survfit.R
@@ -194,8 +194,8 @@ tbl_survfit.list <- function(x,
     predicate = \(x) inherits(x, "survfit"),
     error_msg = "The values passed in the {.cls list} from argument {.arg x} must be class {.cls survfit}."
   )
-  check_class(times, "numeric", allow_empty = TRUE)
-  check_class(probs, "numeric", allow_empty = TRUE)
+  check_class(times, c("numeric", "integer"), allow_empty = TRUE)
+  check_class(probs, c("numeric", "integer"), allow_empty = TRUE)
   if (is_empty(times) + is_empty(probs) != 1L) {
     cli::cli_abort(
       "Specify one and only one of arguments {.arg times} and {.arg probs}.",

--- a/R/tbl_survfit.R
+++ b/R/tbl_survfit.R
@@ -110,6 +110,8 @@ tbl_survfit <- function(x, ...) {
 #' @export
 #' @rdname tbl_survfit
 tbl_survfit.survfit <- function(x, ...) {
+  set_cli_abort_call()
+
   tbl_survfit.list(x = list(x), ...)
 }
 

--- a/R/tbl_survfit.R
+++ b/R/tbl_survfit.R
@@ -197,7 +197,7 @@ tbl_survfit.list <- function(x,
     error_msg = "The values passed in the {.cls list} from argument {.arg x} must be class {.cls survfit}."
   )
   check_class(times, c("numeric", "integer"), allow_empty = TRUE)
-  check_class(probs, c("numeric", "integer"), allow_empty = TRUE)
+  check_class(probs, "numeric", allow_empty = TRUE)
   if (is_empty(times) + is_empty(probs) != 1L) {
     cli::cli_abort(
       "Specify one and only one of arguments {.arg times} and {.arg probs}.",

--- a/tests/testthat/test-tbl_survfit.R
+++ b/tests/testthat/test-tbl_survfit.R
@@ -22,7 +22,7 @@ test_that("tbl_survfit(probs) works", {
   )
 })
 
-test_that("tbl_survfit(times) works with integer times values", {
+test_that("tbl_survfit works with integer times values", {
   expect_silent(
     trial |>
       tbl_survfit(

--- a/tests/testthat/test-tbl_survfit.R
+++ b/tests/testthat/test-tbl_survfit.R
@@ -1,6 +1,6 @@
 skip_on_cran()
 
-test_that("tbl_survfit(time) works", {
+test_that("tbl_survfit(times) works", {
   expect_silent(
     trial |>
       tbl_survfit(
@@ -18,6 +18,17 @@ test_that("tbl_survfit(probs) works", {
         include = trt,
         y = "Surv(ttdeath, death)",
         probs = 0.5
+      )
+  )
+})
+
+test_that("tbl_survfit(times) works with integer times values", {
+  expect_silent(
+    trial |>
+      tbl_survfit(
+        include = trt,
+        y = "Surv(ttdeath, death)",
+        times = c(6L, 12L)
       )
   )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**

* When checking that the class of a value is numeric, also allow integers.

Closes #1867 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] Ensure all package dependencies are installed: `renv::install()`
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] Increment the version number using `usethis::use_version(which = "dev")` 
- [x] Run `usethis::use_spell_check()` again
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge".

