### PR TITLE
`tbl_summary(by)` order of levels in table with encoding issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Bug fix in `add_ci.tbl_svysummary()` for factor variables where order was alphabetical instead of the factor levels. (#2036)
 
+* Addressing encoding issue where `sort()` and `dplyr::arrange()` sorted differently, and the order of the `by` levels was inconsistent in the resulting table. (#2038)
+
 # gtsummary 2.0.3
 
 ### New Features and Functions

--- a/R/tbl_summary.R
+++ b/R/tbl_summary.R
@@ -452,8 +452,8 @@ tbl_summary <- function(data,
           !cards$context %in% "attributes",
         ) |>
           dplyr::select(cards::all_ard_groups(), "variable", "context") |>
-          dplyr::distinct() |>
-          dplyr::arrange(unlist(!!sym("group1_level"))) |>
+          dplyr::distinct() %>%
+          {.[order(unlist(.$group1_level)), ]} |> # styler: off
           dplyr::mutate(
             .by = cards::all_ard_groups(),
             gts_column = paste0("stat_", dplyr::cur_group_id())

--- a/tests/testthat/test-tbl_summary.R
+++ b/tests/testthat/test-tbl_summary.R
@@ -666,3 +666,18 @@ test_that("tbl_summary() data frame column labels are not dropped", {
     "Age"
   )
 })
+
+# addressing issue #2038
+test_that("tbl_summary() test encoding/sorting difference between sort() and dplyr::arrange()", {
+  # before this fix, the columns would print in reverse order, e.g. stat_3, stat_2, stat_1
+  expect_equal(
+    data.frame(
+      groupe_etude = c(rep("Tem", 13), rep("TTA-", 7), rep("TTA+", 18)),
+      tympan_g_inc = rep(1,38)
+    ) |>
+      tbl_summary(by = groupe_etude, include = tympan_g_inc) |>
+      as.data.frame(col_labels = FALSE) |>
+      names(),
+    c("label", "stat_1", "stat_2", "stat_3")
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Addressing encoding issue where `sort()` and `dplyr::arrange()` sorted differently, and the order of the `by` levels was inconsistent in the resulting table. (#2038)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2038 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] PR branch has pulled the most recent updates from main branch.
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

