### PR TITLE
Allowing `tbl_summary(percent=c('row','cell'))` in `add_ci()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -86,6 +86,7 @@ Suggests:
     testthat (>= 3.2.0),
     withr (>= 2.5.0),
     workflows (>= 0.2.4)
+Remotes: insightsengineering/cardx@204-ci-denom
 VignetteBuilder: 
     knitr
 Config/Needs/check: hms

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ Suggests:
     broom.helpers (>= 1.17.0),
     broom.mixed (>= 0.2.9),
     car (>= 3.0-11),
-    cardx (>= 0.2.2),
+    cardx (>= 0.2.2.9005),
     cmprsk,
     effectsize (>= 0.6.0),
     emmeans (>= 1.7.3),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.4.9005
+Version: 2.0.4.9006
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ Suggests:
     broom.helpers (>= 1.17.0),
     broom.mixed (>= 0.2.9),
     car (>= 3.0-11),
-    cardx (>= 0.2.2.9005),
+    cardx (>= 0.2.2.9006),
     cmprsk,
     effectsize (>= 0.6.0),
     emmeans (>= 1.7.3),
@@ -86,7 +86,7 @@ Suggests:
     testthat (>= 3.2.0),
     withr (>= 2.5.0),
     workflows (>= 0.2.4)
-Remotes: insightsengineering/cardx@204-ci-denom
+Remotes: insightsengineering/cardx
 VignetteBuilder: 
     knitr
 Config/Needs/check: hms

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * Swapped out `dplyr::rows_update()` with a base R implementation in `tbl_merge()` that allows for tables with mixed types in `x$table_styling$header$modify_*` columns. For example, `tbl_summary()` has integer Ns and `tbl_svysummary()` has double Ns that can now be combined. (#1626)
 
+* The `add_ci.tbl_summary()` function now works with categorical variables that were summarized using `tbl_summary(percent = c('row', 'cell'))`. (#1929)
+
 # gtsummary 2.0.4
 
 ### New Features and Functions

--- a/tests/testthat/test-add_ci.tbl_summary.R
+++ b/tests/testthat/test-add_ci.tbl_summary.R
@@ -801,15 +801,3 @@ test_that("add_ci() correctly handles dichotomous variables", {
   )
 })
 
-test_that("add_ci() messaging for tbl_summary(percent)", {
-  expect_message(
-    trial |>
-      tbl_summary(
-        missing = "no",
-        statistic = all_continuous() ~ "{mean} ({sd})",
-        include = c(marker, response, trt), percent = "row"
-      ) |>
-      add_ci(),
-    "function is meant to work with"
-  )
-})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The `add_ci.tbl_summary()` function now works with categorical variables that were summarized using `tbl_summary(percent = c('row', 'cell'))`. (#1929)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #1929

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

