### PR TITLE
Updating `remove_*()` function defaults

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.1.0.9001
+Version: 2.1.0.9002
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* The `remove_*()` family of functions default argument values have been updated to remove _all_ footnotes, source notes, abbreviations, column merging, bold and italic styling by default, so the users are not longer required to remove, for example, one source note at a time. The one exception is `remove_spanning_headers()`, which will remove the first level spanning headers be default. (#2161)
+
 # gtsummary 2.1.0
 
 ### New Features and Functions

--- a/R/modify.R
+++ b/R/modify.R
@@ -176,7 +176,7 @@ modify_spanning_header <- function(x, ..., text_interpret = c("md", "html"),
 
 #' @name modify
 #' @export
-remove_spanning_header <- function(x, columns, level = 1L) {
+remove_spanning_header <- function(x, columns = everything(), level = 1L) {
   set_cli_abort_call()
   updated_call_list <- c(x$call_list, list(remove_spanning_header = match.call()))
 

--- a/R/modify_abbreviation.R
+++ b/R/modify_abbreviation.R
@@ -5,7 +5,8 @@
 #'
 #' @inheritParams modify_footnote2
 #' @param abbreviation (`string`)\cr
-#'   a string
+#'   a string. In `remove_abbreviation()`, the default value is `NULL`, which
+#'   will remove all abbreviation source notes.
 #'
 #' @return Updated gtsummary object
 #' @name modify_abbreviation

--- a/R/modify_abbreviation.R
+++ b/R/modify_abbreviation.R
@@ -49,13 +49,21 @@ modify_abbreviation <- function(x, abbreviation, text_interpret = c("md", "html"
 
 #' @export
 #' @rdname modify_abbreviation
-remove_abbreviation <- function(x, abbreviation) {
+remove_abbreviation <- function(x, abbreviation = NULL) {
   set_cli_abort_call()
   updated_call_list <- c(x$call_list, list(modify_footnote_body = match.call()))
 
   # check inputs ---------------------------------------------------------------
   check_class(x, "gtsummary")
-  check_string(abbreviation)
+  check_string(abbreviation, allow_empty = TRUE)
+
+  # remove all abbreviations if abbreviation=NULL ------------------------------
+  if (is_empty(abbreviation)) {
+    x$table_styling$abbreviation <- x$table_styling$abbreviation[0,]
+    return(x)
+  }
+
+  # check passed abbreviations for validity
   if (nrow(x$table_styling$abbreviation) == 0L) {
     cli::cli_abort("There are no abbreviations to remove.", call = get_cli_abort_call())
   }

--- a/R/modify_bold_italic.R
+++ b/R/modify_bold_italic.R
@@ -1,6 +1,7 @@
 #' Modify Bold and Italic
 #'
 #' Add or remove bold and italic styling to a cell in a table.
+#' By default, the remove functions will remove all bold/italic styling.
 #'
 #' @inheritParams modify_footnote2
 #'
@@ -45,7 +46,7 @@ modify_bold <- function(x, columns, rows) {
 
 #' @rdname modify_bold_italic
 #' @export
-remove_bold <- function(x, columns, rows) {
+remove_bold <- function(x, columns = everything(), rows = TRUE) {
   set_cli_abort_call()
 
   # check inputs ---------------------------------------------------------------
@@ -89,7 +90,7 @@ modify_italic <- function(x, columns, rows) {
 
 #' @rdname modify_bold_italic
 #' @export
-remove_italic <- function(x, columns, rows) {
+remove_italic <- function(x, columns = everything(), rows = TRUE) {
   set_cli_abort_call()
 
   # check inputs ---------------------------------------------------------------

--- a/R/modify_column_merge.R
+++ b/R/modify_column_merge.R
@@ -106,7 +106,7 @@ modify_column_merge <- function(x, pattern, rows = NULL) {
 
 #' @export
 #' @name modify_column_merge
-remove_column_merge <- function(x, columns) {
+remove_column_merge <- function(x, columns = everything()) {
   set_cli_abort_call()
   # check inputs ---------------------------------------------------------------
   check_class(x, "gtsummary")

--- a/R/modify_footnote.R
+++ b/R/modify_footnote.R
@@ -169,7 +169,7 @@ modify_footnote_spanning_header <- function(x, footnote, columns,
 
 #' @export
 #' @rdname modify_footnote2
-remove_footnote_header <- function(x, columns) {
+remove_footnote_header <- function(x, columns = everything()) {
   set_cli_abort_call()
   updated_call_list <- c(x$call_list, list(remove_footnote_header = match.call()))
 
@@ -197,7 +197,7 @@ remove_footnote_header <- function(x, columns) {
 
 #' @export
 #' @rdname modify_footnote2
-remove_footnote_body <- function(x, columns, rows) {
+remove_footnote_body <- function(x, columns = everything(), rows = TRUE) {
   set_cli_abort_call()
   updated_call_list <- c(x$call_list, list(remove_footnote_body = match.call()))
 
@@ -227,13 +227,13 @@ remove_footnote_body <- function(x, columns, rows) {
 
 #' @export
 #' @rdname modify_footnote2
-remove_footnote_spanning_header <- function(x, columns, level) {
+remove_footnote_spanning_header <- function(x, columns = everything(), level = 1L) {
   set_cli_abort_call()
   updated_call_list <- c(x$call_list, list(remove_footnote_body = match.call()))
 
   # check inputs ---------------------------------------------------------------
   check_class(x, "gtsummary")
-  check_scalar_integerish(level)
+  check_scalar_integerish(level, allow_empty = NULL)
   if (level < 1) {
     cli::cli_abort(
       "The {.arg level} argument must be a positive integer.",

--- a/R/modify_source_note.R
+++ b/R/modify_source_note.R
@@ -12,6 +12,7 @@
 #' @param source_note_id (`integers`)\cr
 #'   Integers specifying the ID of the source note to remove.
 #'   Source notes are indexed sequentially at the time of creation.
+#'   Default is `NULL`, which removes all source notes.
 #' @inheritParams modify
 #'
 #' @details
@@ -62,13 +63,12 @@ modify_source_note <- function(x, source_note, text_interpret = c("md", "html"))
 
 #' @export
 #' @rdname modify_source_note
-remove_source_note <- function(x, source_note_id) {
+remove_source_note <- function(x, source_note_id = NULL) {
   set_cli_abort_call()
   updated_call_list <- c(x$call_list, list(remove_source_note = match.call()))
 
   # check inputs ---------------------------------------------------------------
   check_not_missing(x)
-  check_not_missing(source_note_id)
   check_class(x, "gtsummary")
   check_integerish(source_note_id, allow_empty = TRUE)
 

--- a/man/add_glance.Rd
+++ b/man/add_glance.Rd
@@ -86,7 +86,7 @@ To re-order the rows with glance statistics on bottom, use the script below:
 }
 
 \examples{
-\dontshow{if ((identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) && gtsummary:::is_pkg_installed("cardx")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if ((identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) && gtsummary:::is_pkg_installed(c("cardx", "broom", "broom.helpers"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 mod <- lm(age ~ marker + grade, trial) |> tbl_regression()
 
 # Example 1 ----------------------------------

--- a/man/modify.Rd
+++ b/man/modify.Rd
@@ -19,7 +19,7 @@ modify_spanning_header(
   update
 )
 
-remove_spanning_header(x, columns, level = 1L)
+remove_spanning_header(x, columns = everything(), level = 1L)
 
 show_header_names(x, show_hidden = FALSE, include_example, quiet)
 }

--- a/man/modify_abbreviation.Rd
+++ b/man/modify_abbreviation.Rd
@@ -14,7 +14,8 @@ remove_abbreviation(x, abbreviation = NULL)
 A gtsummary object}
 
 \item{abbreviation}{(\code{string})\cr
-a string}
+a string. In \code{remove_abbreviation()}, the default value is \code{NULL}, which
+will remove all abbreviation source notes.}
 
 \item{text_interpret}{(\code{string})\cr
 String indicates whether text will be interpreted with

--- a/man/modify_abbreviation.Rd
+++ b/man/modify_abbreviation.Rd
@@ -7,7 +7,7 @@
 \usage{
 modify_abbreviation(x, abbreviation, text_interpret = c("md", "html"))
 
-remove_abbreviation(x, abbreviation)
+remove_abbreviation(x, abbreviation = NULL)
 }
 \arguments{
 \item{x}{(\code{gtsummary})\cr

--- a/man/modify_bold_italic.Rd
+++ b/man/modify_bold_italic.Rd
@@ -10,11 +10,11 @@
 \usage{
 modify_bold(x, columns, rows)
 
-remove_bold(x, columns, rows)
+remove_bold(x, columns = everything(), rows = TRUE)
 
 modify_italic(x, columns, rows)
 
-remove_italic(x, columns, rows)
+remove_italic(x, columns = everything(), rows = TRUE)
 }
 \arguments{
 \item{x}{(\code{gtsummary})\cr
@@ -36,6 +36,7 @@ Updated gtsummary object
 }
 \description{
 Add or remove bold and italic styling to a cell in a table.
+By default, the remove functions will remove all bold/italic styling.
 }
 \examples{
 \dontshow{if (identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/modify_column_merge.Rd
+++ b/man/modify_column_merge.Rd
@@ -7,7 +7,7 @@
 \usage{
 modify_column_merge(x, pattern, rows = NULL)
 
-remove_column_merge(x, columns)
+remove_column_merge(x, columns = everything())
 }
 \arguments{
 \item{x}{(\code{gtsummary})\cr

--- a/man/modify_footnote2.Rd
+++ b/man/modify_footnote2.Rd
@@ -36,11 +36,11 @@ modify_footnote_spanning_header(
   text_interpret = c("md", "html")
 )
 
-remove_footnote_header(x, columns)
+remove_footnote_header(x, columns = everything())
 
-remove_footnote_body(x, columns, rows)
+remove_footnote_body(x, columns = everything(), rows = TRUE)
 
-remove_footnote_spanning_header(x, columns, level)
+remove_footnote_spanning_header(x, columns = everything(), level = 1L)
 }
 \arguments{
 \item{x}{(\code{gtsummary})\cr

--- a/man/modify_source_note.Rd
+++ b/man/modify_source_note.Rd
@@ -7,7 +7,7 @@
 \usage{
 modify_source_note(x, source_note, text_interpret = c("md", "html"))
 
-remove_source_note(x, source_note_id)
+remove_source_note(x, source_note_id = NULL)
 }
 \arguments{
 \item{x}{(\code{gtsummary})\cr
@@ -23,7 +23,8 @@ Applies to tables printed with \code{{gt}}.}
 
 \item{source_note_id}{(\code{integers})\cr
 Integers specifying the ID of the source note to remove.
-Source notes are indexed sequentially at the time of creation.}
+Source notes are indexed sequentially at the time of creation.
+Default is \code{NULL}, which removes all source notes.}
 }
 \value{
 gtsummary object

--- a/tests/testthat/_snaps/modify_bold_italic.md
+++ b/tests/testthat/_snaps/modify_bold_italic.md
@@ -1,0 +1,18 @@
+# remove_bold/italic() removes all by default
+
+    Code
+      as.data.frame(remove_bold(bold_p(tbl_regression(glm(response ~ death, trial,
+      family = binomial())))), col_labels = FALSE)
+    Output
+               label estimate    conf.low p.value
+      1 Patient Died    -0.96 -1.6, -0.34   0.003
+
+---
+
+    Code
+      as.data.frame(remove_italic(modify_italic(tbl_summary(trial, include = age,
+        missing = "no"), columns = label, rows = variable == "age")), col_labels = FALSE)
+    Output
+        label      stat_0
+      1   Age 47 (38, 57)
+

--- a/tests/testthat/test-modify_abbreviation.R
+++ b/tests/testthat/test-modify_abbreviation.R
@@ -34,6 +34,18 @@ test_that("remove_abbreviation()", {
       NA_character_, "Q1 = First Quartile",        "gt::md",
     )
   )
+
+  # test all abbreviations removed by default
+  expect_equal(
+    tbl_summary(trial, include = marker) |>
+      modify_abbreviation("Q1 = First Quartile") |>
+      modify_abbreviation("Q3 = Third Quartile") |>
+      remove_abbreviation() |>
+      getElement("table_styling") |>
+      getElement("abbreviation") |>
+      nrow(),
+    0L
+  )
 })
 
 test_that("remove_abbreviation() messaging", {

--- a/tests/testthat/test-modify_bold_italic.R
+++ b/tests/testthat/test-modify_bold_italic.R
@@ -1,3 +1,6 @@
+skip_on_cran()
+skip_if_not(is_pkg_installed(c("broom.helpers", "cardx")))
+
 test_that("modify_bold/italic()/remove_bold/italic()", {
   expect_silent(
     tbl1 <- trial |>
@@ -33,5 +36,23 @@ test_that("modify_bold/italic()/remove_bold/italic()", {
     ),
     ignore_formula_env = TRUE,
     ignore_attr = TRUE
+  )
+})
+
+
+test_that("remove_bold/italic() removes all by default", {
+  expect_snapshot(
+    glm(response ~ death, trial, family = binomial()) |>
+      tbl_regression() |>
+      bold_p() |>
+      remove_bold() |>
+      as.data.frame(col_labels = FALSE)
+  )
+
+  expect_snapshot(
+    tbl_summary(trial, include = age, missing = "no") |>
+      modify_italic(columns = label, rows = variable == "age") |>
+      remove_italic() |>
+      as.data.frame(col_labels = FALSE)
   )
 })

--- a/tests/testthat/test-modify_column_merge.R
+++ b/tests/testthat/test-modify_column_merge.R
@@ -64,4 +64,15 @@ test_that("remove_column_merge() works", {
       intersect(c("conf.low", "conf.high")),
     c("conf.low", "conf.high")
   )
+
+  # all are removed by default
+  expect_equal(
+    lm(mpg ~ am, mtcars) |>
+      tbl_regression() |>
+      remove_column_merge() |>
+      getElement("table_styling") |>
+      getElement("cols_merge") |>
+      nrow(),
+    0L
+  )
 })

--- a/tests/testthat/test-modify_footnote_body.R
+++ b/tests/testthat/test-modify_footnote_body.R
@@ -65,4 +65,20 @@ test_that("remove_footnote_body(footnote)", {
     ),
     ignore_attr = TRUE
   )
+
+  # test we can remove footnotes from the cells by default
+  expect_true(
+    base_tbl_summary |>
+      modify_footnote_body(
+        footnote = "this will not appear",
+        columns = label,
+        rows = row_type == "label"
+      ) |>
+      remove_footnote_body() |>
+      getElement("table_styling") |>
+      getElement("footnote_body") |>
+      dplyr::slice_tail(by = "column", n = 1L) |>
+      getElement("remove") |>
+      unique()
+  )
 })

--- a/tests/testthat/test-modify_footnote_header.R
+++ b/tests/testthat/test-modify_footnote_header.R
@@ -59,4 +59,20 @@ test_that("remove_footnote_header(footnote)", {
       "stat_0",                NA,        "gt::md",     TRUE,    TRUE
     )
   )
+
+  # test all footnotes are removed by default
+  expect_true(
+    base_tbl_summary |>
+      modify_footnote_header(
+        footnote = "testing",
+        columns = all_stat_cols(),
+        replace = FALSE
+      ) |>
+      remove_footnote_header() |>
+      getElement("table_styling") |>
+      getElement("footnote_header") |>
+      dplyr::slice_tail(by = column, n = 1L) |>
+      getElement("remove") |>
+      unique()
+  )
 })

--- a/tests/testthat/test-modify_source_note.R
+++ b/tests/testthat/test-modify_source_note.R
@@ -62,6 +62,18 @@ test_that("remove_source_note(source_note_id)", {
       getElement("remove") |>
       unique()
   )
+
+  # test all source notes are removed by default
+  expect_true(
+    tbl_summary(trial, include = trt) |>
+      modify_source_note("Created June 26, 2015") |>
+      modify_source_note("Created June 26, 2015") |>
+      remove_source_note() |>
+      getElement("table_styling") |>
+      getElement("source_note") |>
+      getElement("remove") |>
+      unique()
+  )
 })
 
 test_that("remove_source_note(source_note_id) messaging", {

--- a/vignettes/gtsummary_definition.Rmd
+++ b/vignettes/gtsummary_definition.Rmd
@@ -175,7 +175,7 @@ dplyr::tribble(
 
 **`abbreviation`**
 
-Abbreviations are added one at a time, and at the time of table rendering, the are coalesced into a single source note.
+Abbreviations are added one at a time, and at the time of table rendering, they are coalesced into a single source note.
 
 ```{r, echo=FALSE}
 dplyr::tribble(


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The `remove_*()` family of functions default argument values have been updated to remove _all_ footnotes, source notes, abbreviations, column merging, bold and italic styling by default, so the users are not longer required to remove, for example, one source note at a time. The one except is `remove_spanning_headers()`, which will remove the first level spanning headers be default. (#2161)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2161

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

