### PR TITLE
Glue delimiters in modify_header

### DIFF
--- a/R/modify.R
+++ b/R/modify.R
@@ -82,7 +82,8 @@ NULL
 #' @name modify
 #' @export
 modify_header <- function(x, ..., text_interpret = c("md", "html"),
-                          quiet, update) {
+                          quiet, update,
+                          glue_open="{", glue_close="}") {
   set_cli_abort_call()
   updated_call_list <- c(x$call_list, list(modify_footnote = match.call()))
 
@@ -109,7 +110,7 @@ modify_header <- function(x, ..., text_interpret = c("md", "html"),
   )
 
   # evaluate the strings with glue
-  dots <- .evaluate_string_with_glue(x, dots)
+  dots <- .evaluate_string_with_glue(x, dots, glue_open=glue_open, glue_close=glue_close)
 
   # updated header meta data
   x <-
@@ -318,7 +319,7 @@ show_header_names <- function(x, include_example, quiet) {
 }
 
 
-.evaluate_string_with_glue <- function(x, dots) {
+.evaluate_string_with_glue <- function(x, dots, glue_open="{", glue_close="}") {
   # only keep values that are in the table_body
   dots <- dots[intersect(names(dots), x$table_styling$header$column)]
 
@@ -342,7 +343,7 @@ show_header_names <- function(x, include_example, quiet) {
         cards::eval_capture_conditions(
           case_switch(
             is.na(value) ~ NA_character_,
-            .default = expr(glue::glue(value))
+            .default = expr(glue::glue(value, .open=glue_open, .close=glue_close))
           ),
           data = df_header_subset
         )


### PR DESCRIPTION
Allows to specify glue delimiters in `modify_header`.

**What changes are proposed in this pull request?**
<< Insert text here that can be directly copied into NEWS.md by your reviewer. >>

**If there is an GitHub issue associated with this pull request, please provide link.**


--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

