### PR TITLE
Improving error msg in `tbl_survfit()` when 2 or more stratifying variables are present

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.4.9007
+Version: 2.0.4.9008
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/R/tbl_survfit.R
+++ b/R/tbl_survfit.R
@@ -1,7 +1,10 @@
 #' Survival table
 #'
+#' @description
 #' Function takes a `survfit` object as an argument, and provides a
-#' formatted summary table of the results
+#' formatted summary table of the results.
+#'
+#' No more than one stratifying variable is allowed in each model.
 #'
 #' @param x (`survfit`, `list`, `data.frame`)\cr
 #'   a survfit object, list of survfit objects, or a data frame.
@@ -286,6 +289,7 @@ brdg_survfit <- function(cards,
                          statistic = "{estimate} ({conf.low}, {conf.high})",
                          label = NULL,
                          label_header) {
+  set_cli_abort_call()
   # grab information for the headers -------------------------------------------
   df_header_survfit <- cards[[1]] |>
     dplyr::filter(!.data$context %in% "attributes") |>
@@ -307,7 +311,8 @@ brdg_survfit <- function(cards,
     if (length(cards_names[[i]]) > 1L) {
       cli::cli_abort(
         c("The {.fun tbl_survfit} function supports {.fun survival::survfit} objects with no more than one stratifying variable.",
-          i = "The model is stratified by {.val {cards_names[[i]]}}.")
+          i = "The model is stratified by {.val {cards_names[[i]]}}."),
+        call = get_cli_abort_call()
       )
     }
   }
@@ -413,7 +418,7 @@ brdg_survfit <- function(cards,
 .default_survfit_labels <- function(x) {
   label <- list()
   for (i in seq_along(x)) {
-    variable_i <- x[[i]]$call$formula |> rlang::f_rhs() |> all.vars()
+    variable_i <- x[[i]]$call$formula |> rlang::f_rhs() |> all.vars() |> dplyr::first()
     if (!is_empty(variable_i)) {
       label[[variable_i]] <-
         tryCatch(

--- a/R/tbl_survfit.R
+++ b/R/tbl_survfit.R
@@ -418,7 +418,7 @@ brdg_survfit <- function(cards,
 .default_survfit_labels <- function(x) {
   label <- list()
   for (i in seq_along(x)) {
-    variable_i <- x[[i]]$call$formula |> rlang::f_rhs() |> all.vars() |> dplyr::first()
+    variable_i <- x[[i]]$call$formula |> rlang::f_rhs() |> all.vars() |> dplyr::first() |> discard(is.na)
     if (!is_empty(variable_i)) {
       label[[variable_i]] <-
         tryCatch(

--- a/man/tbl_survfit.Rd
+++ b/man/tbl_survfit.Rd
@@ -91,7 +91,9 @@ Must be one of the following:\tabular{ll}{
 }
 \description{
 Function takes a \code{survfit} object as an argument, and provides a
-formatted summary table of the results
+formatted summary table of the results.
+
+No more than one stratifying variable is allowed in each model.
 }
 \examples{
 \dontshow{if (gtsummary:::is_pkg_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/tests/testthat/_snaps/tbl_survfit.md
+++ b/tests/testthat/_snaps/tbl_survfit.md
@@ -1,0 +1,10 @@
+# tbl_survfit(x) messaging
+
+    Code
+      tbl_survfit(survival::survfit(survival::Surv(ttdeath, death) ~ trt + grade,
+      trial), times = c(12, 24))
+    Condition
+      Error in `tbl_survfit()`:
+      ! The `tbl_survfit()` function supports `survival::survfit()` objects with no more than one stratifying variable.
+      i The model is stratified by "trt" and "grade".
+

--- a/tests/testthat/test-tbl_survfit.R
+++ b/tests/testthat/test-tbl_survfit.R
@@ -237,3 +237,14 @@ test_that("tbl_survfit(conf.level)", {
       style_number()
   )
 })
+
+
+test_that("tbl_survfit(x) messaging", {
+  expect_snapshot(
+    error = TRUE,
+    tbl_survfit(
+      survival::survfit(survival::Surv(ttdeath, death) ~ trt + grade, trial),
+      times = c(12, 24)
+    )
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2117

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

