### PR TITLE
Fix for missing counts < 0.5 in tbl_svysummary()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.2.0.9009
+Version: 2.2.0.9010
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * Fix in experimental function `modify_post_fmt_fun()` when tables including this call, did not specify the `rows` argument, and were later stacked. The enquo environment associated with the `rows` argument was empty when the argument is not specified, and the empty environment caused an issue with evaluation if the table was later stacked.
 
+* Fix in `tbl_svysummary(missing='ifany')` when the weighted number of missing observations was <= 0.5. Previously, these counts were coerced to integer and rounded to zero, and therefore, did not appear in the table. (#2229)
+
 * Updated the function name of `modify_column_indent()` to the more accurately named `modify_indent()` as the function operates on cells rather than columns.
 
 * Fix in `gather_ard()` for `tbl_strata_nested_stack()` tables, where the function returned an empty list. (#2223)

--- a/R/brdg_summary.R
+++ b/R/brdg_summary.R
@@ -518,7 +518,7 @@ pier_summary_missing_row <- function(cards,
     variables <-
       cards |>
       dplyr::filter(.data$stat_name == "N_miss", .data$variable %in% .env$variables) |>
-      dplyr::filter(.data$stat > 0L) |>
+      dplyr::filter(.data$stat > 0) |>
       dplyr::pull("variable") |>
       unique()
   }

--- a/tests/testthat/test-as_hux_table.R
+++ b/tests/testthat/test-as_hux_table.R
@@ -1,5 +1,5 @@
 skip_on_cran()
-skip_if_not(is_pkg_installed(c("huxtable", "withr")))
+skip_if_not(is_pkg_installed(c("huxtable", "withr", "broom.helpers")))
 
 my_tbl_summary <- trial |>
   select(trt, age, death) |>

--- a/tests/testthat/test-tbl_svysummary.R
+++ b/tests/testthat/test-tbl_svysummary.R
@@ -600,3 +600,24 @@ test_that("tbl_svysummary() default fmt fn", {
     "11 (5.5%)"
   )
 })
+
+# Fix for missing counts <1 in #2229
+test_that("tbl_svysummary() default fmt fn", {
+  expect_equal(
+    dplyr::tribble(
+      ~category,  ~success, ~weight,
+      "A",        TRUE,     2,
+      "A",        FALSE,    1,
+      "A",        NA,       0.5
+    ) |>
+      survey::svydesign(data = _, id = ~1, weights = ~weight) |>
+      tbl_svysummary(
+        include = success,
+        by = category
+      ) |>
+      getElement("table_body") |>
+      dplyr::filter(row_type == "missing") |>
+      dplyr::pull("stat_1"),
+    "1"
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fix in `tbl_svysummary(missing='ifany')` when the weighted number of missing observations was <= 0.5. Previously, these counts were coerced to integer and rounded to zero, and therefore, did not appear in the table. (#2229)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2229

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

