### PR TITLE
Removed the `"tbl_summary-arg:statistic"` theme from `tbl_continuous()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.2.9001
+Version: 2.0.2.9002
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Headers in {gt} tables being exported to PDF do not support the `\n` line breaker. Previously, line breakers were stripped from the header in the `print.gtsummary()` S3 method. But this did not apply to users utilizing `as_gt()` to further customize their tables. As a result, the line breaking strip has been migrated to `as_gt()`. (#1960)
 
+* Removed the `"tbl_summary-arg:statistic"` theme that was incorrectly added to `tbl_continuous()`.
+
 # gtsummary 2.0.2
 
 Updates to address regressions in the v2.0.0 release:

--- a/R/tbl_continuous.R
+++ b/R/tbl_continuous.R
@@ -64,11 +64,7 @@ tbl_continuous <- function(data,
   # processed arguments are saved into this env
   cards::process_formula_selectors(
     data = scope_table_body(.list2tb(rep_named(include, list("categorical")), "var_type"), data[include]),
-    statistic =
-      case_switch(
-        missing(statistic) ~ get_theme_element("tbl_summary-arg:statistic", default = statistic),
-        .default = statistic
-      ),
+    statistic = statistic,
     include_env = TRUE
   )
   # add the calling env to the statistics


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Removed the `"tbl_summary-arg:statistic"` theme that was incorrectly added to `tbl_continuous()`.


--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

