### PR TITLE
Migrating gt->PDF line breaking code to `as_gt()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.2.9000
+Version: 2.0.2.9001
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Headers in {gt} tables being exported to PDF do not support the `\n` line breaker. Previously, line breakers were stripped from the header in the `print.gtsummary()` S3 method. But this did not apply to users utilizing `as_gt()` to further customize their tables. As a result, the line breaking strip has been migrated to `as_gt()`. (#1960)
+
 # gtsummary 2.0.2
 
 Updates to address regressions in the v2.0.0 release:

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -225,6 +225,16 @@ table_styling_to_gt_calls <- function(x, ...) {
     set_names(x$table_styling$header$column) %>%
     {call2(expr(gt::cols_label), !!!.)} # styler: off
 
+  # remove_line_breaks ---------------------------------------------------------
+  # We include line breaks in many tables by default in the headers
+  # This removes them if rendering to PDF. Hopefully we can remove this soon.
+  gt_calls[["remove_line_breaks"]] <-
+    case_switch(
+      knitr::is_latex_output() ~
+        expr(gt::cols_label_with(fn = function(x) gsub(x = x, pattern = "\\n(?!\\\\)", replacement = "", fixed = FALSE, perl = TRUE)))
+    )
+
+
   # tab_footnote ---------------------------------------------------------------
   if (nrow(x$table_styling$footnote) == 0 &&
     nrow(x$table_styling$footnote_abbrev) == 0) {

--- a/R/print.R
+++ b/R/print.R
@@ -62,12 +62,6 @@ knit_print.gtsummary <- function(x,
     "tibble" = as_tibble(x)
   )
 
-  # remove_line_breaks
-  if (print_engine == "gt" && knitr::is_latex_output()) {
-    res <- res |>
-        gt::cols_label_with(fn = function(x) str_replace_all(x, pattern = "\\n(?!\\\\)", replacement = ""))
-  }
-
   knitr::knit_print(res)
 }
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Headers in {gt} tables being exported to PDF do not support the `\n` line breaker. Previously, line breakers were stripped from the header in the `print.gtsummary()` S3 method. But this did not apply to users utilizing `as_gt()` to further customize their tables. As a result, the line breaking strip has been migrated to `as_gt()`. (#1960)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1960 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] Ensure all package dependencies are installed: `renv::install()`
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] Increment the version number using `usethis::use_version(which = "dev")` 
- [x] Run `usethis::use_spell_check()` again
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge".

