### PR TITLE
Unweighted stats in `tbl_svysummary()` headers fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -85,7 +85,7 @@ Suggests:
     testthat (>= 3.2.0),
     withr (>= 2.5.0),
     workflows (>= 0.2.4)
-Remotes: insightsengineering/cards
+Remotes: insightsengineering/cards, insightsengineering/cardx
 VignetteBuilder: 
     knitr
 RdMacros: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ Suggests:
     broom.helpers (>= 1.15.0),
     broom.mixed (>= 0.2.9),
     car (>= 3.0-11),
-    cardx (>= 0.2.0),
+    cardx (>= 0.2.0.9008),
     cmprsk,
     effectsize (>= 0.6.0),
     emmeans (>= 1.7.3),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.1.9001
+Version: 2.0.1.9002
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,14 @@
 Updates to address regressions in the v2.0.0 release:
 
   * The default `add_glance_*(glance_fun)` function fixed for `mice` models with class `'mira'`. (#1912)
+  * We can again report unweighted statistics in the headers of `tbl_svysummary()` tables. (#1911)
   
+### Other updates
+
+* The total N is now returned with `.$cards` using the `cards::ard_total_n()` function for the calculation.
+
+* The default headers for `tbl_ard_*()` functions no longer include counts, as these are not required data to be passed along in the ARD input.
+
 # gtsummary 2.0.1
 
 Updates to address regressions in the v2.0.0 release:

--- a/R/add_stat_label.R
+++ b/R/add_stat_label.R
@@ -244,7 +244,7 @@ add_stat_label.tbl_svysummary <- add_stat_label.tbl_summary
               expr(glue::glue(gsub("\\{(p|p_miss|p_nonmiss|p_unweighted)\\}%", "{\\1}", x = sub_statistic))),
               cards::get_ard_statistics(
                 x$cards[[1]] |>
-                  dplyr::filter(.data$variable %in% variable) |>
+                  dplyr::filter(.data$variable %in% .env$variable) |>
                   dplyr::distinct(.data$stat_name, .data$stat_label),
                 .column = "stat_label"
               )

--- a/R/brdg_continuous.R
+++ b/R/brdg_continuous.R
@@ -57,6 +57,9 @@ brdg_continuous <- function(cards, by = NULL, statistic, include, variable) {
         if (.y$context %in% "attributes" || identical(.x$variable[1], by)) {
           return(dplyr::bind_cols(.x, .y))
         }
+        if (.y$context %in% "total_n") {
+          return(dplyr::bind_cols(.x, .y))
+        }
 
         .x |>
           dplyr::select(-cards::all_ard_variables()) %>%

--- a/R/brdg_summary.R
+++ b/R/brdg_summary.R
@@ -542,22 +542,47 @@ pier_summary_missing_row <- function(cards,
 
 .add_table_styling_stats <- function(x, cards, by) {
   if (is_empty(by)) {
-    x$table_styling$header <-
-      x$table_styling$header |>
-      dplyr::mutate(
-        modify_stat_N =
-          cards |>
-          dplyr::filter(.data$stat_name %in% "N_obs") |>
-          dplyr::pull("stat") |>
-          unlist() |>
-          getElement(1) %||% NA_integer_,
-        modify_stat_n = .data$modify_stat_N,
-        modify_stat_p = 1,
-        modify_stat_level = "Overall"
-      )
-  } else {
+    # add overall N to x$table_styling$header
+    if ("N_obs" %in% unique(cards$stat_name)) {
+      x$table_styling$header <-
+        x$table_styling$header |>
+        dplyr::mutate(
+          modify_stat_N =
+            cards |>
+            dplyr::filter(.data$stat_name %in% "N_obs") |>
+            dplyr::pull("stat") |>
+            unlist() |>
+            getElement(1) %||% NA_integer_,
+          modify_stat_n = .data$modify_stat_N,
+          modify_stat_p = 1,
+          modify_stat_level = translate_string("Overall")
+        )
+    }
+
+
+    # if this is a survey object, then add unweighted stats as well
+    if ("N_obs_unweighted" %in% unique(cards$stat_name)) {
+      x$table_styling$header <-
+        x$table_styling$header |>
+        dplyr::mutate(
+          modify_stat_N_unweighted =
+            cards |>
+            dplyr::filter(.data$stat_name %in% "N_obs_unweighted") |>
+            dplyr::pull("stat") |>
+            unlist() |>
+            getElement(1) %||% NA_integer_,
+          modify_stat_n_unweighted = .data$modify_stat_N_unweighted,
+          modify_stat_p_unweighted = 1
+        )
+    }
+  }
+  # add by variable stats
+  else {
     df_by_stats <- cards |>
-      dplyr::filter(.data$variable %in% .env$by & .data$stat_name %in% c("N", "n", "p"))
+      dplyr::filter(
+        .data$variable %in% .env$by,
+        .data$stat_name %in% c("N", "n", "p", "N_unweighted", "n_unweighted", "p_unweighted")
+      )
 
     if (nrow(df_by_stats) == 0L) {
       cli::cli_abort(
@@ -569,7 +594,7 @@ pier_summary_missing_row <- function(cards,
 
     df_by_stats_wide <-
       df_by_stats |>
-      dplyr::filter(.data$stat_name %in% c("n", "p")) |>
+      dplyr::filter(.data$stat_name %in% c("N", "n", "p", "N_unweighted", "n_unweighted", "p_unweighted")) |>
       dplyr::select(cards::all_ard_variables(), "stat_name", "stat") |>
       dplyr::left_join(
         cards |>
@@ -602,19 +627,23 @@ pier_summary_missing_row <- function(cards,
     # add the stats here to the header data frame
     x$table_styling$header <-
       x$table_styling$header |>
-      dplyr::mutate(
-        modify_stat_N =
-          df_by_stats |>
-          dplyr::filter(.data$stat_name %in% "N") |>
-          dplyr::pull("stat") |>
-          unlist() |>
-          getElement(1L)
-      ) |>
       dplyr::left_join(
         df_by_stats_wide,
         by = "column"
-      )
+      ) |>
+      tidyr::fill(any_of(c("modify_stat_N", "modify_stat_N_unweighted")), .direction = "updown")
   }
 
+  # re-ording the columns
+  x$table_styling$header <-
+    x$table_styling$header |>
+    dplyr::relocate(
+      any_of(c("modify_stat_level",
+               "modify_stat_N", "modify_stat_n", "modify_stat_p",
+               "modify_stat_N_unweighted", "modify_stat_n_unweighted", "modify_stat_p_unweighted")),
+      .before = last_col()
+    )
+
+  # return final object
   x
 }

--- a/R/brdg_summary.R
+++ b/R/brdg_summary.R
@@ -542,35 +542,26 @@ pier_summary_missing_row <- function(cards,
 
 .add_table_styling_stats <- function(x, cards, by) {
   if (is_empty(by)) {
+    x$table_styling$header$modify_stat_level <- translate_string("Overall")
+
     # add overall N to x$table_styling$header
-    if ("N_obs" %in% unique(cards$stat_name)) {
+    lst_total_n <- cards::get_ard_statistics(cards, .data$variable %in% "..ard_total_n..")
+    if ("N" %in% names(lst_total_n)) {
       x$table_styling$header <-
         x$table_styling$header |>
         dplyr::mutate(
-          modify_stat_N =
-            cards |>
-            dplyr::filter(.data$stat_name %in% "N_obs") |>
-            dplyr::pull("stat") |>
-            unlist() |>
-            getElement(1) %||% NA_integer_,
+          modify_stat_N = lst_total_n[["N"]],
           modify_stat_n = .data$modify_stat_N,
-          modify_stat_p = 1,
-          modify_stat_level = translate_string("Overall")
+          modify_stat_p = 1
         )
     }
 
-
     # if this is a survey object, then add unweighted stats as well
-    if ("N_obs_unweighted" %in% unique(cards$stat_name)) {
+    if ("N_unweighted" %in% names(lst_total_n)) {
       x$table_styling$header <-
         x$table_styling$header |>
         dplyr::mutate(
-          modify_stat_N_unweighted =
-            cards |>
-            dplyr::filter(.data$stat_name %in% "N_obs_unweighted") |>
-            dplyr::pull("stat") |>
-            unlist() |>
-            getElement(1) %||% NA_integer_,
+          modify_stat_N_unweighted = lst_total_n[["N_unweighted"]],
           modify_stat_n_unweighted = .data$modify_stat_N_unweighted,
           modify_stat_p_unweighted = 1
         )

--- a/R/tbl_ard_continuous.R
+++ b/R/tbl_ard_continuous.R
@@ -157,7 +157,7 @@ tbl_ard_continuous <- function(cards, variable, include, by = NULL, statistic = 
   # if `by` is missing, then remove Ns since they are not in the ARD by default
   if (is_empty(by)) {
     x$table_styling$header <- x$table_styling$header |>
-      dplyr::mutate(across(c("modify_stat_N", "modify_stat_n"), ~NA_integer_))
+      dplyr::mutate(modify_stat_N = NA_integer_, modify_stat_n = NA_integer_, modify_stat_p = NA_real_)
   }
 
   # adding styling -------------------------------------------------------------

--- a/R/tbl_ard_continuous.R
+++ b/R/tbl_ard_continuous.R
@@ -154,23 +154,10 @@ tbl_ard_continuous <- function(cards, variable, include, by = NULL, statistic = 
   # prepare the base table via `brdg_continuous()` -----------------------------
   x <- brdg_continuous(cards, by = by, statistic = statistic, include = include, variable = variable)
 
-  # if `by` is missing, then remove Ns since they are not in the ARD by default
-  if (is_empty(by)) {
-    x$table_styling$header <- x$table_styling$header |>
-      dplyr::mutate(modify_stat_N = NA_integer_, modify_stat_n = NA_integer_, modify_stat_p = NA_real_)
-  }
-
   # adding styling -------------------------------------------------------------
   x <- x |>
     # updating the headers for the stats columns
-    modify_header(
-      all_stat_cols() ~
-        ifelse(
-          is_empty(by),
-          "**N = {style_number(N)}**",
-          "**{level}**  \nN = {style_number(n)}"
-        )
-    )
+    modify_header(all_stat_cols() ~ "**{level}**")
 
   # prepend the footnote with information about the variable -------------------
   x$table_styling$footnote$footnote <-

--- a/R/tbl_ard_summary.R
+++ b/R/tbl_ard_summary.R
@@ -261,9 +261,9 @@ tbl_ard_summary <- function(cards,
         ifelse(
           is_empty(by),
           get_theme_element("tbl_summary-str:header-noby",
-                            default = "**N = {style_number(N)}**"),
+                            default = "**{level}**"),
           get_theme_element("tbl_summary-str:header-withby",
-                            default = "**{level}**  \nN = {style_number(n)}")
+                            default = "**{level}**")
         )
     )
 

--- a/R/tbl_continuous.R
+++ b/R/tbl_continuous.R
@@ -142,7 +142,8 @@ tbl_continuous <- function(data,
     dplyr::bind_rows(
       cards,
       cards::ard_attributes(data, variables = all_of(c(variable, by, include)), label = label),
-      cards::ard_categorical(data, variables = any_of(by), stat_label = ~ default_stat_labels())
+      cards::ard_categorical(data, variables = any_of(by), stat_label = ~ default_stat_labels()),
+      cards::ard_total_n(data)
     )
 
   # fill NULL stats with NA
@@ -159,13 +160,6 @@ tbl_continuous <- function(data,
 
   # prepare the base table via `brdg_continuous()` -----------------------------
   x <- brdg_continuous(cards, by = by, statistic = statistic, include = include, variable = variable)
-
-  # if no by variable, fix the header N ----------------------------------------
-  if (is_empty(by)) {
-    x$table_styling$header <- x$table_styling$header |>
-      dplyr::mutate(across(c("modify_stat_N", "modify_stat_n"), ~nrow(data)))
-  }
-
 
   # adding styling -------------------------------------------------------------
   x <- x |>

--- a/R/tbl_custom_summary.R
+++ b/R/tbl_custom_summary.R
@@ -399,6 +399,7 @@ tbl_custom_summary <- function(data,
                          fmt_fn = digits,
                          stat_label = ~ default_stat_labels()
       ),
+      cards::ard_total_n(data),
       # tabulate by variable for header stats
       if (!is_empty(by)) {
         cards::ard_categorical(data,

--- a/R/tbl_summary.R
+++ b/R/tbl_summary.R
@@ -354,6 +354,8 @@ tbl_summary <- function(data,
                          fmt_fn = digits,
                          stat_label = ~ default_stat_labels()
       ),
+      # adding total N
+      cards::ard_total_n(data),
       # tabulate by variable for header stats
       case_switch(
         !is_empty(by) ~
@@ -429,7 +431,7 @@ tbl_summary <- function(data,
   if (is_empty(by)) {
     cards$gts_column <-
       ifelse(
-        !cards$context %in% "attributes",
+        !cards$context %in% "attributes" & !cards$variable %in% "..ard_total_n..",
         "stat_0",
         NA_character_
       )

--- a/R/tbl_svysummary.R
+++ b/R/tbl_svysummary.R
@@ -274,6 +274,8 @@ tbl_svysummary <- function(data,
     cards::bind_ard(
       # attributes for summary columns
       cardx::ard_attributes(data, variables = all_of(c(include, by)), label = label),
+      # total N
+      cardx::ard_total_n(data),
       # tabulate missing information
       cardx::ard_missing(data,
                          variables = all_of(include),

--- a/R/utils-cards.R
+++ b/R/utils-cards.R
@@ -13,7 +13,7 @@ bootstrap_df_from_cards <- function(x) {
         dplyr::rename(name = any_of(.x), level = any_of(paste0(.x, "_level")))
     ) |>
     dplyr::bind_rows() |>
-    dplyr::filter(!is.na(.data$name))
+    dplyr::filter(!is.na(.data$name), !.data$name %in% "..ard_total_n..")
 
   if (!"level" %in% df_long) {
     df_long$level <- list(NA)

--- a/tests/testthat/_snaps/tbl_ard_continuous.md
+++ b/tests/testthat/_snaps/tbl_ard_continuous.md
@@ -4,7 +4,7 @@
       as.data.frame(tbl_ard_continuous(cards::ard_continuous(trial, by = grade,
         variables = age), variable = "age", include = "grade"))
     Output
-        **Characteristic**        **N = NA**
+        **Characteristic**       **Overall**
       1              grade              <NA>
       2                  I 47.0 (37.0, 56.0)
       3                 II 48.5 (37.0, 57.0)
@@ -17,11 +17,11 @@
         by = c(trt, grade), variables = age), cards::ard_categorical(trial, trt)),
       variable = "age", include = "grade", by = "trt"))
     Output
-        **Characteristic** **Drug A**  \nN = 98 **Drug B**  \nN = 102
-      1              grade                 <NA>                  <NA>
-      2                  I    46.0 (36.0, 60.0)     48.0 (42.0, 55.0)
-      3                 II    44.5 (31.0, 55.0)     50.5 (42.0, 57.5)
-      4                III    51.5 (41.5, 60.5)     45.0 (36.0, 52.0)
+        **Characteristic**        **Drug A**        **Drug B**
+      1              grade              <NA>              <NA>
+      2                  I 46.0 (36.0, 60.0) 48.0 (42.0, 55.0)
+      3                 II 44.5 (31.0, 55.0) 50.5 (42.0, 57.5)
+      4                III 51.5 (41.5, 60.5) 45.0 (36.0, 52.0)
 
 # tbl_ard_continuous(cards) error messaging
 

--- a/tests/testthat/_snaps/tbl_ard_summary.md
+++ b/tests/testthat/_snaps/tbl_ard_summary.md
@@ -5,27 +5,27 @@
       cards::ard_categorical(variables = "AGEGR1"), cards::ard_continuous(variables = "AGE"),
       .attributes = TRUE, .missing = TRUE), by = ARM))
     Output
-        **Characteristic** **Placebo**  \nN = 86 **Xanomeline High Dose**  \nN = 84
-      1 Pooled Age Group 1                  <NA>                               <NA>
-      2              65-80            42 (48.8%)                         55 (65.5%)
-      3                <65            14 (16.3%)                         11 (13.1%)
-      4                >80            30 (34.9%)                         18 (21.4%)
-      5                Age     76.0 (69.0, 82.0)                  76.0 (70.5, 80.0)
-        **Xanomeline Low Dose**  \nN = 84
-      1                              <NA>
-      2                        47 (56.0%)
-      3                          8 (9.5%)
-      4                        29 (34.5%)
-      5                 77.5 (71.0, 82.0)
+        **Characteristic**       **Placebo** **Xanomeline High Dose**
+      1 Pooled Age Group 1              <NA>                     <NA>
+      2              65-80        42 (48.8%)               55 (65.5%)
+      3                <65        14 (16.3%)               11 (13.1%)
+      4                >80        30 (34.9%)               18 (21.4%)
+      5                Age 76.0 (69.0, 82.0)        76.0 (70.5, 80.0)
+        **Xanomeline Low Dose**
+      1                    <NA>
+      2              47 (56.0%)
+      3                8 (9.5%)
+      4              29 (34.5%)
+      5       77.5 (71.0, 82.0)
 
 ---
 
     Code
       as.data.frame(tbl_ard_summary(cards::ard_stack(data = cards::ADSL, cards::ard_categorical(
         variables = "AGEGR1"), cards::ard_continuous(variables = "AGE"), .attributes = TRUE,
-      .missing = TRUE)))
+      .missing = TRUE, .total_n = TRUE)))
     Output
-        **Characteristic**       **N = 254**
+        **Characteristic**       **Overall**
       1 Pooled Age Group 1              <NA>
       2              65-80       144 (56.7%)
       3                <65        33 (13.0%)
@@ -39,10 +39,10 @@
       cards::ard_continuous(variables = "AGE"), .attributes = FALSE, .missing = FALSE),
       by = ARM, missing = "no"))
     Output
-        **Characteristic** **Placebo**  \nN = 86 **Xanomeline High Dose**  \nN = 84
-      1                AGE     76.0 (69.0, 82.0)                  76.0 (70.5, 80.0)
-        **Xanomeline Low Dose**  \nN = 84
-      1                 77.5 (71.0, 82.0)
+        **Characteristic**       **Placebo** **Xanomeline High Dose**
+      1                AGE 76.0 (69.0, 82.0)        76.0 (70.5, 80.0)
+        **Xanomeline Low Dose**
+      1       77.5 (71.0, 82.0)
 
 # tbl_ard_summary(cards) error messages
 
@@ -91,7 +91,7 @@
       as.data.frame(tbl_ard_summary(ard, statistic = list(all_continuous() ~
         "{median}", all_categorical() ~ "{n} / {N} (Total {N_obs})")))
     Output
-        **Characteristic**           **N = 254**
+        **Characteristic**           **Overall**
       1 Pooled Age Group 1                  <NA>
       2              65-80 144 / 254 (Total 254)
       3                <65  33 / 254 (Total 254)
@@ -104,7 +104,7 @@
       as.data.frame(tbl_ard_summary(ard, type = list(all_continuous() ~ "continuous2"),
       statistic = list(all_continuous() ~ c("{median}", "{mean}"))))
     Output
-        **Characteristic** **N = 254**
+        **Characteristic** **Overall**
       1 Pooled Age Group 1        <NA>
       2              65-80 144 (56.7%)
       3                <65  33 (13.0%)

--- a/tests/testthat/test-modify_header.R
+++ b/tests/testthat/test-modify_header.R
@@ -165,6 +165,20 @@ test_that("modify_header() works with tbl_svysummary()", {
       "No | N = 2201 | n = 1490 | p = 68%",
       "Yes | N = 2201 | n = 711 | p = 32%")
   )
+
+  expect_equal(
+    survey::svydesign(~1, data = as.data.frame(Titanic), weights = ~Freq) |>
+      tbl_svysummary(by = Survived, percent = "row", include = c(Class, Age))|>
+      add_overall() |>
+      modify_header(all_stat_cols() ~ "{level} | N = {N_unweighted} | n = {n_unweighted} | p = {style_percent(p_unweighted)}%") |>
+      getElement("table_styling") |>
+      getElement("header") |>
+      dplyr::filter(startsWith(column, "stat_")) |>
+      dplyr::pull("label"),
+    c("Overall | N = 32 | n = 32 | p = 100%",
+      "No | N = 32 | n = 16 | p = 50%",
+      "Yes | N = 32 | n = 16 | p = 50%")
+  )
 })
 
 test_that("modify_header() works with tbl_continuous()", {

--- a/tests/testthat/test-tbl_ard_summary.R
+++ b/tests/testthat/test-tbl_ard_summary.R
@@ -21,13 +21,12 @@ test_that("tbl_ard_summary() works", {
       cards::ard_categorical(variables = "AGEGR1"),
       cards::ard_continuous(variables = "AGE"),
       .attributes = TRUE,
-      .missing = TRUE
+      .missing = TRUE,
+      .total_n = TRUE
     ) |>
       tbl_ard_summary() |>
       as.data.frame()
   )
-
-
 })
 
 
@@ -121,7 +120,8 @@ test_that("tbl_ard_summary(statistic) argument works", {
       cards::ard_categorical(variables = "AGEGR1"),
       cards::ard_continuous(variables = "AGE"),
       .attributes = TRUE,
-      .missing = TRUE
+      .missing = TRUE,
+      .total_n = TRUE
     )
 
   expect_snapshot(


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* We can again report unweighted statistics in the headers of `tbl_svysummary()` tables. (#1911)

* The total N is now returned with `.$cards` using the `cards::ard_total_n()` function for the calculation.

* The default headers for `tbl_ard_*()` functions no longer include counts, as these are not required data to be passed along in the ARD input.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1911

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] Ensure all package dependencies are installed: `renv::install()`
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

