### PR TITLE
Correct order when the `tbl_summary(by)` variable has 10+ levels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Correct the order of the columns when the `tbl_summary(by)` variables has ten or more levels: a regression introduced in v2.0.0. (#1877)
+
 # gtsummary 2.0.0
 
 ### New Features

--- a/R/brdg_summary.R
+++ b/R/brdg_summary.R
@@ -258,8 +258,13 @@ pier_summary_categorical <- function(cards,
         )
       }
     ) |>
-    dplyr::bind_rows() |>
-    dplyr::arrange(as.integer(str_remove(!!sym("gts_column"), "^stat_")))
+    dplyr::bind_rows() %>%
+    # this ensures the correct order when there are 10+ groups
+    dplyr::left_join(
+      cards_no_attr |> dplyr::distinct(!!sym("gts_column")),
+      .,
+      by = "gts_column"
+    )
 
   # reshape results for final table --------------------------------------------
   df_result_levels <-
@@ -365,7 +370,13 @@ pier_summary_continuous2 <- function(cards,
         )
       }
     ) |>
-    dplyr::bind_rows()
+    dplyr::bind_rows() %>%
+    # this ensures the correct order when there are 10+ groups
+    dplyr::left_join(
+      cards_no_attr |> dplyr::distinct(!!sym("gts_column")),
+      .,
+      by = "gts_column"
+    )
 
   # reshape results for final table --------------------------------------------
   df_result_levels <-
@@ -451,8 +462,13 @@ pier_summary_continuous <- function(cards,
         )
       }
     ) |>
-    dplyr::bind_rows() |>
-    dplyr::arrange(as.integer(str_remove(!!sym("gts_column"), "^stat_")))
+    dplyr::bind_rows() %>%
+    # this ensures the correct order when there are 10+ groups
+    dplyr::left_join(
+      cards_no_attr |> dplyr::distinct(!!sym("gts_column")),
+      .,
+      by = "gts_column"
+    )
 
   # reshape results for final table --------------------------------------------
   df_results <-

--- a/R/brdg_summary.R
+++ b/R/brdg_summary.R
@@ -258,7 +258,8 @@ pier_summary_categorical <- function(cards,
         )
       }
     ) |>
-    dplyr::bind_rows()
+    dplyr::bind_rows() |>
+    dplyr::arrange(as.integer(str_remove(!!sym("gts_column"), "^stat_")))
 
   # reshape results for final table --------------------------------------------
   df_result_levels <-
@@ -450,7 +451,8 @@ pier_summary_continuous <- function(cards,
         )
       }
     ) |>
-    dplyr::bind_rows()
+    dplyr::bind_rows() |>
+    dplyr::arrange(as.integer(str_remove(!!sym("gts_column"), "^stat_")))
 
   # reshape results for final table --------------------------------------------
   df_results <-

--- a/tests/testthat/test-tbl_summary.R
+++ b/tests/testthat/test-tbl_summary.R
@@ -20,12 +20,43 @@ test_that("tbl_summary(by)", {
   expect_snapshot(tbl_summary(data = trial, by = trt) |> as.data.frame())
   expect_snapshot(tbl_summary(data = mtcars, by = am) |> as.data.frame())
   expect_snapshot(tbl_summary(data = iris, by = Species) |> as.data.frame())
+
+  # ensure the columns appear in the correct order with 10+ by levels
+  expect_equal(
+    tbl_summary(data.frame(x = 1, y = LETTERS[1:10]), by = y, type = x ~ "continuous") |>
+      getElement("table_body") |>
+      select(all_stat_cols()) |>
+      names(),
+    paste0("stat_", 1:10)
+  )
+  expect_equal(
+    tbl_summary(data.frame(x = 1, y = LETTERS[1:10]), by = y, type = x ~ "continuous2") |>
+      getElement("table_body") |>
+      select(all_stat_cols()) |>
+      names(),
+    paste0("stat_", 1:10)
+  )
+  expect_equal(
+    tbl_summary(data.frame(x = 1, y = LETTERS[1:10]), by = y, type = x ~ "categorical") |>
+      getElement("table_body") |>
+      select(all_stat_cols()) |>
+      names(),
+    paste0("stat_", 1:10)
+  )
+  expect_equal(
+    tbl_summary(data.frame(x = 1, y = LETTERS[1:10]), by = y, type = x ~ "dichotomous", value = x ~ 1) |>
+      getElement("table_body") |>
+      select(all_stat_cols()) |>
+      names(),
+    paste0("stat_", 1:10)
+  )
 })
 
 test_that("tbl_summary(by) errors properly", {
   # errors thrown when bad data argument passed
   expect_snapshot(error = TRUE, tbl_summary(mtcars, by = c("mpg", "am")))
 })
+
 
 # tbl_summary(label) -----------------------------------------------------------
 test_that("tbl_summary(label)", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Correct the order of the columns when the `tbl_summary(by)` variables has ten or more levels. (#1877)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1877

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] Ensure all package dependencies are installed: `renv::install()`
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

