### PR TITLE
Add missing `skip_if_not(is_pkg_installed(...))` calls to tests

### DIFF
--- a/R/add_global_p.R
+++ b/R/add_global_p.R
@@ -29,7 +29,7 @@
 #' @author Daniel D. Sjoberg
 #' @name add_global_p
 #'
-#' @examplesIf gtsummary:::is_pkg_installed(c("cardx", "broom", "car"))
+#' @examplesIf gtsummary:::is_pkg_installed(c("cardx", "broom", "car", "parameters"))
 #' # Example 1 ----------------------------------
 #' lm(marker ~ age + grade, trial) |>
 #'   tbl_regression() |>

--- a/man/add_global_p.Rd
+++ b/man/add_global_p.Rd
@@ -63,7 +63,7 @@ for model covariates.
 Output from \code{tbl_regression} and \code{tbl_uvregression} objects supported.
 }
 \examples{
-\dontshow{if (gtsummary:::is_pkg_installed(c("cardx", "broom", "car"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (gtsummary:::is_pkg_installed(c("cardx", "broom", "car", "parameters"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # Example 1 ----------------------------------
 lm(marker ~ age + grade, trial) |>
   tbl_regression() |>

--- a/tests/testthat/test-add_global_p.R
+++ b/tests/testthat/test-add_global_p.R
@@ -1,4 +1,6 @@
 skip_on_cran()
+skip_if_not(is_pkg_installed("parameters"))
+
 test_that("add_global_p() works", {
   expect_error(
     lm(age ~ trt, trial) |>

--- a/tests/testthat/test-add_global_p.tbl_regression.R
+++ b/tests/testthat/test-add_global_p.tbl_regression.R
@@ -1,5 +1,5 @@
 skip_on_cran()
-skip_if_not(is_pkg_installed(c("broom.helpers", "car", "aod", "cardx")))
+skip_if_not(is_pkg_installed(c("broom.helpers", "car", "aod", "cardx", "parameters")))
 
 
 test_that("add_global_p.tbl_regression works with standard use", {

--- a/tests/testthat/test-add_global_p.tbl_uvregression.R
+++ b/tests/testthat/test-add_global_p.tbl_uvregression.R
@@ -1,5 +1,5 @@
 skip_on_cran()
-skip_if_not(is_pkg_installed(c("broom.helpers", "car", "aod", "cardx")))
+skip_if_not(is_pkg_installed(c("broom.helpers", "car", "aod", "cardx", "parameters")))
 
 test_that("add_global_p.tbl_uvregression(x)", {
   tbl <- trial |>

--- a/tests/testthat/test-add_p.tbl_summary.R
+++ b/tests/testthat/test-add_p.tbl_summary.R
@@ -437,6 +437,8 @@ test_that("no error with missing data", {
 })
 
 test_that("add_p.tbl_summary() can be run after add_difference()", {
+  skip_if_not(is_pkg_installed("parameters"))
+
   expect_error(
     trial |>
       select(age, trt) |>

--- a/tests/testthat/test-add_stat.R
+++ b/tests/testthat/test-add_stat.R
@@ -228,6 +228,8 @@ test_that("add_stat(location) for 'tbl_continuous'", {
 
 # adding test against a `tbl_svysummary()` object
 test_that("add_stat() with tbl_svysummary()", {
+  skip_if_not(is_pkg_installed("survey"))
+
   return_three_10s <- function(...) rep_len(10, 3)
   expect_equal(
     survey::svydesign(~1, data = trial, weights = ~1) |>

--- a/tests/testthat/test-combine_terms.R
+++ b/tests/testthat/test-combine_terms.R
@@ -51,6 +51,8 @@ test_that("combine_terms(label) works as expected", {
 })
 
 test_that("combine_terms works with add_global_p", {
+  skip_if_not(is_pkg_installed("parameters"))
+
   expect_silent(
     tbl <- lmod |>
       tbl_regression() |>

--- a/tests/testthat/test-separate_p_footnotes.R
+++ b/tests/testthat/test-separate_p_footnotes.R
@@ -1,5 +1,5 @@
 skip_on_cran()
-skip_if_not(is_pkg_installed(c("cardx", "broom")))
+skip_if_not(is_pkg_installed(c("cardx", "broom", "smd")))
 
 test_that("separate_p_footnotes()", {
   tbl <- trial |>
@@ -43,6 +43,8 @@ test_that("separate_p_footnotes() messaging", {
 
 # adding test against a `tbl_svysummary()` object
 test_that("separate_p_footnotes() with tbl_svysummary()", {
+  skip_if_not(is_pkg_installed("survey"))
+
   expect_error(
     survey::svydesign(~1, data = trial, weights = ~1) |>
       tbl_svysummary(by = trt, include = c(age, grade)) |>

--- a/tests/testthat/test-tbl_regression_methods.R
+++ b/tests/testthat/test-tbl_regression_methods.R
@@ -59,7 +59,7 @@ test_that("tbl_regression.mira()", {
 })
 
 test_that("tbl_regression.lmerMod()", {
-  skip_if_not(is_pkg_installed("lme4"))
+  skip_if_not(is_pkg_installed(c("lme4", "broom.mixed")))
 
   expect_snapshot(
     lme4::lmer(mpg ~ hp + (1 | cyl), mtcars) |>

--- a/tests/testthat/test-theme_gtsummary.R
+++ b/tests/testthat/test-theme_gtsummary.R
@@ -194,6 +194,8 @@ test_that("theme_gtsummary_journal('nejm') works", {
 })
 
 test_that("theme_gtsummary_journal('jama') works", {
+  skip_if_not(is_pkg_installed("survey"))
+
   # check that we get
   #  - IQR separated with emdash in table
   #  - pvalues are rounded to 2 places


### PR DESCRIPTION
**What changes are proposed in this pull request?**

* Adds missing packages to `skip_if_not(is_pkg_installed(...))` calls in tests to prevent errors from occurring when tests are run without all suggested packages installed.

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

