### PR TITLE
updates for `tbl_strata_nested_stack()` 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.1.0.9002
+Version: 2.1.0.9003
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 * The `remove_*()` family of functions default argument values have been updated to remove _all_ footnotes, source notes, abbreviations, column merging, bold and italic styling by default, so the users are not longer required to remove, for example, one source note at a time. The one exception is `remove_spanning_headers()`, which will remove the first level spanning headers be default. (#2161)
 
+* The `tbl_strata_nested_stack(quiet)` argument documentation was updated. (#2164)
+
+* Corrected the class of objects returned from `tbl_strata_nested_stack()`.
+
+* Corrected bug in `tbl_strata_nested_stack()` when the strata variable had a single level. Pervasively, the indentation of the single strata level was not correct.
+
 # gtsummary 2.1.0
 
 ### New Features and Functions

--- a/R/tbl_strata_nested_stack.R
+++ b/R/tbl_strata_nested_stack.R
@@ -1,10 +1,15 @@
 #' Stratified Nested Stacking
 #'
+#' @description
 #' This function stratifies your data frame, builds gtsummary tables, and
 #' stacks the resulting tables in a nested style. The underlying functionality
 #' is similar to `tbl_strata()`, except the resulting tables are nested or indented
 #' within each group.
 #'
+#' **NOTE**: The header from the first table is used for the final table. Oftentimes,
+#'           this header will include incorrect Ns and _must be updated._
+#'
+#' @inheritParams tbl_stack
 #' @inheritParams tbl_strata
 #' @param data (`data.frame`)\cr
 #'   a data frame
@@ -155,7 +160,7 @@ tbl_strata_nested_stack <- function(data, strata, .tbl_fun, ..., row_header = "{
   tbl <- tbl_stack(tbls = tbls, quiet = quiet)
 
   # cycle over the depth and indenting nesting headers
-  for (d in seq_len(nrow(df_headers) - 1L)) {
+  for (d in seq_along(strata)) {
     tbl <- tbl |>
       modify_column_indent(
         columns = all_of(first_non_hidden_col),
@@ -169,7 +174,7 @@ tbl_strata_nested_stack <- function(data, strata, .tbl_fun, ..., row_header = "{
   tbl$inputs = list(tbl_row_split = func_inputs)
   tbl$tbls <- NULL
   tbl |>
-    structure(class = c("tbl_row_split", "gtsummary"))
+    structure(class = c("tbl_strata_nested_stack", "tbl_stack", "gtsummary"))
 }
 
 

--- a/man/add_glance.Rd
+++ b/man/add_glance.Rd
@@ -86,7 +86,7 @@ To re-order the rows with glance statistics on bottom, use the script below:
 }
 
 \examples{
-\dontshow{if ((identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) && gtsummary:::is_pkg_installed("cardx")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if ((identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) && gtsummary:::is_pkg_installed(c("cardx", "broom", "broom.helpers"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 mod <- lm(age ~ marker + grade, trial) |> tbl_regression()
 
 # Example 1 ----------------------------------

--- a/man/tbl_strata_nested_stack.Rd
+++ b/man/tbl_strata_nested_stack.Rd
@@ -35,7 +35,8 @@ row headers. Elements available to insert are \code{strata}, \code{n}, \code{N} 
 The \code{strata} element is the variable level of the strata variables.
 Default is \code{'{strata}'}.}
 
-\item{quiet}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
+\item{quiet}{(scalar \code{logical})\cr
+Logical indicating whether to suppress additional messaging. Default is \code{FALSE}.}
 }
 \value{
 a stacked 'gtsummary' table
@@ -45,6 +46,9 @@ This function stratifies your data frame, builds gtsummary tables, and
 stacks the resulting tables in a nested style. The underlying functionality
 is similar to \code{tbl_strata()}, except the resulting tables are nested or indented
 within each group.
+
+\strong{NOTE}: The header from the first table is used for the final table. Oftentimes,
+this header will include incorrect Ns and \emph{must be updated.}
 }
 \examples{
 # Example 1 ----------------------------------

--- a/tests/testthat/test-tbl_strata_nested_stack.R
+++ b/tests/testthat/test-tbl_strata_nested_stack.R
@@ -103,6 +103,23 @@ test_that("tbl_strata_nested_stack() works with unobserved factor levels", {
       setdiff(x = seq_len(nrow(tbl$table_body)), y = _),
     c(1L, 7L)
   )
+
+  # check indentation is correct when only one level present in stratum
+  expect_true({
+    df_indent <- trial |>
+      dplyr::filter(trt == "Drug A") |>
+      tbl_strata_nested_stack(
+        strata = "trt",
+        ~ tbl_summary(.x, include = "age", missing = "no")
+      ) |>
+      getElement("table_styling") |>
+      getElement("indent") |>
+      dplyr::filter(n_spaces == 0L)
+
+    (df_indent$column == "label") &&
+      (df_indent$rows[[1]] |> rlang::quo_squash() |> rlang::expr_deparse() == ".data$tbl_indent_id1 == 1L")
+  })
+
 })
 
 test_that("tbl_strata_nested_stack() messaging", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The `tbl_strata_nested_stack(quiet)` argument documentation was updated. (#2164)
* Corrected the class of objects returned from `tbl_strata_nested_stack()`.
* Corrected bug in `tbl_strata_nested_stack()` when the strata variable had a single level. Pervasively, the indentation of the single strata level was not correct.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2164

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

