### PR TITLE
fix in `add_ci.tbl_svysummary()` for factor variables where order was alphabetical instead of the factor levels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Bug fix in `add_ci.tbl_svysummary()` for factor variables where order was alphabetical instead of the factor levels. (#2036)
+
 # gtsummary 2.0.3
 
 ### New Features and Functions

--- a/R/add_ci.R
+++ b/R/add_ci.R
@@ -219,7 +219,16 @@ brdg_add_ci <- function(x, pattern, statistic, include, conf.level, updated_call
         .y
       }
     ) |>
-    dplyr::bind_rows()
+    dplyr::bind_rows() %>%
+    # ensuring it appears in the original order (issue with survey data GH #2036)
+    dplyr::left_join(
+      x = x$cards$add_ci |>
+        dplyr::distinct(dplyr::pick(cards::all_ard_groups(), cards::all_ard_variables())),
+      y = .,
+      by = x$cards$add_ci |>
+        dplyr::select(cards::all_ard_groups(), cards::all_ard_variables()) |>
+        names()
+    )
 
   # format results to merge into primary table ---------------------------------
   df_prepped_for_merge <-


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Bug fix in `add_ci.tbl_svysummary()` for factor variables where order was alphabetical instead of the factor levels. (#2036)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2036

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

