### PR TITLE
Fix `filter_hierarchical()` bug when no `by` variable present

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.2.0.9012
+Version: 2.2.0.9013
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Fixed bug in `filter_hierarchical()` causing an error for unstratified tables.
+
 * The `add_overall()` function no longer returns an error when an unstratified table is passed. Rather, a message is printed and the unaltered table is returned.
 
 * Adding new function `add_difference_row()`. The function is similar to `add_difference()`, except that differences are placed on the rows below the summary statistics. (#2138)

--- a/R/filter_hierarchical.R
+++ b/R/filter_hierarchical.R
@@ -84,10 +84,14 @@ filter_hierarchical <- function(x, filter, keep_empty = FALSE) {
   x_ard <- reshape_x$x_ard
 
   # get `by` variable count rows (do not correspond to a table row)
-  rm_idx <- x_ard |>
-    dplyr::filter(is.na(.data$group1)) |>
-    dplyr::pull("pre_idx") |>
-    unique()
+  rm_idx <- if (!is_empty(ard_args$by)) {
+    x_ard |>
+      dplyr::filter(is.na(.data$group1)) |>
+      dplyr::pull("pre_idx") |>
+      unique()
+  } else {
+    NULL
+  }
 
   # apply filtering
   x_ard_filter <- x_ard |> cards::filter_ard_hierarchical({{ filter }}, keep_empty)

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -107,7 +107,7 @@ sort_hierarchical <- function(x, sort = c("descending", "alphanumeric")) {
 }
 
 .reshape_ard_compare <- function(x, x_ard, ard_args, sort = NULL) {
-  by_cols <- paste0("group", seq_along(length(ard_args$by)), c("", "_level"))
+  by_cols <- if (length(ard_args$by) > 0) c("group1", "group1_level") else NULL
 
   # add dummy rows for variables not in include so their label rows are sorted correctly
   x_ard <- x_ard |> .append_not_incl(ard_args, sort)
@@ -121,8 +121,12 @@ sort_hierarchical <- function(x, sort = c("descending", "alphanumeric")) {
   gps <- x_ard |>
     dplyr::group_keys() |>
     dplyr::mutate(pre_idx = dplyr::row_number()) |>
-    cards::as_card() |>
-    cards::rename_ard_groups_shift(shift = -1) |>
+    cards::as_card()
+
+  # if by variable present, shift grouping columns
+  if (!is_empty(by_cols)) gps <- gps |> cards::rename_ard_groups_shift(shift = -1)
+
+  gps <- gps |>
     dplyr::filter(!.data$variable %in% ard_args$by) |>
     dplyr::rename(label = "variable_level")
 

--- a/tests/testthat/test-filter_hierarchical.R
+++ b/tests/testthat/test-filter_hierarchical.R
@@ -129,6 +129,19 @@ test_that("filter_hierarchical() works with no by variable", {
 
   expect_silent(tbl_f <- filter_hierarchical(tbl_noby, sum(n) / sum(N) > 0.05))
   expect_equal(nrow(tbl_f$table_body), 21)
+
+  # check indentation of results, line 2 should be indented 4 spaces
+  expect_equal(
+    tbl_noby |>
+      .table_styling_expr_to_row_number() |>
+      getElement("table_styling") |>
+      getElement("indent") |>
+      tidyr::unnest(row_numbers) |>
+      dplyr::filter(column == "label", row_numbers %in% 2) |>
+      dplyr::arrange(row_numbers) |>
+      dplyr::pull(n_spaces),
+    4
+  )
 })
 
 test_that("filter_hierarchical() works when some variables not included in x", {

--- a/tests/testthat/test-filter_hierarchical.R
+++ b/tests/testthat/test-filter_hierarchical.R
@@ -115,7 +115,7 @@ test_that("filter_hierarchical() works with no by variable", {
   )
 
   expect_silent(tbl_f <- filter_hierarchical(tbl_noby, sum(n) / sum(N) > 0.05))
-  expect_equal(nrow(tbl_f$table_body), 15)
+  expect_equal(nrow(tbl_f$table_body), 21)
 })
 
 test_that("filter_hierarchical() works when some variables not included in x", {

--- a/tests/testthat/test-filter_hierarchical.R
+++ b/tests/testthat/test-filter_hierarchical.R
@@ -20,6 +20,19 @@ test_that("filter_hierarchical() works", {
 
   # row order is retained
   expect_snapshot(tbl |> as.data.frame())
+
+  # check indentation of results, lines 3,4 should be indented 4 and 8 spaces
+  expect_equal(
+    tbl |>
+      .table_styling_expr_to_row_number() |>
+      getElement("table_styling") |>
+      getElement("indent") |>
+      tidyr::unnest(row_numbers) |>
+      dplyr::filter(column == "label", row_numbers %in% c(3, 4)) |>
+      dplyr::arrange(row_numbers) |>
+      dplyr::pull(n_spaces),
+    c(4, 8)
+  )
 })
 
 test_that("filter_hierarchical(keep_empty) works", {

--- a/tests/testthat/test-filter_hierarchical.R
+++ b/tests/testthat/test-filter_hierarchical.R
@@ -106,6 +106,18 @@ test_that("filter_hierarchical() works with only one variable in x", {
   expect_equal(nrow(tbl_single$table_body), 4)
 })
 
+test_that("filter_hierarchical() works with no by variable", {
+  tbl_noby <- tbl_hierarchical(
+    data = cards::ADAE,
+    denominator = cards::ADSL |> dplyr::rename(TRTA = ARM),
+    variables = c(AEBODSYS, AEDECOD),
+    id = "USUBJID"
+  )
+
+  expect_silent(tbl_f <- filter_hierarchical(tbl_noby, sum(n) / sum(N) > 0.05))
+  expect_equal(nrow(tbl_f$table_body), 15)
+})
+
 test_that("filter_hierarchical() works when some variables not included in x", {
   tbl <- tbl_hierarchical(
     data = ADAE_subset,


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fixed bug in `filter_hierarchical()` causing an error for unstratified tables.

Closes #2233 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

