### PR TITLE
Removed `add_overall.tbl_ard_summary(digits)` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.2.9003
+Version: 2.0.2.9005
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Added `add_stat_label.tbl_ard_summary()` method. (#1969)
 
+* Removed documentation for the `add_overall.tbl_ard_summary(digits)` argument, which was never meant to be a part of this function. (#1975)
+
 # gtsummary 2.0.2
 
 Updates to address regressions in the v2.0.0 release:

--- a/R/add_overall_ard.R
+++ b/R/add_overall_ard.R
@@ -15,9 +15,6 @@
 #' @param statistic ([`formula-list-selector`][syntax])\cr
 #'   Override the statistic argument in initial `tbl_*` function
 #'   call. Default is `NULL`.
-#' @param digits ([`formula-list-selector`][syntax])\cr
-#'   Override the digits argument in initial `tbl_*` function
-#'   call. Default is `NULL`.
 #' @inheritParams rlang::args_dots_empty
 #'
 #' @author Daniel D. Sjoberg
@@ -60,8 +57,7 @@ add_overall.tbl_ard_summary <- function(x,
                                         cards,
                                         last = FALSE,
                                         col_label = "**Overall**",
-                                        statistic = NULL,
-                                        digits = NULL, ...) {
+                                        statistic = NULL, ...) {
   set_cli_abort_call()
   check_dots_empty()
   check_not_missing(cards)
@@ -80,7 +76,7 @@ add_overall.tbl_ard_summary <- function(x,
     last = last,
     col_label = col_label,
     statistic = statistic,
-    digits = digits,
+    digits = NULL,
     call = c(x$call_list, list(add_overall = match.call())),
     calling_fun = names(x$call_list)[1]
   )

--- a/man/add_overall_ard.Rd
+++ b/man/add_overall_ard.Rd
@@ -11,7 +11,6 @@
   last = FALSE,
   col_label = "**Overall**",
   statistic = NULL,
-  digits = NULL,
   ...
 )
 }
@@ -31,10 +30,6 @@ String indicating the column label. Default is \code{"**Overall**"}}
 
 \item{statistic}{(\code{\link[=syntax]{formula-list-selector}})\cr
 Override the statistic argument in initial \verb{tbl_*} function
-call. Default is \code{NULL}.}
-
-\item{digits}{(\code{\link[=syntax]{formula-list-selector}})\cr
-Override the digits argument in initial \verb{tbl_*} function
 call. Default is \code{NULL}.}
 
 \item{...}{These dots are for future extensions and must be empty.}


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Removed documentation for the `add_overall.tbl_ard_summary(digits)` argument, which was never meant to be a part of this function. (#1975)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1975

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] Ensure all package dependencies are installed: `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

