### PR TITLE
Separate internal hierarchy processing from summary functions

### DIFF
--- a/R/brdg_hierarchical.R
+++ b/R/brdg_hierarchical.R
@@ -137,7 +137,7 @@ brdg_hierarchical <- function(cards,
 
   # add info to x$table_styling$header for dynamic headers ---------------------
   noby_groups <- cards |> select(cards::all_ard_groups()) |> names() |> setdiff(by_groups)
-  x <- .add_table_styling_stats(x, cards = cards |> select(-noby_groups), by = by)
+  x <- .add_table_styling_stats(x, cards = cards |> select(-all_of(noby_groups)), by = by)
 
   # adding styling -------------------------------------------------------------
   x <- x |>

--- a/R/brdg_hierarchical.R
+++ b/R/brdg_hierarchical.R
@@ -136,7 +136,8 @@ brdg_hierarchical <- function(cards,
   x <- .create_gtsummary_object(table_body)
 
   # add info to x$table_styling$header for dynamic headers ---------------------
-  x <- .add_table_styling_stats_hierarchical(x, cards = cards, by = by)
+  noby_groups <- cards |> select(cards::all_ard_groups()) |> names() |> setdiff(by_groups)
+  x <- .add_table_styling_stats(x, cards = cards |> select(-noby_groups), by = by)
 
   # adding styling -------------------------------------------------------------
   x <- x |>
@@ -367,97 +368,6 @@ pier_summary_hierarchical <- function(cards,
   }
 
   df_result_levels
-}
-
-.add_table_styling_stats_hierarchical <- function(x, cards, by) {
-  if (is_empty(by)) {
-    x$table_styling$header$modify_stat_level <- translate_string("Overall")
-
-    # add overall N to x$table_styling$header
-    lst_total_n <- cards::get_ard_statistics(cards, .data$variable %in% "..ard_total_n..")
-    if ("N" %in% names(lst_total_n)) {
-      x$table_styling$header <-
-        x$table_styling$header |>
-        dplyr::mutate(
-          modify_stat_N = lst_total_n[["N"]],
-          modify_stat_n = .data$modify_stat_N,
-          modify_stat_p = 1
-        )
-    }
-  }
-  # add by variable stats
-  else {
-    df_by_stats <- cards |>
-      dplyr::filter(
-        .data$variable %in% .env$by,
-        .data$stat_name %in% c("N", "n", "p")
-      )
-    by_gps <- paste0("group", seq_along(by), c("", "_level"))
-
-    # if no tabulation of the 'by' variable provided, just return the 'by' levels
-    if (nrow(df_by_stats) == 0L) {
-      df_by_stats_wide <-
-        cards |>
-        dplyr::select(column = "gts_column", modify_stat_level = "group1_level") |>
-        dplyr::distinct() |>
-        dplyr::filter(!is.na(.data$column) & !map_lgl(.data$modify_stat_level, is.null)) |>
-        dplyr::mutate(across(everything(), ~unlist(.) |> as.character()))
-    }
-    # otherwise prepare the tabulation stats
-    else {
-      df_by_stats_wide <-
-        df_by_stats |>
-        dplyr::filter(.data$stat_name %in% c("N", "n", "p")) |>
-        dplyr::select(cards::all_ard_variables(), "stat_name", "stat") |>
-        dplyr::left_join(
-          cards |>
-            dplyr::select(by_gps, "gts_column") |>
-            dplyr::filter(!is.na(.data$gts_column)) |>
-            dplyr::distinct() |>
-            dplyr::rename(variable = "group1", variable_level = "group1_level"),
-          by = c("variable", "variable_level")
-        ) %>%
-        dplyr::bind_rows(
-          dplyr::select(., "variable_level", "gts_column", stat = "variable_level") |>
-            dplyr::mutate(stat_name = "level") |>
-            dplyr::distinct()
-        ) |>
-        tidyr::pivot_wider(
-          id_cols = "gts_column",
-          names_from = "stat_name",
-          values_from = "stat"
-        ) |>
-        dplyr::mutate(
-          dplyr::across(-"gts_column", unlist),
-          dplyr::across("level", as.character)
-        ) |>
-        dplyr::rename_with(
-          function(x) paste0("modify_stat_", x),
-          .cols = -"gts_column"
-        ) |>
-        dplyr::rename(column = "gts_column")
-    }
-
-    # add the stats here to the header data frame
-    x$table_styling$header <-
-      x$table_styling$header |>
-      dplyr::left_join(
-        df_by_stats_wide,
-        by = "column"
-      ) |>
-      tidyr::fill(any_of(c("modify_stat_N")), .direction = "updown")
-  }
-
-  # re-ording the columns
-  x$table_styling$header <-
-    x$table_styling$header |>
-    dplyr::relocate(
-      any_of(c("modify_stat_level", "modify_stat_N", "modify_stat_n", "modify_stat_p")),
-      .before = last_col()
-    )
-
-  # return final object
-  x
 }
 
 .construct_hierarchical_footnote <- function(card, include, statistic, type) {

--- a/R/brdg_hierarchical.R
+++ b/R/brdg_hierarchical.R
@@ -136,7 +136,7 @@ brdg_hierarchical <- function(cards,
   x <- .create_gtsummary_object(table_body)
 
   # add info to x$table_styling$header for dynamic headers ---------------------
-  x <- .add_table_styling_stats(x, cards = cards, by = by, hierarchical = TRUE)
+  x <- .add_table_styling_stats_hierarchical(x, cards = cards, by = by)
 
   # adding styling -------------------------------------------------------------
   x <- x |>
@@ -367,6 +367,97 @@ pier_summary_hierarchical <- function(cards,
   }
 
   df_result_levels
+}
+
+.add_table_styling_stats_hierarchical <- function(x, cards, by) {
+  if (is_empty(by)) {
+    x$table_styling$header$modify_stat_level <- translate_string("Overall")
+
+    # add overall N to x$table_styling$header
+    lst_total_n <- cards::get_ard_statistics(cards, .data$variable %in% "..ard_total_n..")
+    if ("N" %in% names(lst_total_n)) {
+      x$table_styling$header <-
+        x$table_styling$header |>
+        dplyr::mutate(
+          modify_stat_N = lst_total_n[["N"]],
+          modify_stat_n = .data$modify_stat_N,
+          modify_stat_p = 1
+        )
+    }
+  }
+  # add by variable stats
+  else {
+    df_by_stats <- cards |>
+      dplyr::filter(
+        .data$variable %in% .env$by,
+        .data$stat_name %in% c("N", "n", "p")
+      )
+    by_gps <- paste0("group", seq_along(by), c("", "_level"))
+
+    # if no tabulation of the 'by' variable provided, just return the 'by' levels
+    if (nrow(df_by_stats) == 0L) {
+      df_by_stats_wide <-
+        cards |>
+        dplyr::select(column = "gts_column", modify_stat_level = "group1_level") |>
+        dplyr::distinct() |>
+        dplyr::filter(!is.na(.data$column) & !map_lgl(.data$modify_stat_level, is.null)) |>
+        dplyr::mutate(across(everything(), ~unlist(.) |> as.character()))
+    }
+    # otherwise prepare the tabulation stats
+    else {
+      df_by_stats_wide <-
+        df_by_stats |>
+        dplyr::filter(.data$stat_name %in% c("N", "n", "p")) |>
+        dplyr::select(cards::all_ard_variables(), "stat_name", "stat") |>
+        dplyr::left_join(
+          cards |>
+            dplyr::select(by_gps, "gts_column") |>
+            dplyr::filter(!is.na(.data$gts_column)) |>
+            dplyr::distinct() |>
+            dplyr::rename(variable = "group1", variable_level = "group1_level"),
+          by = c("variable", "variable_level")
+        ) %>%
+        dplyr::bind_rows(
+          dplyr::select(., "variable_level", "gts_column", stat = "variable_level") |>
+            dplyr::mutate(stat_name = "level") |>
+            dplyr::distinct()
+        ) |>
+        tidyr::pivot_wider(
+          id_cols = "gts_column",
+          names_from = "stat_name",
+          values_from = "stat"
+        ) |>
+        dplyr::mutate(
+          dplyr::across(-"gts_column", unlist),
+          dplyr::across("level", as.character)
+        ) |>
+        dplyr::rename_with(
+          function(x) paste0("modify_stat_", x),
+          .cols = -"gts_column"
+        ) |>
+        dplyr::rename(column = "gts_column")
+    }
+
+    # add the stats here to the header data frame
+    x$table_styling$header <-
+      x$table_styling$header |>
+      dplyr::left_join(
+        df_by_stats_wide,
+        by = "column"
+      ) |>
+      tidyr::fill(any_of(c("modify_stat_N")), .direction = "updown")
+  }
+
+  # re-ording the columns
+  x$table_styling$header <-
+    x$table_styling$header |>
+    dplyr::relocate(
+      any_of(c("modify_stat_level", "modify_stat_N", "modify_stat_n", "modify_stat_p")),
+      .before = last_col()
+    )
+
+  # return final object
+  x
 }
 
 .construct_hierarchical_footnote <- function(card, include, statistic, type) {

--- a/R/brdg_summary.R
+++ b/R/brdg_summary.R
@@ -540,7 +540,7 @@ pier_summary_missing_row <- function(cards,
     )
 }
 
-.add_table_styling_stats <- function(x, cards, by, hierarchical = FALSE) {
+.add_table_styling_stats <- function(x, cards, by) {
   if (is_empty(by)) {
     x$table_styling$header$modify_stat_level <- translate_string("Overall")
 
@@ -593,7 +593,7 @@ pier_summary_missing_row <- function(cards,
         dplyr::select(cards::all_ard_variables(), "stat_name", "stat") |>
         dplyr::left_join(
           cards |>
-            dplyr::select(if (hierarchical) by_gps else cards::all_ard_groups(), "gts_column") |>
+            dplyr::select(cards::all_ard_groups(), "gts_column") |>
             dplyr::filter(!is.na(.data$gts_column)) |>
             dplyr::distinct() |>
             dplyr::rename(variable = "group1", variable_level = "group1_level"),

--- a/R/brdg_summary.R
+++ b/R/brdg_summary.R
@@ -574,7 +574,6 @@ pier_summary_missing_row <- function(cards,
         .data$variable %in% .env$by,
         .data$stat_name %in% c("N", "n", "p", "N_unweighted", "n_unweighted", "p_unweighted")
       )
-    by_gps <- paste0("group", seq_along(by), c("", "_level"))
 
     # if no tabulation of the 'by' variable provided, just return the 'by' levels
     if (nrow(df_by_stats) == 0L) {

--- a/R/tbl_ard_hierarchical.R
+++ b/R/tbl_ard_hierarchical.R
@@ -76,7 +76,7 @@ tbl_ard_hierarchical <- function(cards,
   cards::process_selectors(data[variables], include = {{ include }})
 
   # add the gtsummary column names to ARD data frame ---------------------------
-  cards <- .add_gts_column_to_cards_summary(cards, variables, by, hierarchical = TRUE)
+  cards <- .add_gts_column_to_cards_hierarchical(cards, variables, by)
 
   # save arguments
   tbl_ard_hierarchical_inputs <- as.list(environment())

--- a/R/tbl_hierarchical.R
+++ b/R/tbl_hierarchical.R
@@ -296,7 +296,7 @@ internal_tbl_hierarchical <- function(data,
   cards$stat_label <- translate_vector(cards$stat_label)
 
   # add the gtsummary column names to ARD data frame ---------------------------
-  cards <- .add_gts_column_to_cards_summary(cards, variables, by, hierarchical = TRUE)
+  cards <- .add_gts_column_to_cards_hierarchical(cards, variables, by)
 
   # fill in missing labels -----------------------------------------------------
   default_label <- sapply(
@@ -409,4 +409,28 @@ internal_tbl_hierarchical <- function(data,
       total_n = is_empty(by) && !is_empty(denominator)
     )
   }
+}
+
+.add_gts_column_to_cards_hierarchical <- function(cards, variables, by) {
+  # adding the name of the column the stats will populate
+  if (is_empty(by)) {
+    cards$gts_column <-
+      ifelse(
+        !cards$context %in% "attributes" & !cards$variable %in% "..ard_total_n..",
+        "stat_0",
+        NA_character_
+      )
+  } else {
+    cards <- cards |>
+      dplyr::group_by(.data$group1_level) |>
+      dplyr::mutate(gts_column = paste0("stat_", dplyr::cur_group_id()))
+
+    # process overall row
+    cards[cards$variable %in% by, ] <- cards[cards$variable %in% by, ] |>
+      dplyr::group_by(.data$variable_level) |>
+      dplyr::mutate(gts_column = paste0("stat_", dplyr::cur_group_id())) |>
+      dplyr::ungroup()
+  }
+
+  cards
 }

--- a/R/tbl_summary.R
+++ b/R/tbl_summary.R
@@ -426,7 +426,7 @@ tbl_summary <- function(data,
   x
 }
 
-.add_gts_column_to_cards_summary <- function(cards, variables, by, hierarchical = FALSE) {
+.add_gts_column_to_cards_summary <- function(cards, variables, by) {
   if ("gts_column" %in% names(cards)) {
     cli::cli_inform("The {.val gts_column} column is alread present. Defining the column has been skipped.")
     return(cards)
@@ -440,16 +440,6 @@ tbl_summary <- function(data,
         "stat_0",
         NA_character_
       )
-  } else if (hierarchical) { # disregard hierarchies, only check by variable
-    cards <- cards |>
-      dplyr::group_by(.data$group1_level) |>
-      dplyr::mutate(gts_column = paste0("stat_", dplyr::cur_group_id()))
-
-    # process overall row
-    cards[cards$variable %in% by, ] <- cards[cards$variable %in% by, ] |>
-      dplyr::group_by(.data$variable_level) |>
-      dplyr::mutate(gts_column = paste0("stat_", dplyr::cur_group_id())) |>
-      dplyr::ungroup()
   } else {
     # styler: off
     cards <-


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Created separate internal processing function `.add_gts_column_to_cards_hierarchical()` from `.add_gts_column_to_cards_summary()` and removed `hierarchical` argument from internal function `.add_table_styling_stats()`.

Closes #2033 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

