### PR TITLE
Migrate `tbl_survfit(conf.level)` argument to data frame method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Bug fix in `add_p.tbl_survfit()` when the original call included `tbl_survfit(type)` specification. (#2002)
 
+* Migrated the `tbl_survfit.list(conf.level)` up to `tbl_survfit.data.frame(conf.level)` where the confidence level is passed to `survival::survfit()`.
+
 * Update in `tbl_ard_summary()` to better handle non-standard ARDs (i.e. not our typical continuous or categorical summaries) by assigning them a default summary type. (#1991)
 
 * Made the `oneway.test()` available in `add_p.tbl_continuous()`. (#1970)

--- a/R/tbl_survfit.R
+++ b/R/tbl_survfit.R
@@ -117,11 +117,12 @@ tbl_survfit.survfit <- function(x, ...) {
 
 #' @export
 #' @rdname tbl_survfit
-tbl_survfit.data.frame <- function(x, y, include = everything(), ...) {
+tbl_survfit.data.frame <- function(x, y, include = everything(), conf.level = 0.95, ...) {
   set_cli_abort_call()
   check_pkg_installed("survival", reference_pkg = "cardx")
 
   # process inputs -------------------------------------------------------------
+  check_scalar_range(conf.level, range = c(0, 1))
   # convert to a string, in case it wasn't passed this way originally
   y <- .process_x_and_y_args_as_string(x, enquo(y))
   cards::process_selectors(x, include = {{ include }})
@@ -145,7 +146,8 @@ tbl_survfit.data.frame <- function(x, y, include = everything(), ...) {
           data = x,
           formula = stats::reformulate(termlabels = cardx::bt(variable), response = y),
           method = "survfit",
-          package = "survival"
+          package = "survival",
+          method.args = list(conf.int = conf.level)
         )
       }
     ) |>
@@ -165,7 +167,6 @@ tbl_survfit.list <- function(x,
                              label_header = ifelse(!is.null(times), "**Time {time}**", "**{style_sigfig(prob, scale=100)}% Percentile**"),
                              estimate_fun = ifelse(!is.null(times), label_style_percent(symbol=TRUE), label_style_sigfig()),
                              missing = "--",
-                             conf.level = 0.95,
                              type = NULL,
                              reverse = FALSE,
                              quiet = TRUE, ...) {
@@ -224,7 +225,6 @@ tbl_survfit.list <- function(x,
   check_string(label_header)
   estimate_fun <- as_function(estimate_fun)
   missing <- ifelse(missing(missing), "\U2014", check_string(missing))
-  check_scalar_range(conf.level, range = c(0, 1))
   if (!is_empty(type)) type <- arg_match(type, values = c("survival", "risk", "cumhaz"))
 
   tbl_survfit_inputs <- as.list(environment())

--- a/man/tbl_survfit.Rd
+++ b/man/tbl_survfit.Rd
@@ -11,7 +11,7 @@ tbl_survfit(x, ...)
 
 \method{tbl_survfit}{survfit}(x, ...)
 
-\method{tbl_survfit}{data.frame}(x, y, include = everything(), ...)
+\method{tbl_survfit}{data.frame}(x, y, include = everything(), conf.level = 0.95, ...)
 
 \method{tbl_survfit}{list}(
   x,
@@ -24,7 +24,6 @@ tbl_survfit(x, ...)
   estimate_fun = ifelse(!is.null(times), label_style_percent(symbol = TRUE),
     label_style_sigfig()),
   missing = "--",
-  conf.level = 0.95,
   type = NULL,
   reverse = FALSE,
   quiet = TRUE,
@@ -44,6 +43,9 @@ is called directly.}
 \item{y}{outcome call, e.g. \code{y = Surv(ttdeath, death)}}
 
 \item{include}{Variable to include as stratifying variables.}
+
+\item{conf.level}{(scalar \code{numeric})\cr ]
+Confidence level for confidence intervals. Default is \code{0.95}}
 
 \item{times}{(\code{numeric})\cr
 a vector of times for which to return survival probabilities.}
@@ -72,9 +74,6 @@ survival times}
 
 \item{missing}{(\code{string})\cr
 text to fill when estimate is not estimable. Default is \code{"--"}}
-
-\item{conf.level}{(scalar \code{numeric})\cr ]
-Confidence level for confidence intervals. Default is \code{0.95}}
 
 \item{type}{(\code{string} or \code{NULL})\cr
 type of statistic to report. Available for Kaplan-Meier time estimates only, otherwise \code{type}


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Migrated the `tbl_survfit.list(conf.level)` up to `tbl_survfit.data.frame(conf.level)` where the confidence level is passed to `survival::survfit()`.

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

