### PR TITLE
Curly brace pairs condition printing fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.1.9011
+Version: 2.0.1.9012
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),
@@ -45,7 +45,7 @@ BugReports: https://github.com/ddsjoberg/gtsummary/issues
 Depends: 
     R (>= 4.2)
 Imports: 
-    cards (>= 0.2.1.9009),
+    cards (>= 0.2.1.9017),
     cli (>= 3.6.1),
     dplyr (>= 1.1.3),
     glue (>= 1.6.2),

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@ Updates to address regressions in the v2.0.0 release:
 
 * Added function `tbl_likert()` for summarizing ordered categorical (or Likert scales) data as well as the associated `add_n.tbl_likert()` S3 method. (#1660)
 
+* Fix where error or warning condition messages containing curly brace pairs could not be printed.
+
 # gtsummary 2.0.1
 
 Updates to address regressions in the v2.0.0 release:

--- a/R/add_p.R
+++ b/R/add_p.R
@@ -261,7 +261,7 @@ calculate_and_add_test_results <- function(x, include, group = NULL, test.args, 
         if (!is.null(lst_captured_results[["warning"]])) {
           cli::cli_inform(c(
             "The following warning was returned in {.fun {calling_fun}} for variable {.val {variable}}",
-            "!" = lst_captured_results[["warning"]]
+            "!" = "{lst_captured_results[['warning']]}"
           ))
         }
 

--- a/R/add_stat.R
+++ b/R/add_stat.R
@@ -242,12 +242,12 @@ eval_fn_safe <- function(variable, tbl, fn) {
 
   if (!is_empty(result[["warning"]])) {
     cli::cli_inform(
-      c("There was a warning for variable {.val {variable}}", "!" = result[["warning"]])
+      c("There was a warning for variable {.val {variable}}", "!" = "{result[['warning']]}")
     )
   }
   if (!is_empty(result[["error"]])) {
     cli::cli_inform(
-      c("There was a error for variable {.val {variable}}", "x" = result[["error"]])
+      c("There was a error for variable {.val {variable}}", "x" = "{result[['error']]}")
     )
   }
 

--- a/R/add_vif.R
+++ b/R/add_vif.R
@@ -37,7 +37,7 @@ add_vif <- function(x, statistic = NULL, estimate_fun = label_style_sigfig(digit
       cardx::ard_car_vif(x$inputs$x)
     )
   if (!is_empty(ard_vif[["error"]])) {
-    cli::cli_abort(ard_vif[["error"]], call = get_cli_abort_call())
+    cli::cli_abort("{ard_vif[['error']]}", call = get_cli_abort_call())
   }
   x$cards$vif <- ard_vif[["result"]]
 

--- a/R/combine_terms.R
+++ b/R/combine_terms.R
@@ -68,7 +68,7 @@ combine_terms <- function(x, formula_update, label = NULL, quiet, ...) {
         i = "There are two common causes for an error. See error message below.",
         "*" = "The model type is not supported by {.fun stats::anova}.",
         "*" = "The number of observations used to estimate the full and reduced models is different.",
-        "x" = anova[["error"]]
+        "x" = "{anova[['error']]}"
         ),
       call = get_cli_abort_call()
     )

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -301,14 +301,14 @@ is_quo_empty <- function(x) {
       if (!is_empty(tbl_i[["error"]])) {
         cli::cli_abort(
           c("There was an {cli::col_red('error')} running {.fun tbl_regression} for variable {.val {variable}}. See message below.",
-            "x" = tbl_i[["error"]]),
+            "x" = "{tbl_i[['error']]}"),
           call = get_cli_abort_call()
         )
       }
       if (!is_empty(tbl_i[["warning"]])) {
         cli::cli_inform(
           c("There was a {cli::col_yellow('warning')} running {.fun tbl_regression} for variable {.val {variable}}. See message below.",
-            "!" = tbl_i[["warning"]])
+            "!" = "{tbl_i[['warning']]}")
         )
       }
 
@@ -329,14 +329,14 @@ is_quo_empty <- function(x) {
       if (!is_empty(model_i[["error"]])) {
         cli::cli_abort(
           c("There was an {cli::col_red('error')} constructing the model for variable {.val {variable}}. See message below.",
-            "x" = model_i[["error"]]),
+            "x" = "{model_i[['error']]}"),
           call = get_cli_abort_call()
         )
       }
       if (!is_empty(model_i[["warning"]])) {
         cli::cli_inform(
           c("There was a {cli::col_yellow('warning')} constructing the model for variable {.val {variable}}. See message below.",
-            "!" = model_i[["warning"]])
+            "!" = "{model_i[['warning']]}")
         )
       }
 
@@ -363,7 +363,7 @@ is_quo_empty <- function(x) {
         if (!is_empty(formula_i[["error"]])) {
           cli::cli_abort(
             c("There was an error constructing the formula for variable {.val {variable}}. See message below.",
-              "x" = formula_i[["error"]]),
+              "x" = "{formula_i[['error']]}"),
             call = get_cli_abort_call()
           )
         }

--- a/tests/testthat/_snaps/add_overall.tbl_ard_summary.md
+++ b/tests/testthat/_snaps/add_overall.tbl_ard_summary.md
@@ -1,0 +1,8 @@
+# add_overall.tbl_summary() errors
+
+    Code
+      add_overall(tbl_ard_summary(ard_overall), cards = ard_overall)
+    Condition
+      Error:
+      ! object 'ard_overall' not found
+

--- a/tests/testthat/_snaps/add_stat.md
+++ b/tests/testthat/_snaps/add_stat.md
@@ -38,3 +38,38 @@
       Error in `add_stat()`:
       ! The `x` argument must be class <tbl_summary/tbl_svysummary/tbl_continuous>, not a data frame.
 
+# add_stat() with curly braces in errors/warnings
+
+    Code
+      curly_warning <- (function(x, ...) {
+        warning("{curly} warning")
+        10
+      })
+      as.data.frame(add_stat(tbl, fns = ~curly_warning))
+    Message
+      There was a warning for variable "age"
+      ! {curly} warning
+      There was a warning for variable "marker"
+      ! {curly} warning
+    Output
+          **Characteristic** **Drug A**  \nN = 98 **Drug B**  \nN = 102 add_stat_1
+      1                  Age          46 (37, 60)           48 (39, 56)       10.0
+      2 Marker Level (ng/mL)    0.84 (0.23, 1.60)     0.52 (0.18, 1.21)       10.0
+
+---
+
+    Code
+      curly_error <- (function(x, ...) {
+        stop("{curly} error")
+      })
+      as.data.frame(add_stat(tbl, fns = ~curly_error))
+    Message
+      There was a error for variable "age"
+      x {curly} error
+      There was a error for variable "marker"
+      x {curly} error
+    Output
+          **Characteristic** **Drug A**  \nN = 98 **Drug B**  \nN = 102 add_stat_1
+      1                  Age          46 (37, 60)           48 (39, 56)       <NA>
+      2 Marker Level (ng/mL)    0.84 (0.23, 1.60)     0.52 (0.18, 1.21)       <NA>
+

--- a/tests/testthat/test-add_stat.R
+++ b/tests/testthat/test-add_stat.R
@@ -241,4 +241,22 @@ test_that("add_stat() with tbl_svysummary()", {
   )
 })
 
+test_that("add_stat() with curly braces in errors/warnings", {
+  expect_snapshot({
+    curly_warning <- \(x, ...) {
+      warning("{curly} warning"); 10
+    }
+    tbl |>
+      add_stat(fns = ~ curly_warning) |>
+      as.data.frame()
+  })
 
+  expect_snapshot({
+    curly_error <- \(x, ...) {
+      stop("{curly} error")
+    }
+    tbl |>
+      add_stat(fns = ~ curly_error) |>
+      as.data.frame()
+  })
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fix where error or warning condition messages containing curly brace pairs could not be printed.

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

