### PR TITLE
Update styling function for p statistic when integer passed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.0.9004
+Version: 2.0.0.9005
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Updates to address regressions in the v2.0.0 release:
   * The `tbl_survfit(times)` argument accepts integers once again. (#1867)
   * Fix in `tbl_uvregression()` for the `formula` argument when it includes a hard-coded column name, e.g. `formula='{y} ~ {x} + grade'`. The hard-coded variable name is now removed from the `include` argument. This was a regression introduced in the v2.0.0 release. (#1886)
   * Fix for non-Base R classes tabulated with `tbl_summary()` that would not coerce to character correctly after `unlist()`. (#1893)
+  * Updated the styling function from `style_percent()` to `style_number(scale=100)` when user passes an integer to change the rounding of percentages in `tbl_summary()`. (#1899)
 
 # gtsummary 2.0.0
 

--- a/R/assign_summary_digits.R
+++ b/R/assign_summary_digits.R
@@ -114,9 +114,9 @@ assign_summary_digits <- function(data, statistic, type, digits = NULL) {
       if (!is_integerish(value)) {
         return(value)
       }
-      # if an integer is passed for a percentage, process stat with style_percent()
+      # if an integer is passed for a percentage, process stat with label_style_number()
       if (stat_name %in% c("p", "p_miss", "p_nonmiss", "p_unweighted")) {
-        return(label_style_percent(digits = value))
+        return(label_style_number(digits = value, scale = 100))
       }
       # otherwise, use style_number() to style number
       return(label_style_number(digits = value))

--- a/tests/testthat/test-tbl_summary.R
+++ b/tests/testthat/test-tbl_summary.R
@@ -234,6 +234,21 @@ test_that("tbl_summary(digit)", {
       dplyr::pull(stat_0),
     "22.41 (15.92, 24.00)"
   )
+
+  expect_silent(
+    tbl <-
+      tbl_summary(
+        mtcars,
+        include = carb,
+        type = carb ~ "categorical",
+        digits = carb ~ c(0, 1)
+      )
+  )
+  expect_equal(
+    tbl$table_body$stat_0 |>
+      dplyr::last(),
+    "1 (3.1%)"
+  )
 })
 
 test_that("tbl_summary(digit) errors properly", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Updated the styling function from `style_percent()` to `style_number(scale=100)` when user passes an integer to change the rounding of percentages in `tbl_summary()`. (#1899)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1899

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

