### PR TITLE
add robust errors to gallery

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,7 +79,6 @@ Suggests:
     parameters (>= 0.20.2),
     parsnip (>= 0.1.7),
     rmarkdown,
-    sandwich,
     smd (>= 0.6.6),
     spelling,
     survey (>= 4.2),
@@ -91,7 +90,7 @@ Remotes: insightsengineering/cardx
 VignetteBuilder: 
     knitr
 Config/Needs/check: hms
-Config/Needs/website: forcats, scales
+Config/Needs/website: forcats, sandwich, scales
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,6 +79,7 @@ Suggests:
     parameters (>= 0.20.2),
     parsnip (>= 0.1.7),
     rmarkdown,
+    sandwich,
     smd (>= 0.6.6),
     spelling,
     survey (>= 4.2),

--- a/vignettes/articles/gallery.Rmd
+++ b/vignettes/articles/gallery.Rmd
@@ -440,14 +440,14 @@ To use robust standard errors in a regression model, the model is prepared use u
 ```{r}
 dat <- trial |> 
   mutate(subject_id = dplyr::row_number(), .by = trt)
-lmod <- lm(response ~ trt + grade, data = dat)
+lmod <- glm(response ~ trt + grade, data = dat, family = binomial(link = "logit"))
 
 cov <- sandwich::vcovCL(lmod, cluster = ~ subject_id, vcov_type = "HC0")
 ```
 
 Once you have the robust variance-covariance matrix, you can use it with `tidy_robust` to calculate adjusted confidence intervals and p-values. 
 
-Robust errors generally have only a small impact on the confidence intervals and p-values. For demonstration purposes, we therefore show 3 digits for confidence intervals and p-values.
+Robust errors generally have only a small impact on the confidence intervals and p-values. For demonstration purposes, we therefore show 2 digits for p-values.
 
 A standard, non-robust regression table can be made as follows:
 
@@ -455,8 +455,8 @@ A standard, non-robust regression table can be made as follows:
 tbl_standard <- 
   tbl_regression(
     lmod,
-    estimate_fun = label_style_sigfig(digits = 3),
-    pvalue_fun = label_style_pvalue(digits = 3)
+    pvalue_fun = label_style_pvalue(digits = 2),
+    exponentiate = TRUE
   )
 tbl_standard
 ```
@@ -467,13 +467,11 @@ In order to use the robust errors, pass the variance-covariance matrix to the `t
 tbl_robust <- 
   tbl_regression(
     lmod,
-    estimate_fun = label_style_sigfig(digits = 3),
-    pvalue_fun = label_style_pvalue(digits = 3),
-    tidy_fun = \(x, ...) tidy_robust(x, vcov = cov))
+    pvalue_fun = label_style_pvalue(digits = 2),
+    exponentiate = TRUE,
+    tidy_fun = \(x, ...) tidy_robust(x, vcov = cov, ...))
 tbl_robust
 ```
-
-Note that depending on your model, you may also need to set other arguments in `tidy_robust` (e.g. exponentiate). 
 
 Comparing the tables side-by-side, we see that the confidence intervals and p-values are very similar.
 

--- a/vignettes/articles/gallery.Rmd
+++ b/vignettes/articles/gallery.Rmd
@@ -491,7 +491,7 @@ tbl_merge(
     tbl_robust |>
       add_global_p(anova_fun = \(x, ...) tidy_wald_test(x, vcov = cov))
   ), 
-  tab_spanner = c("Standard errors", "Robust errors")
+  tab_spanner = c("**Standard errors**", "**Robust errors**")
 )
 ```
 

--- a/vignettes/articles/gallery.Rmd
+++ b/vignettes/articles/gallery.Rmd
@@ -95,6 +95,8 @@ Adding and Modifying Statistics
 
 1. [How do I format a **Wald confidence interval**?](#wald-ci)
 
+1. [How do I use **robust standard errors**?](#use_robust_errors)
+
 <hr>
 
 ## Summary Tables
@@ -429,3 +431,65 @@ trial |>
   ) |> 
   add_significance_stars()
 ```
+
+<hr>
+<a id="use_robust_errors"></a>
+
+To use robust standard errors in a regression model, the model is prepared use usual, and the variance-covariance matrix of the model is modified via an appropriate function, such as `vcovCL` from the sandwich package. 
+
+```{r}
+dat <- trial |> 
+  mutate(subject_id = dplyr::row_number(), .by = trt)
+lmod <- lm(response ~ trt + grade, data = dat)
+
+library(sandwich)
+cov <- vcovCL(lmod, cluster = ~ subject_id, vcov_type = "HC0")
+```
+
+Once you have the robust variance-covariance matrix, you can use it with `tidy_robust` to calculate adjusted confidence intervals and p-values. 
+
+Robust errors generally have only a small impact on the confidence intervals and p-values. For demonstration purposes, we therefore edit the default gtsummary theme to show 3 digits for confidence intervals and p-values.
+
+```{r}
+my_theme <-
+  list(
+    # round large p-values to three places
+    "pkgwide-fn:pvalue_fun" = label_style_pvalue(digits = 3),
+    "pkgwide-fn:prependpvalue_fun" = label_style_pvalue(digits = 3, prepend_p = TRUE),
+    # show more digits in summary statistics
+    "tbl_regression-arg:estimate_fun" = label_style_sigfig(digits = 3)
+  )
+set_gtsummary_theme(my_theme)
+```
+
+In order to use the robust errors, pass the variance-covariance matrix to the `tidy_robust` function, as shown below. The example below shows the non-robust approach, as well as the robust approach so that the values can be compared.
+
+```{r}
+tbl_merge(
+  list(
+    tbl_regression(lmod),
+    tbl_regression(lmod, 
+                   tidy_fun = \(x, ...) tidy_robust(x, vcov = cov))
+  ), 
+  tab_spanner = c("Standard errors", "Robust errors")
+)
+```
+
+Note that depending on your model, you may also need to set other arguments in `tidy_robust` (e.g. exponentiate). 
+
+Global p-values can also be calculated with robust errors in the same manner via the `tidy_wald_test` function. Again, the following example demonstrates the non-robust approach and the robust approach side-by-side.
+
+```{r}
+tbl_merge(
+  list(
+    tbl_regression(lmod) |> 
+      add_global_p(anova_fun = tidy_wald_test),
+    tbl_regression(lmod, 
+                   tidy_fun = \(x, ...) tidy_robust(x, vcov = cov)) |>
+      add_global_p(anova_fun = \(x, ...) tidy_wald_test(x, vcov = cov))
+  ), 
+  tab_spanner = c("Standard errors", "Robust errors")
+)
+```
+
+

--- a/vignettes/articles/gallery.Rmd
+++ b/vignettes/articles/gallery.Rmd
@@ -442,50 +442,55 @@ dat <- trial |>
   mutate(subject_id = dplyr::row_number(), .by = trt)
 lmod <- lm(response ~ trt + grade, data = dat)
 
-library(sandwich)
-cov <- vcovCL(lmod, cluster = ~ subject_id, vcov_type = "HC0")
+cov <- sandwich::vcovCL(lmod, cluster = ~ subject_id, vcov_type = "HC0")
 ```
 
 Once you have the robust variance-covariance matrix, you can use it with `tidy_robust` to calculate adjusted confidence intervals and p-values. 
 
-Robust errors generally have only a small impact on the confidence intervals and p-values. For demonstration purposes, we therefore edit the default gtsummary theme to show 3 digits for confidence intervals and p-values.
+Robust errors generally have only a small impact on the confidence intervals and p-values. For demonstration purposes, we therefore show 3 digits for confidence intervals and p-values.
+
+A standard, non-robust regression table can be made as follows:
 
 ```{r}
-my_theme <-
-  list(
-    # round large p-values to three places
-    "pkgwide-fn:pvalue_fun" = label_style_pvalue(digits = 3),
-    "pkgwide-fn:prependpvalue_fun" = label_style_pvalue(digits = 3, prepend_p = TRUE),
-    # show more digits in summary statistics
-    "tbl_regression-arg:estimate_fun" = label_style_sigfig(digits = 3)
+tbl_standard <- 
+  tbl_regression(
+    lmod,
+    estimate_fun = label_style_sigfig(digits = 3),
+    pvalue_fun = label_style_pvalue(digits = 3)
   )
-set_gtsummary_theme(my_theme)
+tbl_standard
 ```
 
-In order to use the robust errors, pass the variance-covariance matrix to the `tidy_robust` function, as shown below. The example below shows the non-robust approach, as well as the robust approach so that the values can be compared.
+In order to use the robust errors, pass the variance-covariance matrix to the `tidy_robust` function, as shown below. 
 
 ```{r}
-tbl_merge(
-  list(
-    tbl_regression(lmod),
-    tbl_regression(lmod, 
-                   tidy_fun = \(x, ...) tidy_robust(x, vcov = cov))
-  ), 
-  tab_spanner = c("Standard errors", "Robust errors")
-)
+tbl_robust <- 
+  tbl_regression(
+    lmod,
+    estimate_fun = label_style_sigfig(digits = 3),
+    pvalue_fun = label_style_pvalue(digits = 3),
+    tidy_fun = \(x, ...) tidy_robust(x, vcov = cov))
+tbl_robust
 ```
 
 Note that depending on your model, you may also need to set other arguments in `tidy_robust` (e.g. exponentiate). 
+
+Comparing the tables side-by-side, we see that the confidence intervals and p-values are very similar.
+
+```{r}
+tbl_merge(
+  list(tbl_standard, tbl_robust), 
+  tab_spanner = c("**Standard errors**", "**Robust errors**")
+)
+```
 
 Global p-values can also be calculated with robust errors in the same manner via the `tidy_wald_test` function. Again, the following example demonstrates the non-robust approach and the robust approach side-by-side.
 
 ```{r}
 tbl_merge(
   list(
-    tbl_regression(lmod) |> 
-      add_global_p(anova_fun = tidy_wald_test),
-    tbl_regression(lmod, 
-                   tidy_fun = \(x, ...) tidy_robust(x, vcov = cov)) |>
+    tbl_standard |> add_global_p(anova_fun = tidy_wald_test),
+    tbl_robust |>
       add_global_p(anova_fun = \(x, ...) tidy_wald_test(x, vcov = cov))
   ), 
   tab_spanner = c("Standard errors", "Robust errors")


### PR DESCRIPTION
**What changes are proposed in this pull request?**

As discussed in the issue, here's an example of using robust standard errors. I had to add a dependency (under suggests) for sandwich. I hope thats OK. If you happen to know of an existing dependency that contains a function for modifying the vcov matrix, i'm happy to try that instead.

<< Addition of an example on robust standard errors to the gallery vignette >>

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2076 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

