### PR TITLE
Fix in printing error/warning conditions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ BugReports: https://github.com/ddsjoberg/gtsummary/issues
 Depends: 
     R (>= 4.2)
 Imports: 
-    cards (>= 0.2.1),
+    cards (>= 0.2.1.9006),
     cli (>= 3.6.1),
     dplyr (>= 1.1.3),
     glue (>= 1.6.2),
@@ -85,6 +85,7 @@ Suggests:
     testthat (>= 3.2.0),
     withr (>= 2.5.0),
     workflows (>= 0.2.4)
+Remotes: insightsengineering/cards
 VignetteBuilder: 
     knitr
 RdMacros: 

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -80,6 +80,7 @@ NULL
 #' @name tbl_uvregression
 tbl_uvregression <- function(data, ...) {
   check_not_missing(data)
+  check_pkg_installed("cardx", reference_pkg = "gtsummary")
   UseMethod("tbl_uvregression")
 }
 

--- a/tests/testthat/_snaps/tbl_summary.md
+++ b/tests/testthat/_snaps/tbl_summary.md
@@ -418,3 +418,22 @@
       Error in `tbl_summary()`:
       ! `percent` must be one of "column", "row", or "cell", not "a".
 
+# tbl_summary() edge case of warning condition printing
+
+    Code
+      as_kable(tbl_summary(dplyr::tibble(by_var = as.factor(c(rep("cohort_1", 3), rep(
+        "cohort_2", 3))), continuous_var = c(NA, NA, NA, 1, 2, 3)), by = by_var,
+      type = continuous_var ~ "continuous", statistic = continuous_var ~
+        "{min}, {max}"))
+    Message
+      The following warnings were returned during `as_kable()`:
+      ! For variable `continuous_var` (`by_var = "cohort_1"`) and "min" statistic: no non-missing arguments to min; returning Inf
+      ! For variable `continuous_var` (`by_var = "cohort_1"`) and "max" statistic: no non-missing arguments to max; returning -Inf
+    Output
+      
+      
+      |**Characteristic** | **cohort_1**  N = 3 | **cohort_2**  N = 3 |
+      |:------------------|:-------------------:|:-------------------:|
+      |continuous_var     |      Inf, -Inf      |     1.00, 3.00      |
+      |Unknown            |          3          |          0          |
+

--- a/tests/testthat/test-tbl_summary.R
+++ b/tests/testthat/test-tbl_summary.R
@@ -638,3 +638,18 @@ test_that("tbl_summary() with hms times", {
   )
 })
 
+# addressing issue #1915
+test_that("tbl_summary() edge case of warning condition printing", {
+ expect_snapshot(
+   dplyr::tibble(
+     by_var = c(rep("cohort_1", 3), rep("cohort_2", 3)) |> as.factor(),
+     continuous_var = c(NA, NA, NA, 1, 2, 3)
+   ) |>
+     tbl_summary(
+       by = by_var,
+       type = continuous_var ~ "continuous",
+       statistic = continuous_var ~ "{min}, {max}"
+     ) |>
+     as_kable()
+ )
+})

--- a/tests/testthat/test-tbl_uvregression.R
+++ b/tests/testthat/test-tbl_uvregression.R
@@ -81,7 +81,7 @@ test_that("tbl_uvregression(method.args)", {
   )
 
   # check with NSE argument
-  expect_silent(
+  expect_error(
     tbl2 <-
       tbl_uvregression(
         trial,
@@ -89,7 +89,8 @@ test_that("tbl_uvregression(method.args)", {
         method = survival::coxph,
         method.args = list(id = response),
         include = c(age, trt)
-      )
+      ),
+    NA
   )
   # check models are the same
   expect_equal(


### PR DESCRIPTION
**What changes are proposed in this pull request?**
The fix was in the cards pkg, where there was an issue with `cli::cli_format()` incorrectly formatting factor variables. We now coerce them to character before printing conditions.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1915 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

