### PR TITLE
Fix in `gather_ard()` for regression tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.2.0.9000
+Version: 2.2.0.9001
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Fix in `gather_ard()` for `tbl_regression()` and `tbl_uvregression()`. Previously, only the ARD for the primary regression model(s) would be returned, and now all ARDs are returned including those from subsequent calls to `add_*()` functions. (#2208)
+
 # gtsummary 2.2.0
 
 ### New Features and Functions

--- a/R/gather_ard.R
+++ b/R/gather_ard.R
@@ -22,14 +22,17 @@ gather_ard <- function(x) {
   check_class(x, "gtsummary")
 
   # cycle through the underlying tbls, and get ARD from each
-  if (inherits(x, c("tbl_stack", "tbl_merge", "tbl_uvregression"))) {
+  if (inherits(x, c("tbl_stack", "tbl_merge"))) {
     return(map(x[["tbls"]], gather_ard))
   }
 
   # the ARD for regression models is an additional calculation, so we don't do it by default
+  if (inherits(x, c("tbl_uvregression"))) {
+    x$cards$tbl_uvregression <- map(x[["tbls"]], ~gather_ard(.x)[[1]])
+  }
   if (inherits(x, "tbl_regression")) {
     check_pkg_installed("cardx")
-    return(cardx::ard_regression(x$inputs$x))
+    x$cards$tbl_regression <- cardx::ard_regression(x$inputs$x)
   }
 
   # grab ARD from standard place

--- a/R/tbl_regression.R
+++ b/R/tbl_regression.R
@@ -231,5 +231,6 @@ tbl_regression.default <- function(x,
       indent = 4
     )
   res$call_list <- list(tbl_regression = match.call())
+  res$cards <- list(tbl_regression = NULL)
   res
 }

--- a/R/tbl_uvregression.R
+++ b/R/tbl_uvregression.R
@@ -251,6 +251,7 @@ tbl_uvregression.data.frame <- function(data,
 
   # exporting results ----------------------------------------------------------
   results$inputs <- tbl_uvregression_inputs
+  results$cards <- list(tbl_uvregression = NULL)
   results$call_list <- list(tbl_uvregression = match.call())
 
   results

--- a/tests/testthat/test-gather_ard.R
+++ b/tests/testthat/test-gather_ard.R
@@ -1,5 +1,5 @@
 skip_on_cran()
-skip_if_not(is_pkg_installed("cardx"))
+skip_if_not(is_pkg_installed(c("cardx", "broom.helpers", "car")))
 
 test_that("gather_ard(x) works with `tbl_*()` functions", {
   # tbl_summary()
@@ -23,25 +23,57 @@ test_that("gather_ard(x) works with `tbl_*()` functions", {
   )
 
   # tbl_regression()
-  expect_false(
-    glm(response ~ age + grade, trial, family = binomial()) |>
+  expect_silent(
+    lst_ard <- glm(response ~ age + grade, trial, family = binomial()) |>
       tbl_regression(exponentiate = TRUE) |>
-      gather_ard() |>
-      is_empty()
+      add_global_p() |>
+      gather_ard()
+  )
+  expect_equal(
+    names(lst_ard),
+    c("tbl_regression", "add_global_p")
+  )
+  expect_true(
+    map(lst_ard, ~inherits(.x, "data.frame")) |>
+      unlist() |>
+      all()
   )
 
   # tbl_uvregression()
-  expect_false(
-    tbl_uvregression(
-      trial,
-      method = glm,
-      y = response,
-      method.args = list(family = binomial),
-      exponentiate = TRUE,
-      include = c("age", "grade")
-    ) |>
-      gather_ard() |>
-      is_empty()
+  expect_silent(
+    lst_ard <-
+      tbl_uvregression(
+        trial,
+        method = glm,
+        y = response,
+        method.args = list(family = binomial),
+        exponentiate = TRUE,
+        include = c("age", "grade")
+      ) |>
+      add_global_p() |>
+      gather_ard()
+  )
+  expect_equal(
+    names(lst_ard),
+    c("tbl_uvregression", "add_global_p")
+  )
+  expect_equal(
+    names(lst_ard[["tbl_uvregression"]]),
+    c("age", "grade")
+  )
+  expect_equal(
+    names(lst_ard[["add_global_p"]]),
+    c("age", "grade")
+  )
+  expect_true(
+    map(lst_ard[["tbl_uvregression"]], ~inherits(.x, "data.frame")) |>
+      unlist() |>
+      all()
+  )
+  expect_true(
+    map(lst_ard[["add_global_p"]], ~inherits(.x, "data.frame")) |>
+      unlist() |>
+      all()
   )
 
   # tbl_stack()


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fix in `gather_ard()` for `tbl_regression()` and `tbl_uvregression()`. Previously, only the ARD for the primary regression model(s) would be returned, and now all ARDs are returned including those from subsequent calls to `add_*()` functions. (#2208)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2208

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

