### PR TITLE
 Fix in `tbl_uvregression()` for the `formula` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.0.9002
+Version: 2.0.0.9003
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.0.9000
+Version: 2.0.0.9002
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Fix in `tbl_uvregression()` for the `formula` argument when it includes a hard-coded column name, e.g. `formula='{y} ~ {x} + grade'`. The hard-coded variable name is now removed from the `include` argument. This was a regression introduced in the v2.0.0 release. (#1886)
+
 # gtsummary 2.0.0
 
 ### New Features

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -165,7 +165,11 @@ tbl_uvregression.data.frame <- function(data,
   # styler: off
   # remove any variables specified in arguments `x`/`y` from include
   include <- include |>
-    setdiff(tryCatch(stats::reformulate(c(x, y)) |> all.vars(), error = \(e) character()))
+    # remove the x/y variable from the list
+    setdiff(tryCatch(stats::reformulate(c(x, y)) |> all.vars(), error = \(e) character(0L))) |>
+    # remove any other columns listed in the formula
+    setdiff(tryCatch(glue::glue_data(.x = list(y = 1, x = 1), formula) |> stats::as.formula() |> all.vars(), error = \(e) character(0L)))
+
   # remove any variables not in include
   show_single_row <-
     if (is_empty(x)) intersect(show_single_row, include)

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -169,6 +169,9 @@ tbl_uvregression.data.frame <- function(data,
     setdiff(tryCatch(stats::reformulate(c(x, y)) |> all.vars(), error = \(e) character(0L))) |>
     # remove any other columns listed in the formula
     setdiff(tryCatch(glue::glue_data(.x = list(y = 1, x = 1), formula) |> stats::as.formula() |> all.vars(), error = \(e) character(0L)))
+  if (is_empty(include)) {
+    cli::cli_abort("The {.arg include} argument cannot be empty.", call = get_cli_abort_call())
+  }
 
   # remove any variables not in include
   show_single_row <-

--- a/tests/testthat/test-tbl_uvregression.R
+++ b/tests/testthat/test-tbl_uvregression.R
@@ -197,6 +197,21 @@ test_that("tbl_uvregression(include)", {
   )
   expect_equal(tbl2$inputs$include, c("age", "marker"))
   expect_snapshot(as.data.frame(tbl2))
+
+  # check that variables in the formula are removed from include
+  expect_equal(
+    trial |>
+      select(age, grade, trt) |>
+      tbl_uvregression(
+        y = age,
+        method = "lm",
+        formula = "{y} ~ {x} + grade"
+      ) |>
+      getElement("table_body") |>
+      getElement("variable") |>
+      unique(),
+    "trt"
+  )
 })
 
 test_that("tbl_uvregression(tidy_fun)", {

--- a/tests/testthat/test-tbl_uvregression.R
+++ b/tests/testthat/test-tbl_uvregression.R
@@ -212,6 +212,17 @@ test_that("tbl_uvregression(include)", {
       unique(),
     "trt"
   )
+
+  # check we get an error if no variables are selected
+  expect_error(
+    tbl_uvregression(
+      trial,
+      y = age,
+      method = "lm",
+      include  = starts_with("xxxx")
+    ),
+    "The `include` argument cannot be empty"
+  )
 })
 
 test_that("tbl_uvregression(tidy_fun)", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fix in `tbl_uvregression()` for the `formula` argument when it includes a hard-coded column name, e.g. `formula='{y} ~ {x} + grade'`. The hard-coded variable name is now removed from the `include` argument. This was a regression introduced in the v2.0.0 release. (#1886)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1886

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

