### PR TITLE
fix for add_glance*() for MICE models and the default  glance fun

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.1.9000
+Version: 2.0.1.9001
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # gtsummary (development version)
 
+Updates to address regressions in the v2.0.0 release:
+
+  * The default `add_glance_*(glance_fun)` function fixed for `mice` models with class `'mira'`. (#1912)
+  
 # gtsummary 2.0.1
 
 Updates to address regressions in the v2.0.0 release:

--- a/R/add_glance.R
+++ b/R/add_glance.R
@@ -81,7 +81,7 @@ add_glance_table <- function(x,
   check_class(x, "tbl_regression")
 
   # use a modified glance for mice models --------------------------------------
-  if (missing(glance_fun) && inherits(x$inputs$x, "mice")) {
+  if (missing(glance_fun) && inherits(x$inputs$x, "mira")) {
     check_pkg_installed("mice", reference_pkg = "gtsummary")
     glance_fun <- \(x) broom::glance(mice::pool(x))
   }
@@ -145,7 +145,7 @@ add_glance_source_note <- function(x,
   check_string(sep2)
 
   # use a modified glance for mice models --------------------------------------
-  if (missing(glance_fun) && inherits(x$inputs$x, "mice")) {
+  if (missing(glance_fun) && inherits(x$inputs$x, "mira")) {
     check_pkg_installed("mice", reference_pkg = "gtsummary")
     glance_fun <- \(x) broom::glance(mice::pool(x))
   }


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The default `add_glance_*(glance_fun)` function fixed for `mice` models with class `'mira'`. (#1912)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1912 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

