### PR TITLE
bug in `tbl_cross()` when a column was named `'missing'`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.1.0.9005
+Version: 2.1.0.9006
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Fixed bug in `tbl_cross()` when a column was named `'missing'`. (#2182)
+
 * Corrected bug causing an error in `tbl_hierarchical()` when more than one `by` variable level had been filtered out of the data. (#2173)
 
 * The `remove_*()` family of functions default argument values have been updated to remove _all_ footnotes, source notes, abbreviations, column merging, bold and italic styling by default, so the users are not longer required to remove, for example, one source note at a time. The one exception is `remove_spanning_headers()`, which will remove the first level spanning headers be default. (#2161)

--- a/R/tbl_cross.R
+++ b/R/tbl_cross.R
@@ -132,7 +132,7 @@ tbl_cross <- function(data,
       across(
         all_of(c(row, col)),
         ~ switch(
-          missing,
+          .env$missing,
           "no" = .,
           "ifany" =
             case_switch(

--- a/tests/testthat/test-tbl_cross.R
+++ b/tests/testthat/test-tbl_cross.R
@@ -125,3 +125,16 @@ test_that("tbl_cross(digits) works", {
   )
 })
 
+# Addresses issue #2182
+test_that("tbl_cross() works with column named missing", {
+  expect_equal(
+    trial |>
+      dplyr::mutate(missing = TRUE) |>
+      tbl_cross(stage, grade) |>
+      as.data.frame(),
+    trial |>
+      tbl_cross(stage, grade) |>
+      as.data.frame()
+  )
+})
+


### PR DESCRIPTION
**What changes are proposed in this pull request?**

* Fixed bug in `tbl_cross()` when a column was named `'missing'`. (#2182)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2182

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] PR branch has pulled the most recent updates from main branch.
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [x] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

