### PR TITLE
`add_ci()` on all `NA` columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ Suggests:
     broom.helpers (>= 1.17.0),
     broom.mixed (>= 0.2.9),
     car (>= 3.0-11),
-    cardx (>= 0.2.2.9020),
+    cardx (>= 0.2.2.9021),
     cmprsk,
     effectsize (>= 0.6.0),
     emmeans (>= 1.7.3),
@@ -86,7 +86,7 @@ Suggests:
     testthat (>= 3.2.0),
     withr (>= 2.5.0),
     workflows (>= 0.2.4)
-Remotes: insightsengineering/cardx@further-testing-prop-CIs
+Remotes: insightsengineering/cardx
 VignetteBuilder: 
     knitr
 Config/Needs/check: hms

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.0.4.9015
+Version: 2.0.4.9016
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),
@@ -60,7 +60,7 @@ Suggests:
     broom.helpers (>= 1.17.0),
     broom.mixed (>= 0.2.9),
     car (>= 3.0-11),
-    cardx (>= 0.2.2.9006),
+    cardx (>= 0.2.2.9020),
     cmprsk,
     effectsize (>= 0.6.0),
     emmeans (>= 1.7.3),
@@ -86,7 +86,7 @@ Suggests:
     testthat (>= 3.2.0),
     withr (>= 2.5.0),
     workflows (>= 0.2.4)
-Remotes: insightsengineering/cardx
+Remotes: insightsengineering/cardx@further-testing-prop-CIs
 VignetteBuilder: 
     knitr
 Config/Needs/check: hms

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,8 @@
 
 * Corrected the `?tests` documentation file to reflect that, as of v2.0, we no longer perform pre-processing (such as, converting a column to a factor) on variables before computing tests. (#2135)
 
+* When `add_ci.tbl_summary()` was for a variable that was all `NA` we no longer return an error. Users will now see the confidence interval as `'NA%, NA%'`. (#2139) 
+
 # gtsummary 2.0.4
 
 ### New Features and Functions

--- a/R/add_ci.R
+++ b/R/add_ci.R
@@ -380,6 +380,7 @@ brdg_add_ci <- function(x, pattern, statistic, include, conf.level, updated_call
                         list(style_fun[[.y]]),
                         .data$fmt_fn)
       ) |>
+        cards::replace_null_statistic() |>
         cards::apply_fmt_fn()
     ) |>
     dplyr::bind_rows() |>

--- a/tests/testthat/test-add_ci.tbl_summary.R
+++ b/tests/testthat/test-add_ci.tbl_summary.R
@@ -924,3 +924,19 @@ test_that("add_ci() correctly handles tbl_summary(percent='cell')", {
   )
 })
 
+# Addresses Issue #2139
+test_that("add_ci() correctly handles columns of all NAs", {
+  expect_equal(
+    trial |>
+      mutate(death = ifelse(trt == "Drug B", NA, death)) |>
+      tbl_summary(
+        by = trt,
+        missing = "no",
+        include = death
+      ) |>
+      add_ci() |>
+      as_tibble(col_labels = FALSE) |>
+      dplyr::pull("ci_stat_2"),
+    "NA%, NA%"
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* When `add_ci.tbl_summary()` was for a variable that was all `NA` we no longer return an error. Users will now see the confidence interval as `'NA%, NA%'`. (#2139)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2139

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

