### PR TITLE
syntactic names fix in `tbl_uvregression(include)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.1.9004
+Version: 2.0.1.9005
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ Updates to address regressions in the v2.0.0 release:
 
   * The default `add_glance_*(glance_fun)` function fixed for `mice` models with class `'mira'`. (#1912)
   * We can again report unweighted statistics in the headers of `tbl_svysummary()` tables. (#1911)
+  * `tbl_uvregression()` properly handles variables specified in the `include` argument with non-syntactic names. (#1932)
   
 ### Other updates
 

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -355,8 +355,8 @@ is_quo_empty <- function(x) {
           cards::eval_capture_conditions(
             glue(
               formula,
-              .envir = list(y = ifelse(is_empty(y), variable, y),
-                            x = ifelse(is_empty(x), variable, x))
+              .envir = list(y = ifelse(is_empty(y), cardx::bt(variable), y),
+                            x = ifelse(is_empty(x), cardx::bt(variable), x))
             ) |>
               stats::as.formula()
           )

--- a/tests/testthat/_snaps/tbl_uvregression.md
+++ b/tests/testthat/_snaps/tbl_uvregression.md
@@ -48,6 +48,24 @@
       1                  Age   189   1.01 0.99, 1.02         0.3
       2 Marker Level (ng/mL)   190   0.91 0.72, 1.15         0.4
 
+---
+
+    Code
+      as.data.frame(tbl_uvregression(dplyr::select(mtcars, `M P G` = mpg, hp), y = hp,
+      method = lm))
+    Output
+        **Characteristic** **N** **Beta** **95% CI** **p-value**
+      1              M P G    32     -8.8  -12, -6.2      <0.001
+
+---
+
+    Code
+      as.data.frame(tbl_uvregression(dplyr::select(mtcars, `M P G` = mpg, hp), x = hp,
+      method = lm))
+    Output
+        **Outcome** **N** **Beta**   **95% CI** **p-value**
+      1       M P G    32    -0.07 -0.09, -0.05      <0.001
+
 # tbl_uvregression(tidy_fun)
 
     Code

--- a/tests/testthat/test-tbl_uvregression.R
+++ b/tests/testthat/test-tbl_uvregression.R
@@ -224,6 +224,20 @@ test_that("tbl_uvregression(include)", {
     ),
     "The `include` argument cannot be empty"
   )
+
+  # ensure non-syntactic names work in the `include` variables
+  expect_snapshot(
+    mtcars |>
+      dplyr::select(`M P G` = mpg, hp) |>
+      tbl_uvregression(y = hp, method = lm) |>
+      as.data.frame()
+  )
+  expect_snapshot(
+    mtcars |>
+      dplyr::select(`M P G` = mpg, hp) |>
+      tbl_uvregression(x = hp, method = lm) |>
+      as.data.frame()
+  )
 })
 
 test_that("tbl_uvregression(tidy_fun)", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* `tbl_uvregression()` properly handles variables specified in the `include` argument with non-syntactic names. (#1932)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1932

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

