### PR TITLE
No longer replace existing footnote with the stars footnote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.1.0.9006
+Version: 2.1.0.9007
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* The footnote placed on the p-value column by `add_significance_stars()` no longer replaces any existing footnote. Rather the footnote is added to any existing footnote. (#2184)
+
 * Fixed bug in `tbl_cross()` when a column was named `'missing'`. (#2182)
 
 * Corrected bug causing an error in `tbl_hierarchical()` when more than one `by` variable level had been filtered out of the data. (#2173)

--- a/R/add_significance_stars.R
+++ b/R/add_significance_stars.R
@@ -118,7 +118,7 @@ add_significance_stars <- function(x,
     unlist() |>
     paste(collapse = "; ")
 
-  x <- modify_footnote_header(x, footnote = p_footnote, columns = any_of(pattern_cols[1]))
+  x <- modify_footnote_header(x, footnote = p_footnote, columns = any_of(pattern_cols[1]), replace = FALSE)
 
   # adding stars column --------------------------------------------------------
   thresholds <- union(thresholds, 0L)

--- a/tests/testthat/test-add_significance_stars.R
+++ b/tests/testthat/test-add_significance_stars.R
@@ -89,3 +89,20 @@ test_that("add_significance_stars(pattern) messaging", {
     "no stars will be added"
   )
 })
+
+# check the stars footnote does not replace the tests footnote, issue #2184
+test_that("add_significance_stars() footnote", {
+  expect_equal(
+    trial |>
+      tbl_summary(by = trt, include = c(age, grade)) |>
+      add_p() |>
+      add_significance_stars() |>
+      .table_styling_expr_to_row_number() |>
+      getElement("table_styling") |>
+      getElement("footnote_header") |>
+      dplyr::filter(column == "p.value") |>
+      dplyr::pull(footnote),
+    c("Wilcoxon rank sum test; Pearson's Chi-squared test",
+      "*p<0.05; **p<0.01; ***p<0.001")
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The footnote placed on the p-value column by `add_significance_stars()` no longer replaces any existing footnote. Rather the footnote is added to any existing footnote. (#2184)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2184 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] PR branch has pulled the most recent updates from main branch.
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

