### PR TITLE
Fix bug in `sort_hierarchical()` when no `by` variable is present

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.2.0.9013
+Version: 2.2.0.9014
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Fixed bug in `sort_hierarchical()` causing some rows to be dropped when sorting unstratified tables. (#2237)
+
 * Fixed bug in `filter_hierarchical()` causing an error for unstratified tables.
 
 * The `add_overall()` function no longer returns an error when an unstratified table is passed. Rather, a message is printed and the unaltered table is returned.

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -72,7 +72,7 @@ sort_hierarchical <- function(x, sort = c("descending", "alphanumeric")) {
 
   # get `by` variable count rows (do not correspond to a table row)
   rm_idx <- x_ard |>
-    dplyr::filter(is.na(.data$group1)) |>
+    dplyr::filter(if (!is_empty(ard_args$by)) is.na(.data$group1) else context != "hierarchical") |>
     dplyr::pull("pre_idx") |>
     unique()
 

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -91,7 +91,7 @@ sort_hierarchical <- function(x, sort = c("descending", "alphanumeric")) {
       select(-"tmp")
   }
 
-  # if overall column present, filter x$cards$add_overall
+  # if overall column present, sort x$cards$add_overall
   if ("add_overall" %in% names(x$cards)) {
     # update x$cards$add_overall
     x$cards$add_overall <- x$cards$add_overall |> cards::sort_ard_hierarchical(sort)

--- a/R/tbl_hierarchical.R
+++ b/R/tbl_hierarchical.R
@@ -28,8 +28,8 @@
 #'   The argument is required for `tbl_hierarchical()` and optional for `tbl_hierarchical_count()`.
 #'   The `denominator` argument must be specified when `id` is used to calculate event rates.
 #' @param include ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
-#'   variables from `hierarchy` for which summary statistics should be returned (on the variable label rows) Including
-#'   the last element of `hierarchy` has no effect since each level has its own row for this variable.
+#'   variables from `variables` for which summary statistics should be returned (on the variable label rows) Including
+#'   the last element of `variables` has no effect since each level has its own row for this variable.
 #'   The default is `everything()`.
 #' @param statistic ([`formula-list-selector`][syntax])\cr
 #'   used to specify the summary statistics to display for all variables in `tbl_hierarchical()`.

--- a/man/tbl_ard_hierarchical.Rd
+++ b/man/tbl_ard_hierarchical.Rd
@@ -26,8 +26,8 @@ a single column from \code{data}. Summary statistics will be stratified by this 
 Default is \code{NULL}.}
 
 \item{include}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
-variables from \code{hierarchy} for which summary statistics should be returned (on the variable label rows) Including
-the last element of \code{hierarchy} has no effect since each level has its own row for this variable.
+variables from \code{variables} for which summary statistics should be returned (on the variable label rows) Including
+the last element of \code{variables} has no effect since each level has its own row for this variable.
 The default is \code{everything()}.}
 
 \item{statistic}{(\code{\link[=syntax]{formula-list-selector}})\cr

--- a/man/tbl_hierarchical.Rd
+++ b/man/tbl_hierarchical.Rd
@@ -52,8 +52,8 @@ a single column from \code{data}. Summary statistics will be stratified by this 
 Default is \code{NULL}.}
 
 \item{include}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
-variables from \code{hierarchy} for which summary statistics should be returned (on the variable label rows) Including
-the last element of \code{hierarchy} has no effect since each level has its own row for this variable.
+variables from \code{variables} for which summary statistics should be returned (on the variable label rows) Including
+the last element of \code{variables} has no effect since each level has its own row for this variable.
 The default is \code{everything()}.}
 
 \item{statistic}{(\code{\link[=syntax]{formula-list-selector}})\cr

--- a/tests/testthat/test-sort_hierarchical.R
+++ b/tests/testthat/test-sort_hierarchical.R
@@ -139,6 +139,19 @@ test_that("sort_hierarchical() works when some variables not included in x", {
   expect_message(sort_hierarchical(tbl))
 })
 
+test_that("sort_hierarchical() works with no by variable", {
+  tbl <- tbl_hierarchical(
+    data = ADAE_subset,
+    denominator = cards::ADSL,
+    variables = c(AEBODSYS, AEDECOD),
+    id = "USUBJID",
+    overall_row = TRUE
+  )
+
+  expect_silent(tbl_sort <- sort_hierarchical(tbl))
+  expect_equal(nrow(tbl_sort$table_body), nrow(tbl$table_body))
+})
+
 test_that("sort_hierarchical() works with add_overall()", {
   tbl_s <- sort_hierarchical(tbl)
   tbl_o <- tbl |> add_overall()


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fixed bug in `sort_hierarchical()` causing some rows to be dropped when sorting unstratified tables.

Closes #2237 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] PR branch has pulled the most recent updates from main branch.
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] Increment the version number using `usethis::use_version(which = "dev")` 
- [x] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

