### PR TITLE
updated default value of `tbl_ard_summary(missing)` to `"no"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@ Updates to address regressions in the v2.0.0 release:
 
 * The class of `tbl_split()` objects has been updated from `"tbl_split"` to `c("tbl_split", "list")`. (#1854)
 
+* Updated the default value of `tbl_ard_summary(missing)` to `"no"`. (#1857)
+
 # gtsummary 2.0.0
 
 ### New Features

--- a/R/tbl_ard_summary.R
+++ b/R/tbl_ard_summary.R
@@ -18,7 +18,7 @@
 #'   `list(all_continuous() ~ "{median} ({p25}, {p75})", all_categorical() ~ "{n} ({p}%)")`.
 #' @param missing,missing_text,missing_stat
 #'   Arguments dictating how and if missing values are presented:
-#'   - `missing`: must be one of `c("ifany", "no", "always")`
+#'   - `missing`: must be one of `c("no", "ifany", "always")`
 #'   - `missing_text`: string indicating text shown on missing row. Default is `"Unknown"`
 #'   - `missing_stat`: statistic to show on missing row. Default is `"{N_miss}"`.
 #'     Possible values are `N_miss`, `N_obs`, `N_nonmiss`, `p_miss`, `p_nonmiss`
@@ -61,7 +61,7 @@ tbl_ard_summary <- function(cards,
                               all_categorical() ~ "{n} ({p}%)"
                             ),
                             type = NULL,
-                            missing = c("ifany", "no", "always"),
+                            missing = c("no", "ifany", "always"),
                             missing_text = "Unknown",
                             missing_stat = "{N_miss}",
                             include = everything()) {

--- a/man/tbl_ard_summary.Rd
+++ b/man/tbl_ard_summary.Rd
@@ -10,7 +10,7 @@ tbl_ard_summary(
   statistic = list(all_continuous() ~ "{median} ({p25}, {p75})", all_categorical() ~
     "{n} ({p}\%)"),
   type = NULL,
-  missing = c("ifany", "no", "always"),
+  missing = c("no", "ifany", "always"),
   missing_text = "Unknown",
   missing_stat = "{N_miss}",
   include = everything()
@@ -39,7 +39,7 @@ categorical and dichotomous cannot be modified.}
 
 \item{missing, missing_text, missing_stat}{Arguments dictating how and if missing values are presented:
 \itemize{
-\item \code{missing}: must be one of \code{c("ifany", "no", "always")}
+\item \code{missing}: must be one of \code{c("no", "ifany", "always")}
 \item \code{missing_text}: string indicating text shown on missing row. Default is \code{"Unknown"}
 \item \code{missing_stat}: statistic to show on missing row. Default is \code{"{N_miss}"}.
 Possible values are \code{N_miss}, \code{N_obs}, \code{N_nonmiss}, \code{p_miss}, \code{p_nonmiss}


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Updated the default value of `tbl_ard_summary(missing)` to `"no"`

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1857 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

