### PR TITLE
fix tbl_split examples

### DIFF
--- a/R/tbl_split.R
+++ b/R/tbl_split.R
@@ -42,21 +42,22 @@
 #' trial |>
 #'   tbl_summary(by = trt) |>
 #'   tbl_split_by_rows(variables = c(marker, grade)) |>
-#'   tail(n = 1) # Print only last table for simplicity
+#'   dplyr::last() # Print only last table for simplicity
 #'
 #' # Example 2 ----------------------------------
 #' # Split by rows with row numbers
 #' trial |>
 #'   tbl_summary(by = trt) |>
 #'   tbl_split_by_rows(row_numbers = c(5, 7)) |>
-#'   tail(n = 1) # Print only last table for simplicity
+#'   dplyr::last() # Print only last table for simplicity
 #'
 #' # Example 3 ----------------------------------
 #' # Split by columns
 #' trial |>
 #'   tbl_summary(by = trt, include = c(death, ttdeath)) |>
 #'   tbl_split_by_columns(groups = list("stat_1", "stat_2")) |>
-#'   tail(n = 1) # Print only last table for simplicity
+#'   tail(n = 1) |> # Print only last table for simplicity
+#'   unlist()
 #'
 #' # Example 4 ----------------------------------
 #' # Both row and column splitting
@@ -64,7 +65,7 @@
 #'   tbl_summary(by = trt) |>
 #'   tbl_split_by_rows(variables = c(marker, grade)) |>
 #'   tbl_split_by_columns(groups = list("stat_1", "stat_2")) |>
-#'   tail(n = 1) # Print only last table for simplicity
+#'   dplyr::last() # Print only last table for simplicity
 #'
 #' # Example 5 ------------------------------
 #' # Split by rows with footnotes and caption
@@ -92,7 +93,7 @@
 #'   modify_source_note("Some source note!") |>
 #'   tbl_split_by_rows(variables = c(marker, stage, grade), footnotes = "last", caption = "first") |>
 #'   tail(n = 2) |>
-#'   head(n = 1) # Print only one but not last table for simplicity
+#'   dplyr::first() # Print only one but not last table for simplicity
 #'
 #' @name tbl_split_by
 NULL

--- a/man/tbl_split_by.Rd
+++ b/man/tbl_split_by.Rd
@@ -76,21 +76,22 @@ the last row.
 trial |>
   tbl_summary(by = trt) |>
   tbl_split_by_rows(variables = c(marker, grade)) |>
-  tail(n = 1) # Print only last table for simplicity
+  dplyr::last() # Print only last table for simplicity
 
 # Example 2 ----------------------------------
 # Split by rows with row numbers
 trial |>
   tbl_summary(by = trt) |>
   tbl_split_by_rows(row_numbers = c(5, 7)) |>
-  tail(n = 1) # Print only last table for simplicity
+  dplyr::last() # Print only last table for simplicity
 
 # Example 3 ----------------------------------
 # Split by columns
 trial |>
   tbl_summary(by = trt, include = c(death, ttdeath)) |>
   tbl_split_by_columns(groups = list("stat_1", "stat_2")) |>
-  tail(n = 1) # Print only last table for simplicity
+  tail(n = 1) |> # Print only last table for simplicity
+  unlist()
 
 # Example 4 ----------------------------------
 # Both row and column splitting
@@ -98,7 +99,7 @@ trial |>
   tbl_summary(by = trt) |>
   tbl_split_by_rows(variables = c(marker, grade)) |>
   tbl_split_by_columns(groups = list("stat_1", "stat_2")) |>
-  tail(n = 1) # Print only last table for simplicity
+  dplyr::last() # Print only last table for simplicity
 
 # Example 5 ------------------------------
 # Split by rows with footnotes and caption
@@ -126,6 +127,6 @@ trial |>
   modify_source_note("Some source note!") |>
   tbl_split_by_rows(variables = c(marker, stage, grade), footnotes = "last", caption = "first") |>
   tail(n = 2) |>
-  head(n = 1) # Print only one but not last table for simplicity
+  dplyr::first() # Print only one but not last table for simplicity
 \dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
* Fix rendering of examples in `tbl_split_by` reference documentation.


--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

