### PR TITLE
Small updates in `tbl_likert()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.1.0.9008
+Version: 2.1.0.9009
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.1.0.9009
+Version: 2.1.0.9010
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
 
 * Added a new theme element `tbl_svysummary-arg:missing_stat`
 
+* Corrected bug in `tbl_likert()` where variables in table always appeared in alphabetical order. (#2195) 
+
+* Corrected bug in `add_n.tbl_likert()` where the Ns were not formatted with `style_number()`. (#2195)
+
 # gtsummary 2.1.0
 
 ### New Features and Functions

--- a/R/tbl_likert.R
+++ b/R/tbl_likert.R
@@ -131,7 +131,12 @@ tbl_likert <- function(data,
         variables = all_of(include),
         label = label
       ),
-      cards::ard_missing(data, variables = all_of(include)),
+      cards::ard_missing(
+        data,
+        variables = all_of(include),
+        fmt_fn = digits,
+        stat_label = ~ default_stat_labels()
+      ),
       cards::ard_categorical(
         data = data,
         variables = all_of(include),
@@ -250,5 +255,11 @@ pier_likert <- function(cards, variables, statistic) {
       dplyr::mutate(group1 = .data$variable, group1_level = .data$variable_level),
     variables = variables,
     statistic = statistic
-  )
+  ) |>
+    # put variables in the order requested by user
+    dplyr::left_join(
+      x = data.frame(variable = variables),
+      y = _,
+      by = "variable"
+    )
 }

--- a/tests/testthat/_snaps/tbl_likert.md
+++ b/tests/testthat/_snaps/tbl_likert.md
@@ -47,3 +47,19 @@
       1               7 (35%)
       2               7 (35%)
 
+---
+
+    Code
+      as.data.frame(add_n(tbl_likert(withr::with_seed(seed = 11235, data.frame(
+        recommend_friend = factor(sample(levels, size = 1001, replace = TRUE),
+        levels = levels), regret_purchase = factor(sample(levels, size = 1001,
+          replace = TRUE), levels = levels))), include = c(regret_purchase,
+        recommend_friend))))
+    Output
+        **Characteristic** **N** **Strongly Disagree** **Disagree** **Agree**
+      1    regret_purchase 1,001             259 (26%)    266 (27%) 235 (23%)
+      2   recommend_friend 1,001             233 (23%)    262 (26%) 251 (25%)
+        **Strongly Agree**
+      1          241 (24%)
+      2          255 (25%)
+

--- a/tests/testthat/_snaps/tbl_likert.md
+++ b/tests/testthat/_snaps/tbl_likert.md
@@ -50,16 +50,10 @@
 ---
 
     Code
-      as.data.frame(add_n(tbl_likert(withr::with_seed(seed = 11235, data.frame(
-        recommend_friend = factor(sample(levels, size = 1001, replace = TRUE),
-        levels = levels), regret_purchase = factor(sample(levels, size = 1001,
-          replace = TRUE), levels = levels))), include = c(regret_purchase,
-        recommend_friend))))
+      as.data.frame(add_n(tbl_likert(withr::with_seed(seed = 11235, data.frame(recommend_friend = factor(sample(levels, size = 1001, replace = TRUE), levels = levels), regret_purchase = factor(sample(levels, size = 1001, replace = TRUE), levels = levels))),
+      include = c(regret_purchase, recommend_friend))))
     Output
-        **Characteristic** **N** **Strongly Disagree** **Disagree** **Agree**
-      1    regret_purchase 1,001             259 (26%)    266 (27%) 235 (23%)
-      2   recommend_friend 1,001             233 (23%)    262 (26%) 251 (25%)
-        **Strongly Agree**
-      1          241 (24%)
-      2          255 (25%)
+        **Characteristic** **N** **Strongly Disagree** **Disagree** **Agree** **Strongly Agree**
+      1    regret_purchase 1,001             259 (26%)    266 (27%) 235 (23%)          241 (24%)
+      2   recommend_friend 1,001             233 (23%)    262 (26%) 251 (25%)          255 (25%)
 

--- a/tests/testthat/_snaps/tbl_likert.md
+++ b/tests/testthat/_snaps/tbl_likert.md
@@ -47,13 +47,3 @@
       1               7 (35%)
       2               7 (35%)
 
----
-
-    Code
-      as.data.frame(add_n(tbl_likert(withr::with_seed(seed = 11235, data.frame(recommend_friend = factor(sample(levels, size = 1001, replace = TRUE), levels = levels), regret_purchase = factor(sample(levels, size = 1001, replace = TRUE), levels = levels))),
-      include = c(regret_purchase, recommend_friend))))
-    Output
-        **Characteristic** **N** **Strongly Disagree** **Disagree** **Agree** **Strongly Agree**
-      1    regret_purchase 1,001             259 (26%)    266 (27%) 235 (23%)          241 (24%)
-      2   recommend_friend 1,001             233 (23%)    262 (26%) 251 (25%)          255 (25%)
-

--- a/tests/testthat/test-tbl_likert.R
+++ b/tests/testthat/test-tbl_likert.R
@@ -119,6 +119,7 @@ test_that("tbl_likert(sort)", {
 # addressing issue # 2195
 # check the order of the variables match the input, and the formatting of the N
 test_that("tbl_likert(sort)", {
+  withr::local_options(list(width = 250))
   expect_snapshot(
     withr::with_seed(
       seed = 11235,

--- a/tests/testthat/test-tbl_likert.R
+++ b/tests/testthat/test-tbl_likert.R
@@ -119,17 +119,18 @@ test_that("tbl_likert(sort)", {
 # addressing issue # 2195
 # check the order of the variables match the input, and the formatting of the N
 test_that("tbl_likert(sort)", {
-  withr::local_options(list(width = 250))
-  expect_snapshot(
-    withr::with_seed(
-      seed = 11235,
-      data.frame(
-        recommend_friend = sample(levels, size = 1001, replace = TRUE) |> factor(levels = levels),
-        regret_purchase = sample(levels, size = 1001, replace = TRUE) |> factor(levels = levels)
-      )
-    ) |>
+  expect_silent(
+    tbl <-
+      withr::with_seed(
+        seed = 11235,
+        data.frame(
+          recommend_friend = sample(levels, size = 1001, replace = TRUE) |> factor(levels = levels),
+          regret_purchase = sample(levels, size = 1001, replace = TRUE) |> factor(levels = levels)
+        )
+      ) |>
       tbl_likert(include = c(regret_purchase, recommend_friend)) |>
-      add_n() |>
-      as.data.frame()
+      add_n()
   )
+  expect_equal(tbl$table_body$variable, c("regret_purchase", "recommend_friend"))
+  expect_equal(tbl$table_body$n |> unique(), "1,001")
 })

--- a/tests/testthat/test-tbl_likert.R
+++ b/tests/testthat/test-tbl_likert.R
@@ -115,3 +115,20 @@ test_that("tbl_likert(sort)", {
       as.data.frame()
   )
 })
+
+# addressing issue # 2195
+# check the order of the variables match the input, and the formatting of the N
+test_that("tbl_likert(sort)", {
+  expect_snapshot(
+    withr::with_seed(
+      seed = 11235,
+      data.frame(
+        recommend_friend = sample(levels, size = 1001, replace = TRUE) |> factor(levels = levels),
+        regret_purchase = sample(levels, size = 1001, replace = TRUE) |> factor(levels = levels)
+      )
+    ) |>
+      tbl_likert(include = c(regret_purchase, recommend_friend)) |>
+      add_n() |>
+      as.data.frame()
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Corrected bug in `tbl_likert()` where variables in table always appeared in alphabetical order. (#2195) 

* Corrected bug in `add_n.tbl_likert()` where the Ns were not formatted with `style_number()`. (#2195)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2195

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

