### PR TITLE
Populate all `group*` variables in `table_body` when no `by` variable present

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.1.0.9013
+Version: 2.1.0.9014
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Fixed a bug in `tbl_hierarchical()` where the `group*` variables of the resulting `table_body` were not fully populated. (#2192)
+
 * Added function `modify_post_fmt_fun()` to perform formatting on cells after the primary formatting function has been applied. The functionality is similar to `gt::text_transform()`. (#2014)
 
 * Data pre-processing has now been re-introduced for calculations in `add_p()` and `add_difference()`. Data pre-processing steps  were removed in the v2.0 release; however, in some cases---particularly `add_difference()` for dichotomous variables---the reduced functionality was affecting the user experience. See `?tests` for details on data pre-processing. (#2165)

--- a/R/brdg_hierarchical.R
+++ b/R/brdg_hierarchical.R
@@ -366,7 +366,7 @@ pier_summary_hierarchical <- function(cards,
 
   # if overall_row present, change TRUE to NULL in applicable rows for compatibility when unnesting
   last_gp <- df_result_levels |> select(cards::all_ard_groups("names")) |> names() |> dplyr::last()
-  if ("..ard_hierarchical_overall.." %in% df_result_levels[[last_gp]]) {
+  if (!is.na(last_gp) && "..ard_hierarchical_overall.." %in% df_result_levels[[last_gp]]) {
     idx_overall <- which(df_result_levels[[last_gp]] == "..ard_hierarchical_overall..")
     df_result_levels[[paste0(last_gp, "_level")]][idx_overall] <- list(NULL)
   }

--- a/R/brdg_hierarchical.R
+++ b/R/brdg_hierarchical.R
@@ -362,7 +362,16 @@ pier_summary_hierarchical <- function(cards,
       id_cols = c("row_type", "var_label", "variable", "label", cards::all_ard_groups()),
       names_from = "gts_column",
       values_from = "stat"
-    ) |>
+    )
+
+  # if overall_row present, change TRUE to NULL in applicable rows for compatibility when unnesting
+  last_gp <- df_result_levels |> select(cards::all_ard_groups("names")) |> names() |> dplyr::last()
+  if ("..ard_hierarchical_overall.." %in% df_result_levels[[last_gp]]) {
+    idx_overall <- which(df_result_levels[[last_gp]] == "..ard_hierarchical_overall..")
+    df_result_levels[[paste0(last_gp, "_level")]][idx_overall] <- list(NULL)
+  }
+
+  df_result_levels <- df_result_levels |>
     tidyr::unnest(cols = cards::all_ard_groups("levels"), keep_empty = TRUE) |>
     mutate(across(where(is.factor), as.character))
 

--- a/R/brdg_hierarchical.R
+++ b/R/brdg_hierarchical.R
@@ -370,18 +370,22 @@ pier_summary_hierarchical <- function(cards,
     gps <- df_result_levels |> select(cards::all_ard_groups("names")) |> names()
 
     df_result_levels <- df_result_levels |>
-      mutate(across(cards::all_ard_groups("names"), .fns = ~tidyr::replace_na(., " ")))
+      mutate(across(cards::all_ard_groups("names"), .fns = ~tidyr::replace_na(., " "), .names = "{.col}_sort"))
 
     for (i in seq_along(gps)) {
       df_result_levels[df_result_levels$variable == variables[i], ] <-
         df_result_levels[df_result_levels$variable == variables[i], ] |>
-        mutate(!!paste0(gps[i], "_level") := dplyr::coalesce(!!sym(paste0(gps[i], "_level")), .data$label))
+        mutate(
+          !!gps[i] := dplyr::coalesce(!!sym(gps[i]), .data$variable),
+          !!paste0(gps[i], "_level") := dplyr::coalesce(!!sym(paste0(gps[i], "_level")), .data$label)
+        )
     }
-    ord <- c(rbind(paste0(gps, "_level"), gps))
+    ord <- c(rbind(paste0(gps, "_level"), paste0(gps, "_sort")))
     df_result_levels <- df_result_levels |>
       dplyr::group_by(across(cards::all_ard_groups("levels"))) |>
       dplyr::arrange(across(all_of(ord))) |>
-      dplyr::ungroup()
+      dplyr::ungroup() |>
+      dplyr::select(-ends_with("_sort"))
   }
 
   df_result_levels

--- a/tests/testthat/_snaps/tbl_hierarchical.md
+++ b/tests/testthat/_snaps/tbl_hierarchical.md
@@ -1005,3 +1005,19 @@
       2                                                       EYE ALLERGY              1 (1.2%)
       3                                                      EYE SWELLING              1 (1.2%)
 
+# tbl_hierarchical table_body group variables are correct with no by
+
+    Code
+      as.data.frame(res$table_body)
+    Output
+        row_type group1                                         group1_level var_label variable                                                label    stat_0
+      1    level  AESOC                                    CARDIAC DISORDERS      <NA>    AESOC                                    CARDIAC DISORDERS  5 (2.0%)
+      2    level  AESOC                                    CARDIAC DISORDERS      <NA>  AEDECOD                 ATRIOVENTRICULAR BLOCK SECOND DEGREE  5 (2.0%)
+      3    level  AESOC                           GASTROINTESTINAL DISORDERS      <NA>    AESOC                           GASTROINTESTINAL DISORDERS 18 (7.1%)
+      4    level  AESOC                           GASTROINTESTINAL DISORDERS      <NA>  AEDECOD                                            DIARRHOEA 18 (7.1%)
+      5    level  AESOC GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS      <NA>    AESOC GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS  57 (22%)
+      6    level  AESOC GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS      <NA>  AEDECOD                            APPLICATION SITE ERYTHEMA  30 (12%)
+      7    level  AESOC GENERAL DISORDERS AND ADMINISTRATION SITE CONDITIONS      <NA>  AEDECOD                            APPLICATION SITE PRURITUS  50 (20%)
+      8    level  AESOC               SKIN AND SUBCUTANEOUS TISSUE DISORDERS      <NA>    AESOC               SKIN AND SUBCUTANEOUS TISSUE DISORDERS  38 (15%)
+      9    level  AESOC               SKIN AND SUBCUTANEOUS TISSUE DISORDERS      <NA>  AEDECOD                                             ERYTHEMA  38 (15%)
+

--- a/tests/testthat/test-tbl_hierarchical.R
+++ b/tests/testthat/test-tbl_hierarchical.R
@@ -407,7 +407,7 @@ test_that("tbl_hierarchical table_body group variables are correct with no by", 
     tbl_hierarchical(
       data = ADAE_subset,
       variables = c(AESOC, AEDECOD),
-      denominator = adsl,
+      denominator = cards::ADSL |> dplyr::rename(TRTA = ARM),
       id = USUBJID
     )
   )

--- a/tests/testthat/test-tbl_hierarchical.R
+++ b/tests/testthat/test-tbl_hierarchical.R
@@ -392,3 +392,25 @@ test_that("tbl_hierarchical works with one arm level present", {
 
   expect_snapshot(as.data.frame(res))
 })
+
+# tbl_hierarchical table_body group variables are correct with no by -----------------------
+test_that("tbl_hierarchical table_body group variables are correct with no by", {
+  withr::local_options(list(width = 250))
+
+  ADAE_subset <- cards::ADAE |>
+    dplyr::filter(
+      AESOC %in% unique(cards::ADAE$AESOC)[1:5],
+      AETERM %in% unique(cards::ADAE$AETERM)[1:5]
+    )
+
+  res <- expect_silent(
+    tbl_hierarchical(
+      data = ADAE_subset,
+      variables = c(AESOC, AEDECOD),
+      denominator = adsl,
+      id = USUBJID
+    )
+  )
+
+  expect_snapshot(as.data.frame(res$table_body))
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fixed a bug in `tbl_hierarchical()` where the `group*` variables of the resulting `table_body` were not fully populated.

Closes #2192 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

