### PR TITLE
`add_stat_label(label)` allows NA values 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.1.9006
+Version: 2.0.1.9007
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ Updates to address regressions in the v2.0.0 release:
   * The default `add_glance_*(glance_fun)` function fixed for `mice` models with class `'mira'`. (#1912)
   * We can again report unweighted statistics in the headers of `tbl_svysummary()` tables. (#1911)
   * `tbl_uvregression()` properly handles variables specified in the `include` argument with non-syntactic names. (#1932)
+  * `NA` values can again be specified in `add_stat_label(label)` to suppress a statistic label from being placed. (#1937)
   
 ### Other updates
 

--- a/R/add_stat_label.R
+++ b/R/add_stat_label.R
@@ -116,7 +116,7 @@ add_stat_label.tbl_summary <- function(x, location = c("row", "column"), label =
   imap(
     label[intersect(names(label), x$inputs$type |> discard(~.x == "continuous2") |> names())],
     function(.x, .y) {
-      if (!is_string(.x)) {
+      if (length(.x) > 1L || !(is_string(.x) || is.na(.x))) {
         cli::cli_abort(
           "Elements of the {.arg label} argument for variable {.val {.y}} must be a string of length 1.",
           all = get_cli_abort_call()

--- a/tests/testthat/_snaps/add_stat_label.md
+++ b/tests/testthat/_snaps/add_stat_label.md
@@ -91,6 +91,18 @@
       7                 II             32 (33%)              36 (35%)
       8                III             31 (32%)              33 (32%)
 
+---
+
+    Code
+      as.data.frame(add_stat_label(tbl_summary(trial, type = age ~ "continuous2",
+      include = c(age, response), missing = "no"), label = list(all_continuous() ~
+        "Median (IQR)", all_categorical() ~ NA_character_), location = "row"))
+    Output
+        **Characteristic** **N = 200**
+      1                Age        <NA>
+      2       Median (IQR) 47 (38, 57)
+      3     Tumor Response    61 (32%)
+
 # add_stat_label(label) messaging
 
     Code

--- a/tests/testthat/test-add_stat_label.R
+++ b/tests/testthat/test-add_stat_label.R
@@ -39,6 +39,17 @@ test_that("add_stat_label(label) standard use", {
       add_stat_label(label = age ~ c("Median (IQR)", "Range")) |>
       as.data.frame()
   )
+
+  # passing NA wont add labels to those variables
+  expect_snapshot(
+    trial |>
+      tbl_summary(type = age ~ 'continuous2', include = c(age, response), missing = "no") |>
+      add_stat_label(
+        label = list(all_continuous() ~ 'Median (IQR)', all_categorical() ~ NA_character_),
+        location = "row"
+      ) |>
+      as.data.frame()
+  )
 })
 
 test_that("add_stat_label(label) messaging", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* `NA` values can again be specified in `add_stat_label(label)` to suppress a statistic label from being placed. (#1937)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1937

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

