### PR TITLE
Adding strong connection between `tbl_summary(by)` order and order in table_body

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ BugReports: https://github.com/ddsjoberg/gtsummary/issues
 Depends: 
     R (>= 4.2)
 Imports: 
-    cards (>= 0.2.0),
+    cards (>= 0.2.0.9002),
     cli (>= 3.6.1),
     dplyr (>= 1.1.3),
     glue (>= 1.6.2),
@@ -86,6 +86,7 @@ Suggests:
     tidycmprsk (>= 1.0.0),
     withr (>= 2.5.0),
     workflows (>= 0.2.4)
+Remotes: insightsengineering/cards
 VignetteBuilder: 
     knitr
 RdMacros: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * Correct the order of the columns when the `tbl_summary(by)` variables has ten or more levels: a regression introduced in v2.0.0. (#1877)
 
+* Re-establishing strong link between header by variable levels and those in the table body to ensure correct ordering of columns in `tbl_summary()`.
+
+* The `tbl_survfit(times)` argument accepts integers once again. (#1867)
+
 # gtsummary 2.0.0
 
 ### New Features

--- a/tests/testthat/_snaps/tbl_ard_summary.md
+++ b/tests/testthat/_snaps/tbl_ard_summary.md
@@ -142,7 +142,7 @@
     Condition
       Error in `tbl_ard_summary()`:
       ! Statistic "not_a_valid_summary_statistic" is not available for variable "AGE".
-      i Select among "p_nonmiss", "p_miss", "N_nonmiss", "N_miss", "N_obs", "max", "min", "p75", "p25", "median", "sd", "mean", and "N".
+      i Select among "N", "mean", "sd", "median", "p25", "p75", "min", "max", "N_obs", "N_miss", "N_nonmiss", "p_miss", and "p_nonmiss".
 
 ---
 

--- a/tests/testthat/_snaps/tbl_summary.md
+++ b/tests/testthat/_snaps/tbl_summary.md
@@ -208,7 +208,7 @@
     Condition
       Error in `tbl_summary()`:
       ! Statistic "not_a_statistic" is not available for variable "response".
-      i Select among "p", "N", "n", "p_nonmiss", "p_miss", "N_nonmiss", "N_miss", and "N_obs".
+      i Select among "n", "N", "p", "N_obs", "N_miss", "N_nonmiss", "p_miss", and "p_nonmiss".
 
 ---
 

--- a/tests/testthat/_snaps/tbl_svysummary.md
+++ b/tests/testthat/_snaps/tbl_svysummary.md
@@ -166,7 +166,7 @@
     Condition
       Error in `tbl_svysummary()`:
       ! Statistic "not_a_statistic" is not available for variable "response".
-      i Select among "p_unweighted", "N_unweighted", "n_unweighted", "deff", "p.std.error", "p", "N", "n", "p_nonmiss_unweighted", "N_nonmiss_unweighted", "p_miss_unweighted", "N_obs_unweighted", "N_miss_unweighted", "p_miss", "N_miss", "p_nonmiss", "N_obs", and "N_nonmiss".
+      i Select among "N_nonmiss", "N_obs", "p_nonmiss", "N_miss", "p_miss", "N_miss_unweighted", "N_obs_unweighted", "p_miss_unweighted", "N_nonmiss_unweighted", "p_nonmiss_unweighted", "n", "N", "p", "p.std.error", "deff", "n_unweighted", "N_unweighted", and "p_unweighted".
 
 ---
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Re-establishing strong link between header by variable levels and those in the table body to ensure correct ordering of columns in `tbl_summary()`.

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

