### PR TITLE
fixed the typo for test argument section of in-line roxygen2 document…

### DIFF
--- a/R/add_p.R
+++ b/R/add_p.R
@@ -68,7 +68,7 @@ add_p <- function(x, ...) {
 #' #### Specified neither `add_p(group)` nor `add_p(adj.vars)`
 #'
 #' - `"wilcox.test"` when `by` variable has two levels and variable is continuous.
-#' - `"krustkal.test"` when `by` variable has more than two levels and variable is continuous.
+#' - `"kruskal.test"` when `by` variable has more than two levels and variable is continuous.
 #' - `"chisq.test.no.correct"` for categorical variables with all expected cell counts >=5,
 #'    and `"fisher.test"` for categorical variables with any expected cell count <5.
 #'

--- a/man/add_p.tbl_summary.Rd
+++ b/man/add_p.tbl_summary.Rd
@@ -73,7 +73,7 @@ The default test used in \code{add_p()} primarily depends on these factors:
 \subsection{Specified neither \code{add_p(group)} nor \code{add_p(adj.vars)}}{
 \itemize{
 \item \code{"wilcox.test"} when \code{by} variable has two levels and variable is continuous.
-\item \code{"krustkal.test"} when \code{by} variable has more than two levels and variable is continuous.
+\item \code{"kruskal.test"} when \code{by} variable has more than two levels and variable is continuous.
 \item \code{"chisq.test.no.correct"} for categorical variables with all expected cell counts >=5,
 and \code{"fisher.test"} for categorical variables with any expected cell count <5.
 }


### PR DESCRIPTION
…ation

Fix #1985

**What changes are proposed in this pull request?**
Fixing the typo inside the test argument section of add_p.R roxygen2 in-line documentation (line 71) from Krustkal to Kruskal so that the package reference documentation on the pkgdown website has the correct test name

**If there is an GitHub issue associated with this pull request, please provide link.**
https://github.com/ddsjoberg/gtsummary/issues/1985

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

