### PR TITLE
Generalizing `add_variable_group_header()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.1.0.9010
+Version: 2.1.0.9011
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* The `add_variable_group_header()` function has been generalized to work with gtsummary tables, where previously only `'tbl_summary'` were accepted. (#2197)
+
 * The footnote placed on the p-value column by `add_significance_stars()` no longer replaces any existing footnote. Rather the footnote is added to any existing footnote. (#2184)
 
 * Fixed bug in `tbl_cross()` when a column was named `'missing'`. (#2182)

--- a/R/add_variable_group_header.R
+++ b/R/add_variable_group_header.R
@@ -44,11 +44,22 @@
 #'   ) |>
 #'   modify_caption("**Study Exclusion Criteria**")
 add_variable_group_header <- function(x, header, variables, indent = 4L) {
+  set_cli_abort_call()
   # check inputs ---------------------------------------------------------------
   set_cli_abort_call()
-  check_class(x, "tbl_summary")
+  check_class(x, "gtsummary")
   check_string(header)
   check_scalar_integerish(indent)
+
+  # check the necessary structure is in place
+  if (!all(c("variable", "row_type", "label") %in% names(x$table_body)) ||
+      .first_unhidden_column(x) != "label") {
+    cli::cli_abort(
+      "The {.cls gtsummary} table must include columns {.val {c('variable', 'row_type', 'label')}}
+       in the {.code x$table_body} data frame and the {.val label} column must appear first.",
+      call = get_cli_abort_call()
+    )
+  }
 
   # process variables ----------------------------------------------------------
   cards::process_selectors(scope_table_body(x$table_body), variables = {{ variables }})

--- a/tests/testthat/_snaps/add_variable_group_header.md
+++ b/tests/testthat/_snaps/add_variable_group_header.md
@@ -1,0 +1,10 @@
+# add_variable_group_header() messaging
+
+    Code
+      add_variable_group_header(modify_table_body(tbl_summary(trial, include = c(age,
+        response, death, marker), missing = "no"), ~ dplyr::relocate(.x, label,
+        .after = "stat_0")), header = "the header row", variables = c(response, death))
+    Condition
+      Error in `add_variable_group_header()`:
+      ! The <gtsummary> table must include columns "variable", "row_type", and "label" in the `x$table_body` data frame and the "label" column must appear first.
+

--- a/tests/testthat/test-add_variable_group_header.R
+++ b/tests/testthat/test-add_variable_group_header.R
@@ -4,16 +4,60 @@ test_that("add_variable_group_header() works", {
       tbl_summary(include = c(age, response, death, marker), missing = "no") |>
       add_variable_group_header(header = "the header row", variables = c(response, death))
   )
-
   # header row is in correct location
   expect_equal(
     as_tibble(tbl, col_labels = FALSE)$label[2],
     "the header row"
   )
-
   # grouped variables are indented.
   expect_equal(
     .table_styling_expr_to_row_number(tbl)$table_styling$indent$row_numbers[[1]],
     c(3L, 4L)
+  )
+
+  # check function works on tbl_svysummary tables
+  expect_silent(
+    tbl <-
+      survey::svydesign(~1, data = as.data.frame(Titanic), weights = ~Freq) |>
+      tbl_svysummary(by = Survived, percent = "row", include = c(Class, Age)) |>
+      add_variable_group_header(header = "the header row", variables = c(Class, Age))
+  )
+  # header row is in correct location
+  expect_equal(
+    as_tibble(tbl, col_labels = FALSE)$label[1],
+    "the header row"
+  )
+  # grouped variables are indented.
+  expect_equal(
+    .table_styling_expr_to_row_number(tbl)$table_styling$indent$row_numbers[[1]],
+    2:9
+  )
+
+  # check function works on tbl_regression tables
+  expect_silent(
+    tbl <-
+      glm(response ~ age + grade, trial, family = binomial()) |>
+      tbl_regression(exponentiate = TRUE) |>
+      add_variable_group_header(header = "the header row", variables = age)
+  )
+  # header row is in correct location
+  expect_equal(
+    as_tibble(tbl, col_labels = FALSE)$label[1],
+    "the header row",
+    ignore_attr = TRUE
+  )
+  # grouped variables are indented.
+  expect_true(
+    2L %in% .table_styling_expr_to_row_number(tbl)$table_styling$indent$row_numbers[[1]]
+  )
+})
+
+test_that("add_variable_group_header() messaging", {
+  expect_snapshot(
+    error = TRUE,
+    trial |>
+      tbl_summary(include = c(age, response, death, marker), missing = "no") |>
+      modify_table_body(~dplyr::relocate(.x, label, .after = "stat_0")) |>
+      add_variable_group_header(header = "the header row", variables = c(response, death))
   )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The `add_variable_group_header()` function has been generalized to work with gtsummary tables, where previously only `'tbl_summary'` were accepted. (#2197)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2197

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

