### PR TITLE
Added the `label` argument to functions `tbl_ard_summary()`, `tbl_ard_wide_summary()`, and `tbl_ard_continuous()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.1.9003
+Version: 2.0.1.9004
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ Updates to address regressions in the v2.0.0 release:
 
 * The `tbl_ard_wide_summary()` function no longer requires the results from `cards::ard_attributes()` to create tables. (#1873)
 
+* Added the `label` argument to functions `tbl_ard_summary()`, `tbl_ard_wide_summary()`, and `tbl_ard_continuous()`. (#1850)
+
 # gtsummary 2.0.1
 
 Updates to address regressions in the v2.0.0 release:

--- a/R/tbl_ard_wide_summary.R
+++ b/R/tbl_ard_wide_summary.R
@@ -20,7 +20,8 @@
 #'   trial,
 #'   ard_continuous(variables = age),
 #'   .missing = TRUE,
-#'   .attributes = TRUE
+#'   .attributes = TRUE,
+#'   .total_n = TRUE
 #' ) |>
 #'   tbl_ard_wide_summary()
 #'
@@ -29,7 +30,8 @@
 #'   ard_dichotomous(variables = response),
 #'   ard_categorical(variables = grade),
 #'   .missing = TRUE,
-#'   .attributes = TRUE
+#'   .attributes = TRUE,
+#'   .total_n = TRUE
 #' ) |>
 #'   tbl_ard_wide_summary()
 tbl_ard_wide_summary <- function(cards,
@@ -38,6 +40,7 @@ tbl_ard_wide_summary <- function(cards,
                                           "continuous" = c("{median}", "{p25}, {p75}"),
                                           c("{n}", "{p}%")),
                                  type = NULL,
+                                 label = NULL,
                                  value = NULL,
                                  include = everything()) {
   set_cli_abort_call()
@@ -105,6 +108,10 @@ tbl_ard_wide_summary <- function(cards,
     statistic = statistic,
     include_env = TRUE
   )
+  cards::process_formula_selectors(
+    data = scope_table_body(.list2tb(type, "var_type"), data[include]),
+    label = label
+  )
 
   # add the calling env to the statistics
   statistic <- .add_env_to_list_elements(statistic, env = caller_env())
@@ -126,6 +133,7 @@ tbl_ard_wide_summary <- function(cards,
     cards::bind_ard(
       cards::ard_attributes(data, variables = all_of(include)),
       cards,
+      cards::ard_attributes(data, variables = all_of(names(label)), label = label),
       .update = TRUE,
       .quiet = TRUE
     )

--- a/man/tbl_ard_continuous.Rd
+++ b/man/tbl_ard_continuous.Rd
@@ -9,6 +9,7 @@ tbl_ard_continuous(
   variable,
   include,
   by = NULL,
+  label = NULL,
   statistic = everything() ~ "{median} ({p25}, {p75})"
 )
 }
@@ -24,6 +25,11 @@ Character vector of the categorical variables to}
 
 \item{by}{(\code{string})\cr
 A single variable name of the stratifying variable.}
+
+\item{label}{(\code{\link[=syntax]{formula-list-selector}})\cr
+Used to override default labels in summary table, e.g. \code{list(age = "Age, years")}.
+The default for each variable is the column label attribute, \code{attr(., 'label')}.
+If no label has been set, the column name is used.}
 
 \item{statistic}{(\code{\link[=syntax]{formula-list-selector}})\cr
 Specifies summary statistics to display for each variable.  The default is

--- a/man/tbl_ard_summary.Rd
+++ b/man/tbl_ard_summary.Rd
@@ -10,6 +10,7 @@ tbl_ard_summary(
   statistic = list(all_continuous() ~ "{median} ({p25}, {p75})", all_categorical() ~
     "{n} ({p}\%)"),
   type = NULL,
+  label = NULL,
   missing = c("no", "ifany", "always"),
   missing_text = "Unknown",
   missing_stat = "{N_miss}",
@@ -36,6 +37,11 @@ Specifies the summary type. Accepted value are
 \code{c("continuous", "continuous2", "categorical", "dichotomous")}.
 Continuous summaries may be assigned \code{c("continuous", "continuous2")}, while
 categorical and dichotomous cannot be modified.}
+
+\item{label}{(\code{\link[=syntax]{formula-list-selector}})\cr
+Used to override default labels in summary table, e.g. \code{list(age = "Age, years")}.
+The default for each variable is the column label attribute, \code{attr(., 'label')}.
+If no label has been set, the column name is used.}
 
 \item{missing, missing_text, missing_stat}{Arguments dictating how and if missing values are presented:
 \itemize{
@@ -65,7 +71,8 @@ ard_stack(
   ard_categorical(variables = "AGEGR1"),
   ard_continuous(variables = "AGE"),
   .attributes = TRUE,
-  .missing = TRUE
+  .missing = TRUE,
+  .total_n = TRUE
 ) |>
   tbl_ard_summary()
 
@@ -75,7 +82,8 @@ ard_stack(
   ard_categorical(variables = "AGEGR1"),
   ard_continuous(variables = "AGE"),
   .attributes = TRUE,
-  .missing = TRUE
+  .missing = TRUE,
+  .total_n = TRUE
 ) |>
   tbl_ard_summary(by = ARM)
 }

--- a/man/tbl_ard_wide_summary.Rd
+++ b/man/tbl_ard_wide_summary.Rd
@@ -9,6 +9,7 @@ tbl_ard_wide_summary(
   statistic = switch(type[[1]], continuous = c("{median}", "{p25}, {p75}"), c("{n}",
     "{p}\%")),
   type = NULL,
+  label = NULL,
   value = NULL,
   include = everything()
 )
@@ -28,6 +29,11 @@ Specifies the summary type. Accepted value are
 \code{c("continuous", "continuous2", "categorical", "dichotomous")}.
 If not specified, default type is assigned via
 \code{assign_summary_type()}. See below for details.}
+
+\item{label}{(\code{\link[=syntax]{formula-list-selector}})\cr
+Used to override default labels in summary table, e.g. \code{list(age = "Age, years")}.
+The default for each variable is the column label attribute, \code{attr(., 'label')}.
+If no label has been set, the column name is used.}
 
 \item{value}{(\code{\link[=syntax]{formula-list-selector}})\cr
 Specifies the level of a variable to display on a single row.
@@ -54,7 +60,8 @@ ard_stack(
   trial,
   ard_continuous(variables = age),
   .missing = TRUE,
-  .attributes = TRUE
+  .attributes = TRUE,
+  .total_n = TRUE
 ) |>
   tbl_ard_wide_summary()
 
@@ -63,7 +70,8 @@ ard_stack(
   ard_dichotomous(variables = response),
   ard_categorical(variables = grade),
   .missing = TRUE,
-  .attributes = TRUE
+  .attributes = TRUE,
+  .total_n = TRUE
 ) |>
   tbl_ard_wide_summary()
 }

--- a/tests/testthat/test-tbl_ard_continuous.R
+++ b/tests/testthat/test-tbl_ard_continuous.R
@@ -48,6 +48,36 @@ test_that("tbl_ard_continuous(cards) error messaging", {
   )
 })
 
+test_that("tbl_ard_summary(label) argument works", {
+  expect_equal(
+    cards::bind_ard(
+      # the primary ARD with the results
+      cards::ard_continuous(trial, by = grade, variables = age),
+      # add missing and attributes ARD
+      cards::ard_missing(trial, by = grade, variables = age)
+    ) |>
+      tbl_ard_continuous(variable = "age", include = "grade", label = grade ~ "Updated GRADE!") |>
+      getElement("table_body") |>
+      dplyr::filter(row_type == "label") |>
+      dplyr::pull(label),
+    "Updated GRADE!"
+  )
+
+  expect_equal(
+    cards::bind_ard(
+      # the primary ARD with the results
+      cards::ard_continuous(trial, by = grade, variables = age),
+      # add missing and attributes ARD
+      cards::ard_missing(trial, by = grade, variables = age),
+      cards::ard_attributes(trial, variables = c(grade, age))
+    ) |>
+      tbl_ard_continuous(variable = "age", include = "grade", label = grade ~ "Updated GRADE!") |>
+      getElement("table_body") |>
+      dplyr::filter(row_type == "label") |>
+      dplyr::pull(label),
+    "Updated GRADE!"
+  )
+})
 
 test_that("tbl_ard_continuous(statistic) error messaging", {
   # statistic argument is a long vector

--- a/tests/testthat/test-tbl_ard_summary.R
+++ b/tests/testthat/test-tbl_ard_summary.R
@@ -120,6 +120,36 @@ test_that("tbl_ard_summary(by) messaging", {
   )
 })
 
+test_that("tbl_ard_summary(label) argument works", {
+  expect_equal(
+    cards::ard_stack(
+      data = cards::ADSL,
+      cards::ard_categorical(variables = "AGEGR1"),
+      cards::ard_continuous(variables = "AGE"),
+      .attributes = TRUE
+    ) |>
+      tbl_ard_summary(label = AGE ~ "Updated AGE!") |>
+      getElement("table_body") |>
+      dplyr::filter(row_type == "label") |>
+      dplyr::pull(label),
+    c("Pooled Age Group 1", "Updated AGE!")
+  )
+
+  expect_equal(
+    cards::ard_stack(
+      data = cards::ADSL,
+      cards::ard_categorical(variables = "AGEGR1"),
+      cards::ard_continuous(variables = "AGE"),
+      .attributes = FALSE
+    ) |>
+      tbl_ard_summary(label = AGE ~ "Updated AGE!") |>
+      getElement("table_body") |>
+      dplyr::filter(row_type == "label") |>
+      dplyr::pull(label),
+    c("AGEGR1", "Updated AGE!")
+  )
+})
+
 test_that("tbl_ard_summary(statistic) argument works", {
   ard <-
     cards::ard_stack(

--- a/tests/testthat/test-tbl_ard_wide_summary.R
+++ b/tests/testthat/test-tbl_ard_wide_summary.R
@@ -61,3 +61,33 @@ test_that("tbl_ard_wide_summary(type) messaging", {
       tbl_ard_wide_summary()
   )
 })
+
+test_that("tbl_ard_summary(label) argument works", {
+  expect_equal(
+    cards::ard_stack(
+      trial,
+      cards::ard_continuous(variables = age),
+      .missing = TRUE,
+      .attributes = TRUE,
+      .total_n = TRUE
+    ) |>
+      tbl_ard_wide_summary(label = age ~ "Updated AGE!") |>
+      getElement("table_body") |>
+      dplyr::filter(row_type == "label") |>
+      dplyr::pull(label),
+    "Updated AGE!"
+  )
+
+  expect_equal(
+    cards::ard_stack(
+      trial,
+      cards::ard_continuous(variables = age),
+      .attributes = FALSE
+    ) |>
+      tbl_ard_wide_summary(label = age ~ "Updated AGE!") |>
+      getElement("table_body") |>
+      dplyr::filter(row_type == "label") |>
+      dplyr::pull(label),
+    "Updated AGE!"
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Added the `label` argument to functions `tbl_ard_summary()`, `tbl_ard_wide_summary()`, and `tbl_ard_continuous()`. (#1850)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1850

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] Ensure all package dependencies are installed: `renv::install()`
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

