### PR TITLE
No longer require `by` variable summary stats in `tbl_ard_summary(by)` and `tbl_ard_continuous(by)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.1.9002
+Version: 2.0.1.9003
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ Updates to address regressions in the v2.0.0 release:
 
 * The default headers for `tbl_ard_*()` functions no longer include counts, as these are not required data to be passed along in the ARD input.
 
+* The summary statistics of the `'by'` variable are no longer required in the ARD for functions `tbl_ard_summary()` and `tbl_ard_continuous()`. When the tabulation summary statistics are passed, they are available to place in the header dynamically. (#1860)
+
 # gtsummary 2.0.1
 
 Updates to address regressions in the v2.0.0 release:

--- a/R/brdg_summary.R
+++ b/R/brdg_summary.R
@@ -575,45 +575,49 @@ pier_summary_missing_row <- function(cards,
         .data$stat_name %in% c("N", "n", "p", "N_unweighted", "n_unweighted", "p_unweighted")
       )
 
+    # if not tabulation of the by variable provided, just give return the by levels
     if (nrow(df_by_stats) == 0L) {
-      cli::cli_abort(
-        c("The needed counts for the {.arg by} variable were not found.",
-          i = "The statistics can be added to the ARD with {.code cards::ard_categorical(data, variables = {.val {by}})}."),
-        call = get_cli_abort_call()
-      )
-    }
-
-    df_by_stats_wide <-
-      df_by_stats |>
-      dplyr::filter(.data$stat_name %in% c("N", "n", "p", "N_unweighted", "n_unweighted", "p_unweighted")) |>
-      dplyr::select(cards::all_ard_variables(), "stat_name", "stat") |>
-      dplyr::left_join(
+      df_by_stats_wide <-
         cards |>
-          dplyr::select(cards::all_ard_groups(), "gts_column") |>
-          dplyr::filter(!is.na(.data$gts_column)) |>
-          dplyr::distinct() |>
-          dplyr::rename(variable = "group1", variable_level = "group1_level"),
-        by = c("variable", "variable_level")
-      ) %>%
-      dplyr::bind_rows(
-        dplyr::select(., "variable_level", "gts_column", stat = "variable_level") |>
-          dplyr::mutate(stat_name = "level") |>
-          dplyr::distinct()
-      ) |>
-      tidyr::pivot_wider(
-        id_cols = "gts_column",
-        names_from = "stat_name",
-        values_from = "stat"
-      ) |>
-      dplyr::mutate(
-        dplyr::across(-"gts_column", unlist),
-        dplyr::across("level", as.character)
-      ) |>
-      dplyr::rename_with(
-        function(x) paste0("modify_stat_", x),
-        .cols = -"gts_column"
-      ) |>
-      dplyr::rename(column = "gts_column")
+        dplyr::select(column = "gts_column", modify_stat_level = "group1_level") |>
+        dplyr::distinct() |>
+        dplyr::filter(!is.na(.data$column) & !map_lgl(.data$modify_stat_level, is.null)) |>
+        dplyr::mutate(across(everything(), ~unlist(.) |> as.character()))
+    }
+    # otherwise prepare the tabulation stats
+    else {
+      df_by_stats_wide <-
+        df_by_stats |>
+        dplyr::filter(.data$stat_name %in% c("N", "n", "p", "N_unweighted", "n_unweighted", "p_unweighted")) |>
+        dplyr::select(cards::all_ard_variables(), "stat_name", "stat") |>
+        dplyr::left_join(
+          cards |>
+            dplyr::select(cards::all_ard_groups(), "gts_column") |>
+            dplyr::filter(!is.na(.data$gts_column)) |>
+            dplyr::distinct() |>
+            dplyr::rename(variable = "group1", variable_level = "group1_level"),
+          by = c("variable", "variable_level")
+        ) %>%
+        dplyr::bind_rows(
+          dplyr::select(., "variable_level", "gts_column", stat = "variable_level") |>
+            dplyr::mutate(stat_name = "level") |>
+            dplyr::distinct()
+        ) |>
+        tidyr::pivot_wider(
+          id_cols = "gts_column",
+          names_from = "stat_name",
+          values_from = "stat"
+        ) |>
+        dplyr::mutate(
+          dplyr::across(-"gts_column", unlist),
+          dplyr::across("level", as.character)
+        ) |>
+        dplyr::rename_with(
+          function(x) paste0("modify_stat_", x),
+          .cols = -"gts_column"
+        ) |>
+        dplyr::rename(column = "gts_column")
+    }
 
     # add the stats here to the header data frame
     x$table_styling$header <-

--- a/R/brdg_summary.R
+++ b/R/brdg_summary.R
@@ -575,7 +575,7 @@ pier_summary_missing_row <- function(cards,
         .data$stat_name %in% c("N", "n", "p", "N_unweighted", "n_unweighted", "p_unweighted")
       )
 
-    # if not tabulation of the by variable provided, just give return the by levels
+    # if no tabulation of the 'by' variable provided, just return the 'by' levels
     if (nrow(df_by_stats) == 0L) {
       df_by_stats_wide <-
         cards |>

--- a/R/tbl_ard_continuous.R
+++ b/R/tbl_ard_continuous.R
@@ -28,7 +28,7 @@
 #'     # 'trt' is the column stratifying variable and needs to be listed first.
 #'     by = c(trt, grade),
 #'     variables = age
-#'   ) ,
+#'   ),
 #'   # add univariate trt tabulation
 #'   ard_categorical(
 #'     trial,

--- a/tests/testthat/_snaps/tbl_ard_continuous.md
+++ b/tests/testthat/_snaps/tbl_ard_continuous.md
@@ -23,6 +23,18 @@
       3                 II 44.5 (31.0, 55.0) 50.5 (42.0, 57.5)
       4                III 51.5 (41.5, 60.5) 45.0 (36.0, 52.0)
 
+---
+
+    Code
+      as.data.frame(tbl_ard_continuous(cards::ard_continuous(trial, by = c(trt, grade),
+      variables = age), by = trt, variable = age, include = grade))
+    Output
+        **Characteristic**        **Drug A**        **Drug B**
+      1              grade              <NA>              <NA>
+      2                  I 46.0 (36.0, 60.0) 48.0 (42.0, 55.0)
+      3                 II 44.5 (31.0, 55.0) 50.5 (42.0, 57.5)
+      4                III 51.5 (41.5, 60.5) 45.0 (36.0, 52.0)
+
 # tbl_ard_continuous(cards) error messaging
 
     Code

--- a/tests/testthat/_snaps/tbl_ard_summary.md
+++ b/tests/testthat/_snaps/tbl_ard_summary.md
@@ -44,6 +44,15 @@
         **Xanomeline Low Dose**
       1       77.5 (71.0, 82.0)
 
+---
+
+    Code
+      as.data.frame(tbl_ard_summary(cards::ard_continuous(trial, by = trt, variables = age),
+      by = trt))
+    Output
+        **Characteristic**        **Drug A**        **Drug B**
+      1                age 46.0 (37.0, 60.0) 48.0 (39.0, 56.0)
+
 # tbl_ard_summary(cards) error messages
 
     Code

--- a/tests/testthat/test-tbl_ard_continuous.R
+++ b/tests/testthat/test-tbl_ard_continuous.R
@@ -15,6 +15,13 @@ test_that("tbl_ard_continuous(cards)", {
       tbl_ard_continuous(variable = "age", include = "grade", by = "trt") |>
       as.data.frame()
   )
+
+  # no error when no tablulation of the 'by' data is passed
+  expect_snapshot(
+    cards::ard_continuous(trial, by = c(trt, grade), variables = age) |>
+      tbl_ard_continuous(by = trt, variable = age, include = grade) |>
+      as.data.frame()
+  )
 })
 
 test_that("tbl_ard_continuous(cards) error messaging", {

--- a/tests/testthat/test-tbl_ard_summary.R
+++ b/tests/testthat/test-tbl_ard_summary.R
@@ -31,7 +31,7 @@ test_that("tbl_ard_summary() works", {
 
 
 test_that("tbl_ard_summary(cards)", {
-  # when attribute labels are not provided, we defatult to variable names
+  # when attribute labels are not provided, we default to variable names
   expect_equal(
     cards::ard_stack(
       data = cards::ADSL,
@@ -58,6 +58,13 @@ test_that("tbl_ard_summary(cards)", {
       .missing = FALSE
     ) |>
       tbl_ard_summary(by = ARM, missing = "no") |>
+      as.data.frame()
+  )
+
+  # no error when no tablulation of the 'by' data is passed
+  expect_snapshot(
+    cards::ard_continuous(trial, by = trt, variables = age) |>
+      tbl_ard_summary(by = trt) |>
       as.data.frame()
   )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The summary statistics of the `'by'` variable are no longer required in the ARD for functions `tbl_ard_summary()` and `tbl_ard_continuous()`. When the tabulation summary statistics are passed, they are available to place in the header dynamically. (#1860)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1860

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] Ensure all package dependencies are installed: `renv::install()`
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

