### PR TITLE
Restore functionality in `inline_text.tbl_summary(column)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Restore functionality of `inline_text.tbl_summary(column)` argument to specify a by level when the by variable is a factor: a regression introduced in v2.0.0. (#1883)
+
 # gtsummary 2.0.0
 
 ### New Features

--- a/R/inline_text.tbl_summary.R
+++ b/R/inline_text.tbl_summary.R
@@ -62,7 +62,7 @@ inline_text.tbl_summary <- function(x,
       dplyr::filter(.data$group1 %in% .env$x$inputs$by) |>
       dplyr::select("gts_column", "group1_level") |>
       unique() |>
-      dplyr::mutate(group1_level = unlist(.data$group1_level)) |>
+      dplyr::mutate(group1_level = unlist(.data$group1_level) |> as.character()) |>
       deframe() |>
       as.list()
 

--- a/tests/testthat/test-inline_text.R
+++ b/tests/testthat/test-inline_text.R
@@ -89,6 +89,15 @@ test_that("inline_text.tbl_summary", {
       inline_text(variable = grade, level = "I", column = "stat_1"),
     "35 (36%)"
   )
+
+  # ensure inline_text(column) argument works with factor levels
+  expect_equal(
+    trial |>
+      dplyr::mutate(trt = factor(trt)) |>
+      tbl_summary(by = trt, include = age) |>
+      inline_text(variable = "age", column = "Drug A", pattern = "{median}"),
+    "46"
+  )
 })
 
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Restore functionality of `inline_text.tbl_summary(column)` argument to specify a by level when the by variable is a factor: a regression introduced in v2.0.0. (#1883)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1883

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

