### PR TITLE
estimate_fun takes list of formulas

### DIFF
--- a/R/tbl_regression.R
+++ b/R/tbl_regression.R
@@ -109,12 +109,6 @@ tbl_regression.default <- function(x,
 
   check_scalar_logical(exponentiate)
 
-  if (rlang::is_function(estimate_fun)) {
-    lifecycle::deprecate_stop(
-      "1.4.0",
-      "gtsummary::add_difference(estimate_fun = 'must be a list of forumulas')"
-    )
-  }
   if (missing(estimate_fun)) {
     estimate_fun <-
       get_theme_element("tbl_regression-arg:estimate_fun", default = estimate_fun)
@@ -166,7 +160,6 @@ tbl_regression.default <- function(x,
     scope_table_body(table_body),
     estimate_fun = estimate_fun
   )
-  print(eval(formals(asNamespace("gtsummary")[["tbl_regression"]])[["estimate_fun"]]))
   cards::fill_formula_selectors(
     data = scope_table_body(table_body),
     estimate_fun = eval(~ ifelse(exponentiate, label_style_ratio(), label_style_sigfig()))

--- a/R/utils-tbl_regression.R
+++ b/R/utils-tbl_regression.R
@@ -88,8 +88,7 @@ tidy_prep <- function(x, tidy_fun, exponentiate, conf.level, intercept, label,
       columns = any_of("estimate"),
       label = glue("**{estimate_column_labels$label}**") %>% as.character(),
       hide = !"estimate" %in% tidy_columns_to_report,
-      footnote_abbrev = glue("{estimate_column_labels$footnote}") %>% as.character()#,
-      #fmt_fun = estimate_fun
+      footnote_abbrev = glue("{estimate_column_labels$footnote}") %>% as.character()
     ) |>
     modify_table_styling(
       columns = any_of("estimate"),


### PR DESCRIPTION
Let the estimate_fun take a list of formulas instead of a function. Draft close to the code from `add_difference` and `pvalue_fun`.

If the draft is okay I can do the TODO:

- [ ] Change documentation
- [ ] Add to tbl_uvregression
- [ ] Similar changes for pvalue_fun

https://github.com/ddsjoberg/gtsummary/issues/2058


--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

