### PR TITLE
Adding `tbl_stack(attr_order)` argument

### DIFF
--- a/R/tbl_stack.R
+++ b/R/tbl_stack.R
@@ -9,7 +9,7 @@
 #'   List of gtsummary objects
 #' @param group_header (`character`)\cr
 #'   Character vector with table headers where length matches the length of `tbls`
-#' @param attr_order (`integer`)\cr
+#' @param attr_order (`integer`) `r lifecycle::badge("experimental")` \cr
 #'   Set the order table attributes are set.
 #'   Tables are stacked in the order they are passed in the `tbls` argument:
 #'   use `attr_order` to specify the order the table attributes take precedent.

--- a/man/tbl_stack.Rd
+++ b/man/tbl_stack.Rd
@@ -21,7 +21,7 @@ Character vector with table headers where length matches the length of \code{tbl
 \item{quiet}{(scalar \code{logical})\cr
 Logical indicating whether to suppress additional messaging. Default is \code{FALSE}.}
 
-\item{attr_order}{(\code{integer})\cr
+\item{attr_order}{(\code{integer}) \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} \cr
 Set the order table attributes are set.
 Tables are stacked in the order they are passed in the \code{tbls} argument:
 use \code{attr_order} to specify the order the table attributes take precedent.

--- a/man/tbl_stack.Rd
+++ b/man/tbl_stack.Rd
@@ -4,7 +4,12 @@
 \alias{tbl_stack}
 \title{Stack tables}
 \usage{
-tbl_stack(tbls, group_header = NULL, quiet = FALSE)
+tbl_stack(
+  tbls,
+  group_header = NULL,
+  quiet = FALSE,
+  attr_order = seq_along(tbls)
+)
 }
 \arguments{
 \item{tbls}{(\code{list})\cr
@@ -15,6 +20,13 @@ Character vector with table headers where length matches the length of \code{tbl
 
 \item{quiet}{(scalar \code{logical})\cr
 Logical indicating whether to suppress additional messaging. Default is \code{FALSE}.}
+
+\item{attr_order}{(\code{integer})\cr
+Set the order table attributes are set.
+Tables are stacked in the order they are passed in the \code{tbls} argument:
+use \code{attr_order} to specify the order the table attributes take precedent.
+For example, to use the header from the second table specify \code{attr_order=2}.
+Default is to set precedent in the order tables are passed.}
 }
 \value{
 A \code{tbl_stack} object

--- a/tests/testthat/test-tbl_stack.R
+++ b/tests/testthat/test-tbl_stack.R
@@ -101,6 +101,20 @@ test_that("tbl_stack(quiet) works", {
   )
 })
 
+test_that("tbl_stack(attr_order) works", {
+  tbl1 <- lm(age ~ trt, trial) |> tbl_regression()
+  tbl2 <- glm(response ~ trt, trial, family = binomial()) |> tbl_regression()
+
+  # check that we get the header from the second table (with the OR in the header)
+  expect_equal(
+    tbl_stack(list(tbl1, tbl2), attr_order = 2) |>
+      as.data.frame() |>
+      names() |>
+      getElement(2),
+    "**log(OR)**"
+  )
+})
+
 test_that("tbl_stack works with no group header", {
   expect_silent(tbl <- tbl_stack(list(t1_summary, t2_summary)))
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The `tbl_stack(attr_order)` argument has been added that allows users to specify the order in which the individual attributes take precedent when they are stacked. For example, to use the headers from the second table, specify `arrr_order=2`. (#2202)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2202

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

