### PR TITLE
Fix in `tbl_merge(merge_vars)` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.2.0.9001
+Version: 2.2.0.9002
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fix in `gather_ard()` for `tbl_regression()` and `tbl_uvregression()`. Previously, only the ARD for the primary regression model(s) would be returned, and now all ARDs are returned including those from subsequent calls to `add_*()` functions. (#2208)
 
+* Fix in `tbl_merge(merge_vars)` argument when a table contained a `"row_type"` column and the tables were not merged by this variable (which is included in the default). (#2205)
+
 # gtsummary 2.2.0
 
 ### New Features and Functions

--- a/tests/testthat/_snaps/tbl_merge.md
+++ b/tests/testthat/_snaps/tbl_merge.md
@@ -55,3 +55,13 @@
       Error in `tbl_merge()`:
       ! The tables in the `tbls` argument do not share any columns specified in `merge_vars` argument and merge cannot be performed.
 
+# tbl_merge(merge_vars)
+
+    Code
+      as.data.frame(tbl)
+    Output
+          **Characteristic** **Beta** **95% CI** **p-value** **Beta** **95% CI**
+      1 Marker Level (ng/mL)    -0.05  -2.5, 2.4        >0.9    -0.05  -2.5, 2.4
+        **p-value**
+      1        >0.9
+

--- a/tests/testthat/test-tbl_merge.R
+++ b/tests/testthat/test-tbl_merge.R
@@ -269,6 +269,13 @@ test_that("tbl_merge(merge_vars)", {
       1L,     "cyl_1",    "**Table 1**",        "gt::md",   FALSE
     )
   )
+
+  # no errors when merging doesn't include row_type (and other defaults)
+  expect_silent({
+    tbl0 <- lm(age ~ marker, trial) |> tbl_regression()
+    tbl <- tbl_merge(list(tbl0, tbl0), merge_vars = "label")
+  })
+  expect_snapshot(as.data.frame(tbl))
 })
 
 test_that("tbl_merge() works with tbl_hierarchical()", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fix in `tbl_merge(merge_vars)` argument when a table contained a `"row_type"` column and the tables were not merged by this variable (which is included in the default). (#2205)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2205

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

