### PR TITLE
Allowing rendered curly brackets in `tbl_summary(statistic)` 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.4.9012
+Version: 2.0.4.9013
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,8 @@
 
 * Users may now pass a vector of integers to `tbl_hierarchical*(digits)`, as is possible in other summary functions. (#2080)
 
+* The `tbl_summary(statistic)` argument now allows users to pass curly brackets that appear in the final table. Just like in `glue::glue()` double curly brackets are escaped to a single bracket. For example, `tbl_summary(statistic=~"{{{mean}}}")` results in `"{<mean value>}"`. (#2123)
+
 # gtsummary 2.0.3
 
 ### New Features and Functions

--- a/R/utils-misc.R
+++ b/R/utils-misc.R
@@ -1,9 +1,13 @@
 .extract_glue_elements <- function(x) {
+  # this part removes double curlies pairs, trying to mimic how `glue::glue()` would find the element to evaluate
+  while (isTRUE(any(str_detect(x, "\\{\\{.*\\}\\}")))) {
+    x <- map_chr(x, ~ifelse(str_detect(x, "\\{\\{.*\\}\\}"), str_replace(.x, "(\\{\\{)|(\\}\\})", ""), .x))
+  }
+
+  # extract string from between the curlies
   regmatches(x, gregexpr("\\{([^\\}]*)\\}", x)) |>
     unlist() %>%
-    {
-      substr(., 2, nchar(.) - 1)
-    }
+    substr(start = 2, stop = nchar(.) - 1)
 }
 
 .ifelse1 <- function(test, yes, no) {

--- a/tests/testthat/test-tbl_summary.R
+++ b/tests/testthat/test-tbl_summary.R
@@ -681,3 +681,37 @@ test_that("tbl_summary() test encoding/sorting difference between sort() and dpl
     c("label", "stat_1", "stat_2", "stat_3")
   )
 })
+
+# addressing issue #2123
+test_that("tbl_summary(statistic) double curly bracket escaping", {
+  expect_equal(
+    tbl_summary(trial, include = ttdeath, statistic = ~"{{{mean}}}", missing = "no") |>
+      as_tibble() |>
+      dplyr::pull(last_col()),
+    glue("{{{style_number(mean(trial$ttdeath), 1)}}}")
+  )
+  expect_equal(
+    tbl_summary(trial, include = ttdeath, statistic = ~"{{{{{mean}}}}}", missing = "no") |>
+      as_tibble() |>
+      dplyr::pull(last_col()),
+    glue("{{{{{style_number(mean(trial$ttdeath), 1)}}}}}")
+  )
+  expect_equal(
+    tbl_summary(trial, include = ttdeath, statistic = ~"{mean} }}", missing = "no") |>
+      as_tibble() |>
+      dplyr::pull(last_col()),
+    glue("{style_number(mean(trial$ttdeath), 1)} }}")
+  )
+  expect_equal(
+    tbl_summary(trial, include = ttdeath, statistic = ~"{{{{{mean}}}}}}", missing = "no") |>
+      as_tibble() |>
+      dplyr::pull(last_col()),
+    glue("{{{{{style_number(mean(trial$ttdeath), 1)}}}}}}")
+  )
+  expect_equal(
+    tbl_summary(trial, include = ttdeath, statistic = ~"Me{{an: {{{mean}}}", missing = "no") |>
+      as_tibble() |>
+      dplyr::pull(last_col()),
+    glue("Me{{an: {{{style_number(mean(trial$ttdeath), 1)}}}")
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The `tbl_summary(statistic)` argument now allows users to pass curly brackets that appear in the final table. Just like in `glue::glue()` double curly brackets are escaped to a single bracket. For example, `tbl_summary(statistic=~"{{{mean}}}")` results in `"{<mean value>}"`. (#2123)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2123

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

