### PR TITLE
Corrected bug in `tbl_cross(digits)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.1.9010
+Version: 2.0.1.9011
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Updates to address regressions in the v2.0.0 release:
   * We can again report unweighted statistics in the headers of `tbl_svysummary()` tables. (#1911)
   * `tbl_uvregression()` properly handles variables specified in the `include` argument with non-syntactic names. (#1932)
   * `NA` values can again be specified in `add_stat_label(label)` to suppress a statistic label from being placed. (#1937)
+  * Corrected bug in `tbl_cross()` where the `digits` argument was not always being passed accurately to `tbl_summary()`. (#1943)
   
 ### Other updates
 

--- a/R/tbl_cross.R
+++ b/R/tbl_cross.R
@@ -161,7 +161,7 @@ tbl_cross <- function(data,
       statistic = ~ statistic,
       digits =
         case_switch(
-          !is_empty(digits) ~ everything() ~ digits,
+          !is_empty(digits) ~ (everything() ~ digits),
           .default = NULL
         ),
       percent = ifelse(percent == "none", "cell", percent),

--- a/tests/testthat/_snaps/tbl_cross.md
+++ b/tests/testthat/_snaps/tbl_cross.md
@@ -178,3 +178,22 @@
       Error in `tbl_cross()`:
       ! `percent` must be a character vector, not the number 1.
 
+# tbl_cross(digits) works
+
+    Code
+      as.data.frame(tbl_cross(dplyr::bind_rows(rep(list(trial), 11L)), row = grade,
+      col = trt, statistic = "{n}/{N_nonmiss}/{N} ({p}%)", digits = c(0, 0, 0, 4)))
+    Output
+                                    Drug A                       Drug B
+      1 grade                         <NA>                         <NA>
+      2     I   385/1,078/2,200 (17.5000%)   363/1,122/2,200 (16.5000%)
+      3    II   352/1,078/2,200 (16.0000%)   396/1,122/2,200 (18.0000%)
+      4   III   341/1,078/2,200 (15.5000%)   363/1,122/2,200 (16.5000%)
+      5 Total 1,078/1,078/2,200 (49.0000%) 1,122/1,122/2,200 (51.0000%)
+                                Total
+      1                          <NA>
+      2    748/2,200/2,200 (34.0000%)
+      3    748/2,200/2,200 (34.0000%)
+      4    704/2,200/2,200 (32.0000%)
+      5 2,200/2,200/2,200 (100.0000%)
+

--- a/tests/testthat/test-tbl_cross.R
+++ b/tests/testthat/test-tbl_cross.R
@@ -109,3 +109,19 @@ test_that("tbl_cross(percent) errors properly", {
   expect_snapshot(error = TRUE, tbl_cross(trial2, percent = "columsadasn"))
   expect_snapshot(error = TRUE, tbl_cross(trial2, percent = 1))
 })
+
+# tbl_cross(digits) -----------------------------------------------------------
+test_that("tbl_cross(digits) works", {
+  # ensuring the proper formatting is passed along
+  expect_snapshot(
+    tbl_cross(
+      rep(list(trial), 11L) |> dplyr::bind_rows(),
+      row       = grade,
+      col       = trt,
+      statistic = "{n}/{N_nonmiss}/{N} ({p}%)",
+      digits    = c(0, 0, 0, 4)
+    ) |>
+      as.data.frame()
+  )
+})
+


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Corrected bug in `tbl_cross()` where the `digits` argument was not always being passed accurately to `tbl_summary()`. (#1943)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1943

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

