### PR TITLE
Adding messaging for mixed-type `tbl_ard_summary(by)` variables

### DIFF
--- a/R/tbl_ard_summary.R
+++ b/R/tbl_ard_summary.R
@@ -156,6 +156,16 @@ tbl_ard_summary <- function(cards,
       call = get_cli_abort_call()
     )
   }
+  # check consistent types for the by variable
+  if (!is_empty(by)) {
+    # test if any of the levels have inconsistent classes. making this a message, because it won't always result in a bad table
+    if (some(compact(cards$group1_level), \(x) is_empty(intersect(class(x), class(compact(cards$group1_level)[[1]]))))) {
+      cli::cli_inform(
+        c("Levels of the {.code tbl_ard_summary(by)} variable do not have a consistent S3 class.",
+          "i" = "This may cause an unexpected or incorrect layout in the final table.")
+      )
+    }
+  }
 
   # check the missing stats are available
   if (missing != "no") {

--- a/tests/testthat/test-tbl_ard_summary.R
+++ b/tests/testthat/test-tbl_ard_summary.R
@@ -319,3 +319,16 @@ test_that("tbl_ard_summary() non-standard ARDs (ie not 'continuous', 'categorica
       as.data.frame()
   )
 })
+
+# addressed Issue #2000
+test_that("tbl_ard_summary(by) mixed-type messaging", {
+  expect_message(
+    cards::bind_ard(
+      cards::ard_continuous(trial, variables = age, by = trt),
+      cards::ard_continuous(trial |> dplyr::mutate(trt = factor(trt)), variables = marker, by = trt)
+    ) |>
+      tbl_ard_summary(by = trt),
+    "Levels of the.*variable do not have a consistent S3 class."
+  )
+})
+


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Messaging users if the `by` variable in `tbl_ard_summary()` have inconsistent classes.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2000

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

