### PR TITLE
add vcov argument to tidy_wald_test

### DIFF
--- a/R/custom_tidiers.R
+++ b/R/custom_tidiers.R
@@ -283,7 +283,7 @@ tidy_gam <- function(x, conf.int = FALSE, exponentiate = FALSE, conf.level = 0.9
 
 #' @rdname custom_tidiers
 #' @export
-tidy_wald_test <- function(x, tidy_fun = NULL, ...) {
+tidy_wald_test <- function(x, tidy_fun = NULL, vcov = stats::vcov(x), ...) {
   set_cli_abort_call()
   check_pkg_installed(c("aod", "broom.helpers"))
 
@@ -306,7 +306,7 @@ tidy_wald_test <- function(x, tidy_fun = NULL, ...) {
       model_terms_id = rlang::set_names(.data$data[["term_id"]]) %>% list(),
       wald_test =
         aod::wald.test(
-          Sigma = stats::vcov(x),
+          Sigma = vcov,
           b = stats::coef(x),
           Terms = .data$model_terms_id
         ) %>%


### PR DESCRIPTION
**What changes are proposed in this pull request?**
<< Insert text here that can be directly copied into NEWS.md by your reviewer. >>
addition of a vcov argument to tidy_wald_test to allow calculation of p-values via alternative variance-covariance structure (e.g. for robust SEs)

**If there is an GitHub issue associated with this pull request, please provide link.**
#2076 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

