### PR TITLE
No longer err for unstratified table passed to `add_overall()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.2.0.9011
+Version: 2.2.0.9012
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* The `add_overall()` function no longer returns an error when an unstratified table is passed. Rather, a message is printed and the unaltered table is returned.
+
 * Adding new function `add_difference_row()`. The function is similar to `add_difference()`, except that differences are placed on the rows below the summary statistics. (#2138)
 
 * The `style_*()` and `label_style_*()` functions have gained the `na` argument allowing users to specify how `NA` values are returned.

--- a/R/add_overall.R
+++ b/R/add_overall.R
@@ -70,7 +70,8 @@ add_overall.tbl_summary <- function(x, last = FALSE, col_label = "**Overall**  \
 
   # translating the col_label, if nothing passed by user
   if (missing(col_label)) {
-    paste0("**", translate_string("Overall"), "**  \nN = {style_number(N)}")
+    col_label <-
+      paste0("**", translate_string("Overall"), "**  \nN = {style_number(N)}")
   }
 
   add_overall_generic(

--- a/R/add_overall.R
+++ b/R/add_overall.R
@@ -120,10 +120,12 @@ add_overall_generic <- function(x, last, col_label, statistic, digits, call, cal
 
   # checking that input x has a by var
   if (is_empty(x$inputs[["by"]])) {
-    cli::cli_abort(
-      "Cannot run {.fun add_overall} when original table function is not statified with {.code {calling_fun}(by)}.",
-      call = get_cli_abort_call()
+    cli::cli_inform(
+      c("Cannot add an overall column with {.fun add_overall} when original table
+         is not statified with {.code {calling_fun}(by)}.",
+        i = "Returning table unaltered.")
     )
+    return(x)
   }
 
   # save arguments to pass to original function without `by` stratified --------

--- a/R/brdg_hierarchical.R
+++ b/R/brdg_hierarchical.R
@@ -222,7 +222,7 @@ brdg_hierarchical <- function(cards,
                             default = "**N = {style_number(N)}**"),
           is_empty(by) ~
             get_theme_element("tbl_hierarchical-str:header-noby-noN",
-                            default = "Overall"),
+                            default = "**Overall**"),
           "modify_stat_n" %in% names(x$table_styling$header) ~
             get_theme_element("tbl_hierarchical-str:header-withby",
                             default = "**{level}**  \nN = {style_number(n)}"),

--- a/tests/testthat/_snaps/add_overall.tbl_continuous.md
+++ b/tests/testthat/_snaps/add_overall.tbl_continuous.md
@@ -1,8 +1,8 @@
-# add_overall.tbl_continuous() errors
+# add_overall.tbl_continuous() messaging
 
     Code
-      add_overall(tbl_continuous(mtcars, include = gear, variable = mpg))
-    Condition
-      Error in `add_overall()`:
-      ! Cannot run `add_overall()` when original table function is not statified with `tbl_continuous(by)`.
+      tbl <- add_overall(tbl_continuous(mtcars, include = gear, variable = mpg))
+    Message
+      Cannot add an overall column with `add_overall()` when original table is not statified with `tbl_continuous(by)`.
+      i Returning table unaltered.
 

--- a/tests/testthat/_snaps/add_overall.tbl_summary.md
+++ b/tests/testthat/_snaps/add_overall.tbl_summary.md
@@ -1,10 +1,10 @@
-# add_overall.tbl_summary() errors
+# add_overall.tbl_summary() messaging
 
     Code
-      add_overall(tbl_summary(mtcars))
-    Condition
-      Error in `add_overall()`:
-      ! Cannot run `add_overall()` when original table function is not statified with `tbl_summary(by)`.
+      tbl <- add_overall(tbl_summary(mtcars))
+    Message
+      Cannot add an overall column with `add_overall()` when original table is not statified with `tbl_summary(by)`.
+      i Returning table unaltered.
 
 ---
 

--- a/tests/testthat/_snaps/add_overall.tbl_svysummary.md
+++ b/tests/testthat/_snaps/add_overall.tbl_svysummary.md
@@ -1,10 +1,10 @@
-# add_overall.tbl_svysummary() errors
+# add_overall.tbl_svysummary() messaging
 
     Code
-      add_overall(tbl_svysummary(svy_mtcars))
-    Condition
-      Error in `add_overall()`:
-      ! Cannot run `add_overall()` when original table function is not statified with `tbl_svysummary(by)`.
+      tbl <- add_overall(tbl_svysummary(svy_mtcars))
+    Message
+      Cannot add an overall column with `add_overall()` when original table is not statified with `tbl_svysummary(by)`.
+      i Returning table unaltered.
 
 ---
 

--- a/tests/testthat/_snaps/tbl_hierarchical.md
+++ b/tests/testthat/_snaps/tbl_hierarchical.md
@@ -340,19 +340,19 @@
     Code
       as.data.frame(tbl_hierarchical_count(data = trial, variables = trt))
     Output
-        **Chemotherapy Treatment** Overall
-      1                     Drug A      98
-      2                     Drug B     102
+        **Chemotherapy Treatment** **Overall**
+      1                     Drug A          98
+      2                     Drug B         102
 
 ---
 
     Code
       as.data.frame(tbl_hierarchical_count(data = iris, variables = Species))
     Output
-        **Species** Overall
-      1      setosa      50
-      2  versicolor      50
-      3   virginica      50
+        **Species** **Overall**
+      1      setosa          50
+      2  versicolor          50
+      3   virginica          50
 
 ---
 
@@ -414,23 +414,23 @@
       as.data.frame(tbl_hierarchical_count(data = trial, variables = c(stage, grade),
       include = grade))
     Output
-         **T Stage**  \n    **Grade** Overall
-      1                            T1    <NA>
-      2                             I      17
-      3                            II      23
-      4                           III      13
-      5                            T2    <NA>
-      6                             I      18
-      7                            II      17
-      8                           III      19
-      9                            T3    <NA>
-      10                            I      18
-      11                           II      11
-      12                          III      14
-      13                           T4    <NA>
-      14                            I      15
-      15                           II      17
-      16                          III      18
+         **T Stage**  \n    **Grade** **Overall**
+      1                            T1        <NA>
+      2                             I          17
+      3                            II          23
+      4                           III          13
+      5                            T2        <NA>
+      6                             I          18
+      7                            II          17
+      8                           III          19
+      9                            T3        <NA>
+      10                            I          18
+      11                           II          11
+      12                          III          14
+      13                           T4        <NA>
+      14                            I          15
+      15                           II          17
+      16                          III          18
 
 ---
 
@@ -472,10 +472,10 @@
       as.data.frame(tbl_hierarchical_count(data = trial, variables = trt,
         overall_row = TRUE))
     Output
-        **Chemotherapy Treatment** Overall
-      1     Total number of events     200
-      2                     Drug A      98
-      3                     Drug B     102
+        **Chemotherapy Treatment** **Overall**
+      1     Total number of events         200
+      2                     Drug A          98
+      3                     Drug B         102
 
 ---
 
@@ -500,23 +500,23 @@
     Code
       as.data.frame(res)
     Output
-         **My Stage**  \n    **My Grade** Overall
-      1                                T1      53
-      2                                 I      17
-      3                                II      23
-      4                               III      13
-      5                                T2      54
-      6                                 I      18
-      7                                II      17
-      8                               III      19
-      9                                T3      43
-      10                                I      18
-      11                               II      11
-      12                              III      14
-      13                               T4      50
-      14                                I      15
-      15                               II      17
-      16                              III      18
+         **My Stage**  \n    **My Grade** **Overall**
+      1                                T1          53
+      2                                 I          17
+      3                                II          23
+      4                               III          13
+      5                                T2          54
+      6                                 I          18
+      7                                II          17
+      8                               III          19
+      9                                T3          43
+      10                                I          18
+      11                               II          11
+      12                              III          14
+      13                               T4          50
+      14                                I          15
+      15                               II          17
+      16                              III          18
 
 ---
 
@@ -536,23 +536,23 @@
     Code
       as.data.frame(res)
     Output
-         **T Stage**  \n    **Grade** Overall
-      1                            T1    53,0
-      2                             I    17,0
-      3                            II    23,0
-      4                           III    13,0
-      5                            T2    54,0
-      6                             I    18,0
-      7                            II    17,0
-      8                           III    19,0
-      9                            T3    43,0
-      10                            I    18,0
-      11                           II    11,0
-      12                          III    14,0
-      13                           T4    50,0
-      14                            I    15,0
-      15                           II    17,0
-      16                          III    18,0
+         **T Stage**  \n    **Grade** **Overall**
+      1                            T1        53,0
+      2                             I        17,0
+      3                            II        23,0
+      4                           III        13,0
+      5                            T2        54,0
+      6                             I        18,0
+      7                            II        17,0
+      8                           III        19,0
+      9                            T3        43,0
+      10                            I        18,0
+      11                           II        11,0
+      12                          III        14,0
+      13                           T4        50,0
+      14                            I        15,0
+      15                           II        17,0
+      16                          III        18,0
 
 ---
 
@@ -760,196 +760,196 @@
       187                                                                                                                                                                                                                                                                       P
       188                                                                                                                                                                                                                                                                       Q
       189                                                                                                                                                                                                                                                                       T
-          Overall
-      1      <NA>
-      2      <NA>
-      3      <NA>
-      4      <NA>
-      5      <NA>
-      6      <NA>
-      7      <NA>
-      8      <NA>
-      9      <NA>
-      10        1
-      11     <NA>
-      12     <NA>
-      13     <NA>
-      14     <NA>
-      15     <NA>
-      16        1
-      17     <NA>
-      18     <NA>
-      19     <NA>
-      20     <NA>
-      21        1
-      22     <NA>
-      23     <NA>
-      24     <NA>
-      25     <NA>
-      26     <NA>
-      27     <NA>
-      28     <NA>
-      29        1
-      30     <NA>
-      31     <NA>
-      32     <NA>
-      33     <NA>
-      34        1
-      35     <NA>
-      36     <NA>
-      37        1
-      38     <NA>
-      39     <NA>
-      40     <NA>
-      41     <NA>
-      42     <NA>
-      43     <NA>
-      44        1
-      45     <NA>
-      46     <NA>
-      47     <NA>
-      48     <NA>
-      49     <NA>
-      50        1
-      51     <NA>
-      52     <NA>
-      53     <NA>
-      54     <NA>
-      55     <NA>
-      56     <NA>
-      57     <NA>
-      58     <NA>
-      59        1
-      60     <NA>
-      61     <NA>
-      62     <NA>
-      63        1
-      64     <NA>
-      65     <NA>
-      66     <NA>
-      67     <NA>
-      68     <NA>
-      69        1
-      70     <NA>
-      71     <NA>
-      72     <NA>
-      73     <NA>
-      74        1
-      75     <NA>
-      76     <NA>
-      77     <NA>
-      78     <NA>
-      79     <NA>
-      80     <NA>
-      81        1
-      82     <NA>
-      83     <NA>
-      84     <NA>
-      85     <NA>
-      86     <NA>
-      87        1
-      88     <NA>
-      89     <NA>
-      90     <NA>
-      91     <NA>
-      92     <NA>
-      93     <NA>
-      94     <NA>
-      95        1
-      96     <NA>
-      97     <NA>
-      98     <NA>
-      99     <NA>
-      100    <NA>
-      101       1
-      102    <NA>
-      103    <NA>
-      104    <NA>
-      105    <NA>
-      106       1
-      107    <NA>
-      108    <NA>
-      109    <NA>
-      110    <NA>
-      111    <NA>
-      112    <NA>
-      113       1
-      114    <NA>
-      115       1
-      116    <NA>
-      117    <NA>
-      118    <NA>
-      119       1
-      120    <NA>
-      121    <NA>
-      122    <NA>
-      123    <NA>
-      124    <NA>
-      125    <NA>
-      126    <NA>
-      127    <NA>
-      128    <NA>
-      129       1
-      130    <NA>
-      131    <NA>
-      132    <NA>
-      133    <NA>
-      134    <NA>
-      135    <NA>
-      136    <NA>
-      137       1
-      138    <NA>
-      139    <NA>
-      140    <NA>
-      141    <NA>
-      142    <NA>
-      143    <NA>
-      144       1
-      145    <NA>
-      146    <NA>
-      147    <NA>
-      148    <NA>
-      149    <NA>
-      150    <NA>
-      151    <NA>
-      152    <NA>
-      153       1
-      154    <NA>
-      155    <NA>
-      156    <NA>
-      157    <NA>
-      158       1
-      159    <NA>
-      160    <NA>
-      161    <NA>
-      162    <NA>
-      163    <NA>
-      164    <NA>
-      165    <NA>
-      166       1
-      167    <NA>
-      168    <NA>
-      169    <NA>
-      170    <NA>
-      171       1
-      172    <NA>
-      173    <NA>
-      174    <NA>
-      175    <NA>
-      176    <NA>
-      177       1
-      178    <NA>
-      179    <NA>
-      180    <NA>
-      181    <NA>
-      182       1
-      183    <NA>
-      184    <NA>
-      185    <NA>
-      186    <NA>
-      187    <NA>
-      188    <NA>
-      189       1
+          **Overall**
+      1          <NA>
+      2          <NA>
+      3          <NA>
+      4          <NA>
+      5          <NA>
+      6          <NA>
+      7          <NA>
+      8          <NA>
+      9          <NA>
+      10            1
+      11         <NA>
+      12         <NA>
+      13         <NA>
+      14         <NA>
+      15         <NA>
+      16            1
+      17         <NA>
+      18         <NA>
+      19         <NA>
+      20         <NA>
+      21            1
+      22         <NA>
+      23         <NA>
+      24         <NA>
+      25         <NA>
+      26         <NA>
+      27         <NA>
+      28         <NA>
+      29            1
+      30         <NA>
+      31         <NA>
+      32         <NA>
+      33         <NA>
+      34            1
+      35         <NA>
+      36         <NA>
+      37            1
+      38         <NA>
+      39         <NA>
+      40         <NA>
+      41         <NA>
+      42         <NA>
+      43         <NA>
+      44            1
+      45         <NA>
+      46         <NA>
+      47         <NA>
+      48         <NA>
+      49         <NA>
+      50            1
+      51         <NA>
+      52         <NA>
+      53         <NA>
+      54         <NA>
+      55         <NA>
+      56         <NA>
+      57         <NA>
+      58         <NA>
+      59            1
+      60         <NA>
+      61         <NA>
+      62         <NA>
+      63            1
+      64         <NA>
+      65         <NA>
+      66         <NA>
+      67         <NA>
+      68         <NA>
+      69            1
+      70         <NA>
+      71         <NA>
+      72         <NA>
+      73         <NA>
+      74            1
+      75         <NA>
+      76         <NA>
+      77         <NA>
+      78         <NA>
+      79         <NA>
+      80         <NA>
+      81            1
+      82         <NA>
+      83         <NA>
+      84         <NA>
+      85         <NA>
+      86         <NA>
+      87            1
+      88         <NA>
+      89         <NA>
+      90         <NA>
+      91         <NA>
+      92         <NA>
+      93         <NA>
+      94         <NA>
+      95            1
+      96         <NA>
+      97         <NA>
+      98         <NA>
+      99         <NA>
+      100        <NA>
+      101           1
+      102        <NA>
+      103        <NA>
+      104        <NA>
+      105        <NA>
+      106           1
+      107        <NA>
+      108        <NA>
+      109        <NA>
+      110        <NA>
+      111        <NA>
+      112        <NA>
+      113           1
+      114        <NA>
+      115           1
+      116        <NA>
+      117        <NA>
+      118        <NA>
+      119           1
+      120        <NA>
+      121        <NA>
+      122        <NA>
+      123        <NA>
+      124        <NA>
+      125        <NA>
+      126        <NA>
+      127        <NA>
+      128        <NA>
+      129           1
+      130        <NA>
+      131        <NA>
+      132        <NA>
+      133        <NA>
+      134        <NA>
+      135        <NA>
+      136        <NA>
+      137           1
+      138        <NA>
+      139        <NA>
+      140        <NA>
+      141        <NA>
+      142        <NA>
+      143        <NA>
+      144           1
+      145        <NA>
+      146        <NA>
+      147        <NA>
+      148        <NA>
+      149        <NA>
+      150        <NA>
+      151        <NA>
+      152        <NA>
+      153           1
+      154        <NA>
+      155        <NA>
+      156        <NA>
+      157        <NA>
+      158           1
+      159        <NA>
+      160        <NA>
+      161        <NA>
+      162        <NA>
+      163        <NA>
+      164        <NA>
+      165        <NA>
+      166           1
+      167        <NA>
+      168        <NA>
+      169        <NA>
+      170        <NA>
+      171           1
+      172        <NA>
+      173        <NA>
+      174        <NA>
+      175        <NA>
+      176        <NA>
+      177           1
+      178        <NA>
+      179        <NA>
+      180        <NA>
+      181        <NA>
+      182           1
+      183        <NA>
+      184        <NA>
+      185        <NA>
+      186        <NA>
+      187        <NA>
+      188        <NA>
+      189           1
 
 # tbl_hierarchical_count table_body enables sorting
 

--- a/tests/testthat/test-add_overall.tbl_continuous.R
+++ b/tests/testthat/test-add_overall.tbl_continuous.R
@@ -90,15 +90,15 @@ test_that("add_overall.tbl_continuous() works", {
 })
 
 
-test_that("add_overall.tbl_continuous() errors", {
-  # no stratifying variable
+test_that("add_overall.tbl_continuous() messaging", {
+  # no stratifying variable message
   expect_snapshot(
-    error = TRUE,
-    tbl_continuous(
-      mtcars,
-      include = gear,
-      variable = mpg
-    ) |>
+    tbl <-
+      tbl_continuous(
+        mtcars,
+        include = gear,
+        variable = mpg
+      ) |>
       add_overall()
   )
 })

--- a/tests/testthat/test-add_overall.tbl_summary.R
+++ b/tests/testthat/test-add_overall.tbl_summary.R
@@ -85,11 +85,10 @@ test_that("add_overall.tbl_summary() works", {
 })
 
 
-test_that("add_overall.tbl_summary() errors", {
-  # no stratifying variable
+test_that("add_overall.tbl_summary() messaging", {
+  # no stratifying variable message
   expect_snapshot(
-    error = TRUE,
-    tbl_summary(mtcars) |> add_overall()
+    tbl <- tbl_summary(mtcars) |> add_overall()
   )
 
   # Run add_overall() after after `add_stat_label()`

--- a/tests/testthat/test-add_overall.tbl_svysummary.R
+++ b/tests/testthat/test-add_overall.tbl_svysummary.R
@@ -88,11 +88,10 @@ test_that("add_overall.tbl_svysummary() works", {
 })
 
 
-test_that("add_overall.tbl_svysummary() errors", {
-  # no stratifying variable
+test_that("add_overall.tbl_svysummary() messaging", {
+  # no stratifying variable message
   expect_snapshot(
-    error = TRUE,
-    tbl_svysummary(svy_mtcars) |> add_overall()
+    tbl <- tbl_svysummary(svy_mtcars) |> add_overall()
   )
 
   # Run add_overall() after after `add_stat_label()`


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The `add_overall()` function no longer returns an error when an unstratified table is passed. Rather, a message is printed and the unaltered table is returned.


--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] PR branch has pulled the most recent updates from main branch.
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

