### PR TITLE
adding additional `add_ci()` messaging

### DIFF
--- a/R/add_ci.R
+++ b/R/add_ci.R
@@ -91,6 +91,10 @@ add_ci.tbl_summary <- function(x,
   # check inputs ---------------------------------------------------------------
   check_scalar_range(conf.level, range = c(0, 1))
   check_string(pattern, allow_empty = TRUE)
+  if (!"column" %in% x$inputs$percent) {
+    cli::cli_inform("The {.fun add_ci} function is meant to work with {.code tbl_summary(percent={cli::cli_format('column')})},
+                     but {.code tbl_summary(percent={cli::cli_format(x$inputs$percent)})} was used.")
+  }
 
   # process inputs -------------------------------------------------------------
   cards::process_selectors(

--- a/R/add_ci.tbl_svysummary.R
+++ b/R/add_ci.tbl_svysummary.R
@@ -63,6 +63,10 @@ add_ci.tbl_svysummary <- function(x,
   # check inputs ---------------------------------------------------------------
   check_scalar_range(conf.level, range = c(0, 1))
   check_string(pattern, allow_empty = TRUE)
+  if (!"column" %in% x$inputs$percent) {
+    cli::cli_inform("The {.fun add_ci} function is meant to work with {.code tbl_svysummary(percent={cli::cli_format('column')})},
+                     but {.code tbl_svysummary(percent={cli::cli_format(x$inputs$percent)})} was used.")
+  }
 
   # process inputs -------------------------------------------------------------
   cards::process_selectors(

--- a/man/tbl_ard_continuous.Rd
+++ b/man/tbl_ard_continuous.Rd
@@ -47,7 +47,7 @@ bind_ard(
     # 'trt' is the column stratifying variable and needs to be listed first.
     by = c(trt, grade),
     variables = age
-  ) ,
+  ),
   # add univariate trt tabulation
   ard_categorical(
     trial,

--- a/tests/testthat/test-add_ci.tbl_summary.R
+++ b/tests/testthat/test-add_ci.tbl_summary.R
@@ -800,3 +800,16 @@ test_that("add_ci() correctly handles dichotomous variables", {
     tbl$cards$add_ci[c("variable", "variable_level")] |> unique() |> deframe()
   )
 })
+
+test_that("add_ci() messaging for tbl_summary(percent)", {
+  expect_message(
+    trial |>
+      tbl_summary(
+        missing = "no",
+        statistic = all_continuous() ~ "{mean} ({sd})",
+        include = c(marker, response, trt), percent = "row"
+      ) |>
+      add_ci(),
+    "function is meant to work with"
+  )
+})

--- a/tests/testthat/test-add_ci.tbl_svysummary.R
+++ b/tests/testthat/test-add_ci.tbl_svysummary.R
@@ -726,3 +726,17 @@ test_that("add_ci() correctly handles dichotomous variables", {
     tbl$cards$add_ci[c("variable", "variable_level")] |> unique() |> deframe()
   )
 })
+
+test_that("add_ci() messaging for tbl_svysummary(percent)", {
+  expect_message({
+    data(api, package = "survey")
+    survey::svydesign(id = ~dnum, weights = ~pw, data = apiclus1, fpc = ~fpc) |>
+      tbl_svysummary(
+        by = "both",
+        include = stype,
+        percent = "row"
+      ) |>
+      add_ci()},
+    "function is meant to work with"
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Adding messaging when `tbl_summary(percent='column')` is not used.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1927

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

