### PR TITLE
No longer printing theme names in `with_gtsummary_theme()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.3.9004
+Version: 2.0.3.9005
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* The `with_gtsummary_theme()` has been updated to no longer print theme names when the applied, nor when the original theme is re-applied. (#2031)
+
 * Updated the `theme_gtsummary_journal("jama")` theme to apply changes to `tbl_svysummary()`. (#1964; @vjcatharine)
 
 * Removed `global_pvalue_fun.tidycrr()` as already been migrated to the {tidycmprsk} package. (#1997; @jwoolfolk)

--- a/R/set_gtsummary_theme.R
+++ b/R/set_gtsummary_theme.R
@@ -127,13 +127,13 @@ with_gtsummary_theme <- function(x, expr,
 
   # on exit, restore theme -----------------------------------------------------
   on.exit(reset_gtsummary_theme(), add = TRUE)
-  on.exit(set_gtsummary_theme(current_theme), add = TRUE)
+  on.exit(suppressMessages(set_gtsummary_theme(current_theme)), add = TRUE)
 
   # message ignored theme elements ---------------------------------------------
   .msg_ignored_elements(x, current_theme, msg_ignored_elements)
 
   # add specified theme --------------------------------------------------------
-  set_gtsummary_theme(suppressMessages(x))
+  suppressMessages(set_gtsummary_theme(x))
 
   # evaluate expression
   eval_tidy({{ expr }}, env = env)

--- a/tests/testthat/_snaps/theme_gtsummary.md
+++ b/tests/testthat/_snaps/theme_gtsummary.md
@@ -3,8 +3,6 @@
     Code
       as.data.frame(with_gtsummary_theme(theme_gtsummary_eda(), expr = tbl_summary(
         trial, include = c(age, grade))))
-    Message
-      Setting theme "Exploratory Data Analysis"
     Output
         **Characteristic** **N = 200**
       1                Age        <NA>
@@ -23,8 +21,6 @@
       with_gtsummary_theme(theme_gtsummary_journal("lancet"), expr = as.data.frame(
         modify_column_hide(add_difference(tbl_summary(trial, by = trt, include = marker,
           label = marker ~ "marker", missing = "no")), c("stat_2"))))
-    Message
-      Setting theme "The Lancet"
     Output
         **Characteristic** **Drug A**  \nN = 98 **Difference**    **95% CI**
       1             marker   0·84 (0·23 – 1·60)           0·20 -0·05 to 0·44
@@ -37,8 +33,6 @@
       with_gtsummary_theme(theme_gtsummary_journal("nejm"), expr = as.data.frame(
         modify_column_hide(add_difference(tbl_summary(trial, by = trt, include = age,
           label = age ~ "Age", missing = "no")), c("stat_2"))))
-    Message
-      Setting theme "New England Journal of Medicine"
     Output
         **Characteristic** **Drug A**  \nN = 98 **Difference**  **95% CI**
       1                Age         46 (37 – 60)          -0.44 -4.6 to 3.7
@@ -51,8 +45,6 @@
       with_gtsummary_theme(theme_gtsummary_journal("jama"), expr = as.data.frame(
         modify_column_hide(add_difference(tbl_summary(trial, by = trt, include = age,
           label = age ~ "Age", missing = "no")), c("stat_2"))))
-    Message
-      Setting theme "JAMA"
     Output
         **Characteristic** **Drug A**  \nN = 98 **Difference** **(****95% CI****)**
       1  Age, Median (IQR)         46 (37 – 60)                 -0.44 (-4.6 to 3.7)
@@ -64,8 +56,6 @@
     Code
       with_gtsummary_theme(theme_gtsummary_journal("jama"), expr = as.data.frame(
         tbl_regression(lm(hp ~ am, mtcars))))
-    Message
-      Setting theme "JAMA"
     Output
         **Characteristic** **Beta** **(95% CI)** **p-value**
       1                 am       -33 (-83 to 16)        0.18
@@ -76,8 +66,6 @@
       with_gtsummary_theme(theme_gtsummary_journal("jama"), expr = as.data.frame(
         modify_column_hide(add_difference(tbl_svysummary(svy_trial, by = trt,
           include = age, label = age ~ "Age", missing = "no")), c("stat_2"))))
-    Message
-      Setting theme "JAMA"
     Output
         **Characteristic** **Drug A**  \nN = 98 **Difference** **(****95% CI****)**
       1  Age, Median (IQR)         46 (37 – 60)                  0.44 (-3.7 to 4.6)
@@ -89,8 +77,6 @@
     Code
       with_gtsummary_theme(theme_gtsummary_journal("qjecon"), expr = as.data.frame(
         tbl_regression(lm(mpg ~ factor(cyl) + hp, mtcars))))
-    Message
-      Setting theme "The Quarterly Journal of Economics"
     Output
         **Characteristic** **Beta**  \n**(SE)**
       1        factor(cyl)                 <NA>
@@ -133,10 +119,43 @@
         1L, 1L), msg_ignored_elements = "The following theme elements are temporarilty overwritten: {.val {elements}}.")
     Message
       The following theme elements are temporarilty overwritten: "pkgwide-str:theme_name".
-      Setting theme "My new theme"
-      Setting theme "Compact"
     Output
       [1] TRUE
+    Code
+      reset_gtsummary_theme()
+
+---
+
+    Code
+      theme_gtsummary_language("es")
+    Message
+      Setting theme "language: es"
+    Code
+      with_gtsummary_theme(theme_gtsummary_eda(), expr = as_kable(tbl_summary(trial,
+        include = c(age, grade))))
+    Output
+      
+      
+      |**Característica** | **N = 200** |
+      |:------------------|:-----------:|
+      |Age                |             |
+      |Mediana (Q1, Q3)   | 47 (38, 57) |
+      |Media (DE)         |   47 (14)   |
+      |Min, Max           |    6, 83    |
+      |Desconocido        |     11      |
+      |Grade              |             |
+      |I                  | 68 (34.0%)  |
+      |II                 | 68 (34.0%)  |
+      |III                | 64 (32.0%)  |
+    Code
+      as_kable(tbl_summary(trial, include = age))
+    Output
+      
+      
+      |**Característica** | **N = 200** |
+      |:------------------|:-----------:|
+      |Age                | 47 (38, 57) |
+      |Desconocido        |     11      |
     Code
       reset_gtsummary_theme()
 

--- a/tests/testthat/test-theme_gtsummary.R
+++ b/tests/testthat/test-theme_gtsummary.R
@@ -308,4 +308,16 @@ test_that("with_gtsummary_theme()", {
     )
     reset_gtsummary_theme()
   })
+
+  # check that the theme is reset and a message about the resetting of the theme does not appear
+  expect_snapshot({
+    theme_gtsummary_language("es")
+    with_gtsummary_theme(
+      theme_gtsummary_eda(),
+      expr = trial |> tbl_summary(include = c(age, grade)) |> as_kable()
+    )
+    tbl_summary(trial, include = age) |>
+      as_kable()
+    reset_gtsummary_theme()
+  })
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The `with_gtsummary_theme()` has been updated to no longer print theme names when the applied, nor when the original theme is re-applied. (#2031)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2031

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] PR branch has pulled the most recent updates from main branch.
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

