### PR TITLE
Make hierarchical table sorting more flexible

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ BugReports: https://github.com/ddsjoberg/gtsummary/issues
 Depends: 
     R (>= 4.2)
 Imports: 
-    cards (>= 0.6.1.9007),
+    cards (>= 0.6.1.9015),
     cli (>= 3.6.3),
     dplyr (>= 1.1.3),
     glue (>= 1.8.0),
@@ -89,7 +89,7 @@ Suggests:
     withr (>= 2.5.0),
     workflows (>= 0.2.4)
 Remotes:
-    insightsengineering/cards@487-sort_hierarchical_vars
+    insightsengineering/cards
 VignetteBuilder: 
     knitr
 Config/Needs/check: hms

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -89,7 +89,7 @@ Suggests:
     withr (>= 2.5.0),
     workflows (>= 0.2.4)
 Remotes:
-    insightsengineering/cards
+    insightsengineering/cards@487-sort_hierarchical_vars
 VignetteBuilder: 
     knitr
 Config/Needs/check: hms

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # gtsummary (development version)
 
+* Refactored `sort_hierarchical()` to allow for different sorting methods at each hierarchy variable level.
+
+* Updated `sort_hierarchical()` and `filter_hierarchical()` to always keep attribute and total N rows at the bottom of the ARD.
+
 * Bug fix in `add_p.tbl_cross()` when custom p-value methods were created without any additional arguments. The test and test label would revert to the default, and this is resolved.
 
 * Added parameters `var` and `quiet` to `filter_hierarchical()` to allow for filtering by specific hierarchy variables and to silence messages, respectively.

--- a/R/brdg_hierarchical.R
+++ b/R/brdg_hierarchical.R
@@ -259,7 +259,8 @@ pier_summary_hierarchical <- function(cards,
   cards_no_attr <-
     cards |>
     dplyr::filter(.data$variable %in% .env$variables, !.data$context %in% "attributes") |>
-    cards::apply_fmt_fun()
+    cards::apply_fmt_fun() |>
+    mutate(sort_idx = dplyr::row_number())
 
   # construct formatted statistics ---------------------------------------------
   df_glued <-
@@ -305,7 +306,8 @@ pier_summary_hierarchical <- function(cards,
                           as.character()
                       }
                     ),
-                  label = .data$variable_level |> unlist()
+                  label = .data$variable_level |> unlist(),
+                  sort_idx = df_variable_level_stats$sort_idx[1]
                 ) |>
                   dplyr::bind_cols(
                     df_variable_level_stats[1, ] |> select(cards::all_ard_groups())
@@ -354,6 +356,7 @@ pier_summary_hierarchical <- function(cards,
     select(-cards::all_ard_groups()) |>
     tidyr::unnest(cols = "df_stats") |>
     tidyr::unnest(cols = "stat") |>
+    arrange(sort_idx) |>
     tidyr::pivot_wider(
       id_cols = c("row_type", "var_label", "variable", "label", cards::all_ard_groups()),
       names_from = "gts_column",
@@ -374,9 +377,6 @@ pier_summary_hierarchical <- function(cards,
   if (length(variables) > 1 && length(include) > 1) {
     gps <- df_result_levels |> select(cards::all_ard_groups("names")) |> names()
 
-    df_result_levels <- df_result_levels |>
-      mutate(across(cards::all_ard_groups("names"), .fns = ~tidyr::replace_na(., " "), .names = "{.col}_sort"))
-
     for (i in seq_along(gps)) {
       df_result_levels[df_result_levels$variable == variables[i], ] <-
         df_result_levels[df_result_levels$variable == variables[i], ] |>
@@ -385,12 +385,6 @@ pier_summary_hierarchical <- function(cards,
           !!paste0(gps[i], "_level") := dplyr::coalesce(!!sym(paste0(gps[i], "_level")), .data$label)
         )
     }
-    ord <- c(rbind(paste0(gps, "_level"), paste0(gps, "_sort")))
-    df_result_levels <- df_result_levels |>
-      dplyr::group_by(across(cards::all_ard_groups("levels"))) |>
-      dplyr::arrange(across(all_of(ord))) |>
-      dplyr::ungroup() |>
-      dplyr::select(-ends_with("_sort"))
   }
 
   df_result_levels

--- a/R/brdg_hierarchical.R
+++ b/R/brdg_hierarchical.R
@@ -356,7 +356,7 @@ pier_summary_hierarchical <- function(cards,
     select(-cards::all_ard_groups()) |>
     tidyr::unnest(cols = "df_stats") |>
     tidyr::unnest(cols = "stat") |>
-    arrange(sort_idx) |>
+    dplyr::arrange(.data$sort_idx) |>
     tidyr::pivot_wider(
       id_cols = c("row_type", "var_label", "variable", "label", cards::all_ard_groups()),
       names_from = "gts_column",

--- a/R/filter_hierarchical.R
+++ b/R/filter_hierarchical.R
@@ -52,7 +52,7 @@
 #'    treatment groups observed more than 3 AEs
 #' - `filter = n_2 > 2`: keep rows where the `"Xanomeline High Dose"` treatment group observed more than 2 AEs
 #'
-#' @return A `gtsummary` of the same class as `x`.
+#' @return a gtsummary table of the same class as `x`.
 #'
 #' @seealso [sort_hierarchical()]
 #'

--- a/R/filter_hierarchical.R
+++ b/R/filter_hierarchical.R
@@ -173,9 +173,9 @@ filter_hierarchical.tbl_hierarchical <- function(x, filter, var = NULL, keep_emp
       dplyr::pull("pre_idx") |>
       unique()
 
-    # keep total N row
+    # keep total N, attribute rows
     idx_overall_filter <- x_ard_overall_col$pre_idx |>
-      intersect(c(idx_overall_filter, which(x_ard_overall_col$variable == "..ard_total_n..")))
+      intersect(c(idx_overall_filter, which(x_ard_overall_col$context %in% c("total_n", "attributes"))))
 
     # update x$cards$add_overall
     x$cards$add_overall <- x$cards$add_overall[idx_overall_filter, ]

--- a/R/filter_hierarchical.R
+++ b/R/filter_hierarchical.R
@@ -114,7 +114,7 @@ filter_hierarchical.tbl_hierarchical <- function(x, filter, var = NULL, keep_emp
   # check input
   check_not_missing(x)
 
-  cls <- if (is(x, "tbl_ard_hierarchical")) "tbl_ard_hierarchical" else "tbl_hierarchical"
+  cls <- class(x)[1]
   ard_args <- attributes(x$cards[[cls]])$args
   x_ard <- x$cards[[cls]]
 

--- a/R/filter_hierarchical.R
+++ b/R/filter_hierarchical.R
@@ -69,7 +69,7 @@
 #'     data = ADAE_subset,
 #'     variables = c(AEBODSYS, AEDECOD),
 #'     by = TRTA,
-#'     denominator = cards::ADSL |> mutate(TRTA = ARM),
+#'     denominator = cards::ADSL,
 #'     id = USUBJID,
 #'     overall_row = TRUE
 #'   )

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -28,6 +28,11 @@
 #'   Defaults to `everything() ~ "descending"`.
 #' @inheritParams rlang::args_dots_empty
 #'
+#' @note
+#' When sorting a table that includes an overall column [add_overall()] must be called to add the overall column
+#' _before_ `sort_hierarchical()` is called.
+#'
+#'
 #' @return a gtsummary table of the same class as `x`.
 #'
 #' @seealso [filter_hierarchical()]

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -61,7 +61,7 @@
 #'
 #' # Example 3 ----------------------------------------------
 #' # Sort `AEBODSYS` alphanumerically, `AEDECOD` by descending frequency
-#' sort_hierarchical(tbl, sort = list(AEBODSYS ~ "alphanumeric", AEDECOD ~ "descending"))
+#' sort_hierarchical(tbl, sort = list(AEBODSYS = "alphanumeric", AEDECOD = "descending"))
 #'
 #' reset_gtsummary_theme()
 NULL

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -91,11 +91,11 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = everything() ~ "descend
   if (is.character(sort)) {
     sort <- stats::as.formula(paste0("everything() ~ '", sort, "'"))
   }
-  process_formula_selectors(
+  cards::process_formula_selectors(
     as.list(ard_args$variables) |> data.frame() |> stats::setNames(ard_args$variables),
     sort = sort
   )
-  fill_formula_selectors(
+  cards::fill_formula_selectors(
     as.list(ard_args$variables) |> data.frame() |> stats::setNames(ard_args$variables),
     sort = everything() ~ "descending"
   )

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -41,7 +41,7 @@
 #'     data = ADAE_subset,
 #'     variables = c(AEBODSYS, AEDECOD),
 #'     by = TRTA,
-#'     denominator = cards::ADSL |> mutate(TRTA = ARM),
+#'     denominator = cards::ADSL,
 #'     id = USUBJID,
 #'     overall_row = TRUE
 #'   ) |>

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -225,7 +225,7 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = everything() ~ "descend
         dplyr::group_by(across(all_of(cards::all_ard_group_n((length(ard_args$by) + 1):i)))) |>
         dplyr::group_map(function(.df, .g) {
           # get pseudo-summary row stat value for descending sort
-          if (!is.null(sort) && sort == "descending") {
+          if (!is.null(sort) && sort[v] == "descending") {
             stat_nm <- setdiff(.df$stat_name, "N")[1]
             sum <- .df |>
               dplyr::filter(.data$stat_name == !!stat_nm) |>
@@ -238,8 +238,8 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = everything() ~ "descend
             .df[1, ] |> mutate(
               variable = g_cur,
               variable_level = .g[[ncol(.g)]],
-              stat_name = if (!is.null(sort) && sort == "descending") stat_nm else "no_stat",
-              stat = if (!is.null(sort) && sort == "descending") list(sum) else list(0),
+              stat_name = if (!is.null(sort) && sort[v] == "descending") stat_nm else "no_stat",
+              stat = if (!is.null(sort) && sort[v] == "descending") list(sum) else list(0),
               tmp = TRUE
             )
           } else {

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -12,19 +12,23 @@
 #' @param x (`tbl_hierarchical`, `tbl_hierarchical_count`, `tbl_ard_hierarchical`)\cr
 #'   a hierarchical gtsummary table of class `'tbl_hierarchical'`, `'tbl_hierarchical_count'`,
 #'   or `'tbl_ard_hierarchical'`.
-#' @param sort (`string`)\cr
-#'   type of sorting to perform. Value must be one of:
-#'   - `"alphanumeric"` - at each hierarchy level of the table, rows are ordered alphanumerically (i.e. A to Z)
-#'     by label text.
-#'   - `"descending"` - at each hierarchy level of the table, count sums are calculated for each row and rows are
-#'     sorted in descending order by sum. If `sort = "descending"`, the `n` statistic is used to calculate row sums if
-#'     included in `statistic` for all variables, otherwise `p` is used. If neither `n` nor `p` are present in `x` for
-#'     all variables, an error will occur.
+#' @param sort ([`formula-list-selector`][syntax], `string`)\cr
+#'   a named list, a list of formulas, a single formula where the list element is a named list of functions
+#'   (or the RHS of a formula), or a string specifying the types of sorting to perform at each hierarchy level.
+#'   If the sort method for any variable is not specified then the method will default to `"descending"`. If a single
+#'   unnamed string is supplied it is applied to all hierarchy levels. For each variable, the value specified must
+#'   be one of:
+#'   - `"alphanumeric"` - at the specified hierarchy level, groups are ordered alphanumerically (i.e. A to Z) by
+#'     `variable_level` text.
+#'   - `"descending"` - at the specified hierarchy level, count sums are calculated for each row and rows are sorted in
+#'     descending order by sum. If `sort` is `"descending"` for a given variable and `n` is included in `statistic` for
+#'     the variable then `n` is used to calculate row sums, otherwise `p` is used. If neither `n` nor `p` are present
+#'     in `x` for the variable, an error will occur.
 #'
-#'   Defaults to `"descending"`.
+#'   Defaults to `everything() ~ "descending"`.
 #' @inheritParams rlang::args_dots_empty
 #'
-#' @return A `gtsummary` of the same class as `x`.
+#' @return a gtsummary table of the same class as `x`.
 #'
 #' @seealso [filter_hierarchical()]
 #' @name sort_hierarchical
@@ -47,12 +51,17 @@
 #'   ) |>
 #'   add_overall()
 #'
-#'
-#' # Example 1 - Descending Frequency Sort ------------------
+#' # Example 1 ----------------------------------------------
+#' # Sort all variables by descending frequency (default)
 #' sort_hierarchical(tbl)
 #'
-#' # Example 2 - Alphanumeric Sort --------------------------
-#' sort_hierarchical(tbl, sort = "alphanumeric")
+#' # Example 2 ----------------------------------------------
+#' # Sort all variables alphanumerically
+#' sort_hierarchical(tbl, sort = everything() ~ "alphanumeric")
+#'
+#' # Example 3 ----------------------------------------------
+#' # Sort `AEBODSYS` alphanumerically, `AEDECOD` by descending frequency
+#' sort_hierarchical(tbl, sort = list(AEBODSYS ~ "alphanumeric", AEDECOD ~ "descending"))
 #'
 #' reset_gtsummary_theme()
 NULL
@@ -68,16 +77,34 @@ sort_hierarchical <- function(x, ...) {
 
 #' @rdname sort_hierarchical
 #' @export
-sort_hierarchical.tbl_hierarchical <- function(x, sort = c("descending", "alphanumeric"), ...) {
+sort_hierarchical.tbl_hierarchical <- function(x, sort = everything() ~ "descending", ...) {
   set_cli_abort_call()
 
   # check input
   check_not_missing(x)
 
-  sort <- arg_match(sort, error_call = get_cli_abort_call())
   cls <- class(x)[1]
   ard_args <- attributes(x$cards[[cls]])$args
   x_ard <- x$cards[[cls]]
+
+  # get and check sorting method(s)
+  if (is.character(sort)) {
+    sort <- stats::as.formula(paste0("everything() ~ '", sort, "'"))
+  }
+  process_formula_selectors(
+    as.list(ard_args$variables) |> data.frame() |> stats::setNames(ard_args$variables),
+    sort = sort
+  )
+  fill_formula_selectors(
+    as.list(ard_args$variables) |> data.frame() |> stats::setNames(ard_args$variables),
+    sort = everything() ~ "descending"
+  )
+  if (!all(unlist(sort) %in% c("descending", "alphanumeric"))) {
+    cli::cli_abort(
+      "Sorting type must be either {.val descending} or {.val alphanumeric} for all variables.",
+      call = get_cli_abort_call()
+    )
+  }
 
   # add row indices match structure of ard to x$table_body
   reshape_x <- .reshape_ard_compare(x, x_ard, ard_args, sort)

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -99,12 +99,11 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = everything() ~ "descend
     as.list(ard_args$variables) |> data.frame() |> stats::setNames(ard_args$variables),
     sort = everything() ~ "descending"
   )
-  if (!all(unlist(sort) %in% c("descending", "alphanumeric"))) {
-    cli::cli_abort(
-      "Sorting type must be either {.val descending} or {.val alphanumeric} for all variables.",
-      call = get_cli_abort_call()
-    )
-  }
+  cards::check_list_elements(
+    x = sort,
+    predicate = \(x) x %in% c("descending", "alphanumeric"),
+    error_msg = "Sorting type must be either {.val descending} or {.val alphanumeric} for all variables."
+  )
 
   # add row indices match structure of ard to x$table_body
   reshape_x <- .reshape_ard_compare(x, x_ard, ard_args, sort)

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -86,7 +86,9 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = c("descending", "alphan
 
   # get `by` variable count rows (do not correspond to a table row)
   rm_idx <- x_ard |>
-    dplyr::filter(if (!is_empty(ard_args$by)) is.na(.data$group1) else .data$context != "hierarchical") |>
+    dplyr::filter(
+      if (!is_empty(ard_args$by)) is.na(.data$group1) else !.data$context %in% c("hierarchical", "total_n", "attributes")
+    ) |>
     dplyr::pull("pre_idx") |>
     unique()
 
@@ -95,6 +97,7 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = c("descending", "alphan
 
   # pull updated index order after sorting
   idx_sort <- x_ard_sort |>
+    dplyr::filter(!.data$context %in% c("total_n", "attributes")) |>
     dplyr::pull("pre_idx") |>
     unique() |>
     setdiff(rm_idx)

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -75,7 +75,7 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = c("descending", "alphan
   check_not_missing(x)
 
   sort <- arg_match(sort, error_call = get_cli_abort_call())
-  cls <- if (is(x, "tbl_ard_hierarchical")) "tbl_ard_hierarchical" else "tbl_hierarchical"
+  cls <- class(x)[1]
   ard_args <- attributes(x$cards[[cls]])$args
   x_ard <- x$cards[[cls]]
 

--- a/R/tbl_ard_hierarchical.R
+++ b/R/tbl_ard_hierarchical.R
@@ -25,7 +25,7 @@
 #'     data = ADAE_subset,
 #'     variables = c(AESOC, AETERM),
 #'     by = TRTA,
-#'     denominator = cards::ADSL |> mutate(TRTA = ARM),
+#'     denominator = cards::ADSL,
 #'     id = USUBJID
 #'   )
 #'
@@ -42,7 +42,7 @@
 #'     data = ADAE_subset,
 #'     variables = c(AESOC, AETERM),
 #'     by = TRTA,
-#'     denominator = cards::ADSL |> mutate(TRTA = ARM)
+#'     denominator = cards::ADSL
 #'   )
 #'
 #' tbl_ard_hierarchical(

--- a/R/tbl_hierarchical.R
+++ b/R/tbl_hierarchical.R
@@ -73,7 +73,7 @@
 #'   data = ADAE_subset,
 #'   variables = c(AESOC, AETERM),
 #'   by = TRTA,
-#'   denominator = cards::ADSL |> mutate(TRTA = ARM),
+#'   denominator = cards::ADSL,
 #'   id = USUBJID,
 #'   digits = everything() ~ list(p = 1),
 #'   overall_row = TRUE,
@@ -86,7 +86,7 @@
 #'   variables = c(AESOC, AESEV),
 #'   by = TRTA,
 #'   id = USUBJID,
-#'   denominator = cards::ADSL |> mutate(TRTA = ARM),
+#'   denominator = cards::ADSL,
 #'   include = AESEV,
 #'   label = list(AESEV = "Highest Severity")
 #' )

--- a/R/tbl_split.R
+++ b/R/tbl_split.R
@@ -56,7 +56,7 @@
 #' trial |>
 #'   tbl_summary(by = trt, include = c(death, ttdeath)) |>
 #'   tbl_split_by_columns(groups = list("stat_1", "stat_2")) |>
-#'   dplyr::tail(n = 1) # Print only last table for simplicity
+#'   dplyr::last() # Print only last table for simplicity
 #'
 #' # Example 4 ----------------------------------
 #' # Both row and column splitting

--- a/man/filter_hierarchical.Rd
+++ b/man/filter_hierarchical.Rd
@@ -112,7 +112,7 @@ tbl <-
     data = ADAE_subset,
     variables = c(AEBODSYS, AEDECOD),
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM),
+    denominator = cards::ADSL,
     id = USUBJID,
     overall_row = TRUE
   )

--- a/man/filter_hierarchical.Rd
+++ b/man/filter_hierarchical.Rd
@@ -58,7 +58,7 @@ all rows filtered out. Default is \code{FALSE}.}
 Logical indicating whether to suppress any messaging. Default is \code{FALSE}.}
 }
 \value{
-A \code{gtsummary} of the same class as \code{x}.
+a gtsummary table of the same class as \code{x}.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}\cr

--- a/man/sort_hierarchical.Rd
+++ b/man/sort_hierarchical.Rd
@@ -62,7 +62,7 @@ tbl <-
     data = ADAE_subset,
     variables = c(AEBODSYS, AEDECOD),
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM),
+    denominator = cards::ADSL,
     id = USUBJID,
     overall_row = TRUE
   ) |>

--- a/man/sort_hierarchical.Rd
+++ b/man/sort_hierarchical.Rd
@@ -53,6 +53,10 @@ sorted in descending order by sum (default).
 sorts tables in alphanumeric order.
 }
 }
+\note{
+When sorting a table that includes an overall column \code{\link[=add_overall]{add_overall()}} must be called to add the overall column
+\emph{before} \code{sort_hierarchical()} is called.
+}
 \examples{
 \dontshow{if ((identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 theme_gtsummary_compact()

--- a/man/sort_hierarchical.Rd
+++ b/man/sort_hierarchical.Rd
@@ -82,7 +82,7 @@ sort_hierarchical(tbl, sort = everything() ~ "alphanumeric")
 
 # Example 3 ----------------------------------------------
 # Sort `AEBODSYS` alphanumerically, `AEDECOD` by descending frequency
-sort_hierarchical(tbl, sort = list(AEBODSYS ~ "alphanumeric", AEDECOD ~ "descending"))
+sort_hierarchical(tbl, sort = list(AEBODSYS = "alphanumeric", AEDECOD = "descending"))
 
 reset_gtsummary_theme()
 \dontshow{\}) # examplesIf}

--- a/man/sort_hierarchical.Rd
+++ b/man/sort_hierarchical.Rd
@@ -9,11 +9,11 @@
 \usage{
 sort_hierarchical(x, ...)
 
-\method{sort_hierarchical}{tbl_hierarchical}(x, sort = c("descending", "alphanumeric"), ...)
+\method{sort_hierarchical}{tbl_hierarchical}(x, sort = everything() ~ "descending", ...)
 
-\method{sort_hierarchical}{tbl_hierarchical_count}(x, sort = c("descending", "alphanumeric"), ...)
+\method{sort_hierarchical}{tbl_hierarchical_count}(x, sort = everything() ~ "descending", ...)
 
-\method{sort_hierarchical}{tbl_ard_hierarchical}(x, sort = c("descending", "alphanumeric"), ...)
+\method{sort_hierarchical}{tbl_ard_hierarchical}(x, sort = everything() ~ "descending", ...)
 }
 \arguments{
 \item{x}{(\code{tbl_hierarchical}, \code{tbl_hierarchical_count}, \code{tbl_ard_hierarchical})\cr
@@ -22,21 +22,25 @@ or \code{'tbl_ard_hierarchical'}.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{sort}{(\code{string})\cr
-type of sorting to perform. Value must be one of:
+\item{sort}{(\code{\link[=syntax]{formula-list-selector}}, \code{string})\cr
+a named list, a list of formulas, a single formula where the list element is a named list of functions
+(or the RHS of a formula), or a string specifying the types of sorting to perform at each hierarchy level.
+If the sort method for any variable is not specified then the method will default to \code{"descending"}. If a single
+unnamed string is supplied it is applied to all hierarchy levels. For each variable, the value specified must
+be one of:
 \itemize{
-\item \code{"alphanumeric"} - at each hierarchy level of the table, rows are ordered alphanumerically (i.e. A to Z)
-by label text.
-\item \code{"descending"} - at each hierarchy level of the table, count sums are calculated for each row and rows are
-sorted in descending order by sum. If \code{sort = "descending"}, the \code{n} statistic is used to calculate row sums if
-included in \code{statistic} for all variables, otherwise \code{p} is used. If neither \code{n} nor \code{p} are present in \code{x} for
-all variables, an error will occur.
+\item \code{"alphanumeric"} - at the specified hierarchy level, groups are ordered alphanumerically (i.e. A to Z) by
+\code{variable_level} text.
+\item \code{"descending"} - at the specified hierarchy level, count sums are calculated for each row and rows are sorted in
+descending order by sum. If \code{sort} is \code{"descending"} for a given variable and \code{n} is included in \code{statistic} for
+the variable then \code{n} is used to calculate row sums, otherwise \code{p} is used. If neither \code{n} nor \code{p} are present
+in \code{x} for the variable, an error will occur.
 }
 
-Defaults to \code{"descending"}.}
+Defaults to \code{everything() ~ "descending"}.}
 }
 \value{
-A \code{gtsummary} of the same class as \code{x}.
+a gtsummary table of the same class as \code{x}.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}\cr
@@ -68,12 +72,17 @@ tbl <-
   ) |>
   add_overall()
 
-
-# Example 1 - Descending Frequency Sort ------------------
+# Example 1 ----------------------------------------------
+# Sort all variables by descending frequency (default)
 sort_hierarchical(tbl)
 
-# Example 2 - Alphanumeric Sort --------------------------
-sort_hierarchical(tbl, sort = "alphanumeric")
+# Example 2 ----------------------------------------------
+# Sort all variables alphanumerically
+sort_hierarchical(tbl, sort = everything() ~ "alphanumeric")
+
+# Example 3 ----------------------------------------------
+# Sort `AEBODSYS` alphanumerically, `AEDECOD` by descending frequency
+sort_hierarchical(tbl, sort = list(AEBODSYS ~ "alphanumeric", AEDECOD ~ "descending"))
 
 reset_gtsummary_theme()
 \dontshow{\}) # examplesIf}

--- a/man/tbl_ard_hierarchical.Rd
+++ b/man/tbl_ard_hierarchical.Rd
@@ -63,7 +63,7 @@ ard <-
     data = ADAE_subset,
     variables = c(AESOC, AETERM),
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM),
+    denominator = cards::ADSL,
     id = USUBJID
   )
 
@@ -80,7 +80,7 @@ ard <-
     data = ADAE_subset,
     variables = c(AESOC, AETERM),
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM)
+    denominator = cards::ADSL
   )
 
 tbl_ard_hierarchical(

--- a/man/tbl_hierarchical.Rd
+++ b/man/tbl_hierarchical.Rd
@@ -117,7 +117,7 @@ tbl_hierarchical(
   data = ADAE_subset,
   variables = c(AESOC, AETERM),
   by = TRTA,
-  denominator = cards::ADSL |> mutate(TRTA = ARM),
+  denominator = cards::ADSL,
   id = USUBJID,
   digits = everything() ~ list(p = 1),
   overall_row = TRUE,
@@ -130,7 +130,7 @@ tbl_hierarchical(
   variables = c(AESOC, AESEV),
   by = TRTA,
   id = USUBJID,
-  denominator = cards::ADSL |> mutate(TRTA = ARM),
+  denominator = cards::ADSL,
   include = AESEV,
   label = list(AESEV = "Highest Severity")
 )

--- a/man/tbl_split_by.Rd
+++ b/man/tbl_split_by.Rd
@@ -90,7 +90,7 @@ trial |>
 trial |>
   tbl_summary(by = trt, include = c(death, ttdeath)) |>
   tbl_split_by_columns(groups = list("stat_1", "stat_2")) |>
-  dplyr::tail(n = 1) # Print only last table for simplicity
+  dplyr::last() # Print only last table for simplicity
 
 # Example 4 ----------------------------------
 # Both row and column splitting

--- a/man/tbl_split_by.Rd
+++ b/man/tbl_split_by.Rd
@@ -90,8 +90,7 @@ trial |>
 trial |>
   tbl_summary(by = trt, include = c(death, ttdeath)) |>
   tbl_split_by_columns(groups = list("stat_1", "stat_2")) |>
-  tail(n = 1) |> # Print only last table for simplicity
-  unlist()
+  dplyr::tail(n = 1) # Print only last table for simplicity
 
 # Example 4 ----------------------------------
 # Both row and column splitting

--- a/tests/testthat/_snaps/sort_hierarchical.md
+++ b/tests/testthat/_snaps/sort_hierarchical.md
@@ -44,5 +44,5 @@
       sort_hierarchical(tbl, "10")
     Condition
       Error in `sort_hierarchical()`:
-      ! `sort` must be one of "descending" or "alphanumeric", not "10".
+      ! Sorting type must be either "descending" or "alphanumeric" for all variables.
 

--- a/tests/testthat/test-add_overall.tbl_hierarchical.R
+++ b/tests/testthat/test-add_overall.tbl_hierarchical.R
@@ -16,7 +16,7 @@ test_that("add_overall.tbl_hierarchical() works", {
         data = ADAE_subset,
         variables = c(AESOC, AETERM),
         by = TRTA,
-        denominator = cards::ADSL |> mutate(TRTA = ARM),
+        denominator = cards::ADSL,
         id = USUBJID,
         digits = everything() ~ list(p = 1),
         overall_row = TRUE,

--- a/tests/testthat/test-filter_hierarchical.R
+++ b/tests/testthat/test-filter_hierarchical.R
@@ -7,7 +7,7 @@ tbl <- tbl_hierarchical(
   data = ADAE_subset,
   variables = c(SEX, RACE, AETERM),
   by = TRTA,
-  denominator = cards::ADSL |> mutate(TRTA = ARM),
+  denominator = cards::ADSL,
   id = USUBJID,
   overall_row = TRUE
 )
@@ -40,7 +40,7 @@ test_that("filter_hierarchical(keep_empty) works", {
     data = ADAE_subset,
     variables = c(SEX, RACE, AEBODSYS, AETERM),
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM),
+    denominator = cards::ADSL,
     id = USUBJID
   )
 
@@ -174,7 +174,7 @@ test_that("filter_hierarchical() returns empty table when all rows filtered out"
     data = ADAE_subset,
     variables = c(SEX, RACE, AETERM),
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM),
+    denominator = cards::ADSL,
     id = USUBJID
   )
 
@@ -191,7 +191,7 @@ test_that("filter_hierarchical() works with only one variable in x", {
     data = ADAE_subset,
     variables = AETERM,
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM),
+    denominator = cards::ADSL,
     id = USUBJID,
     overall_row = TRUE
   )
@@ -230,7 +230,7 @@ test_that("filter_hierarchical() works when some variables not included in x", {
     data = ADAE_subset,
     variables = c(SEX, RACE, AETERM),
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM),
+    denominator = cards::ADSL,
     id = USUBJID,
     include = c(SEX, AETERM),
     overall_row = TRUE

--- a/tests/testthat/test-show_header_names.R
+++ b/tests/testthat/test-show_header_names.R
@@ -78,7 +78,7 @@ test_that("show_header_names() has all values aligned", {
       data = cards::ADAE,
       variables = c(AESOC, AETERM),
       by = TRTA,
-      denominator = cards::ADSL |> mutate(TRTA = ARM),
+      denominator = cards::ADSL,
       id = USUBJID
     )
 

--- a/tests/testthat/test-sort_hierarchical.R
+++ b/tests/testthat/test-sort_hierarchical.R
@@ -223,6 +223,22 @@ test_that("sort_hierarchical() works with add_overall()", {
       "APPLICATION SITE PRURITUS", "DIARRHOEA", "ERYTHEMA", "ERYTHEMA"
     )
   )
+
+  # overall col with different sort variables does not affect sort order
+  expect_silent(
+    tbl_s <- sort_hierarchical(
+      tbl,
+      sort = list(SEX ~ "alphanumeric", RACE = "descending", AETERM = "alphanumeric")
+    )
+  )
+  tbl_o <- tbl |> add_overall()
+  expect_silent(
+    tbl_o <- sort_hierarchical(
+      tbl_o,
+      sort = list(SEX ~ "alphanumeric", RACE = "descending", AETERM = "alphanumeric")
+    )
+  )
+  expect_identical(tbl_o$table_body$label, tbl_s$table_body$label)
 })
 
 test_that("sort_hierarchical() error messaging works", {

--- a/tests/testthat/test-sort_hierarchical.R
+++ b/tests/testthat/test-sort_hierarchical.R
@@ -13,7 +13,7 @@ tbl <- tbl_hierarchical(
 )
 
 test_that("sort_hierarchical() works", {
-  withr::local_options(width = 200)
+  withr::local_options(width = 250)
 
   # no errors
   expect_silent(tbl <- sort_hierarchical(tbl))
@@ -64,6 +64,40 @@ test_that("sort_hierarchical(sort = 'alphanumeric') works", {
       "BLACK OR AFRICAN AMERICAN", "APPLICATION SITE PRURITUS", "DIARRHOEA", "ERYTHEMA", "WHITE",
       "APPLICATION SITE ERYTHEMA", "APPLICATION SITE PRURITUS", "ATRIOVENTRICULAR BLOCK SECOND DEGREE", "DIARRHOEA",
       "ERYTHEMA"
+    )
+  )
+})
+
+test_that("sort_hierarchical(sort) works with different sorting methods for each variable", {
+  expect_silent(
+    tbl <- sort_hierarchical(
+      tbl,
+      sort = list(SEX ~ "alphanumeric", RACE = "descending", AETERM = "alphanumeric")
+    )
+  )
+
+  # results are ordered correctly
+  expect_equal(
+    tbl$table_body |>
+      dplyr::filter(variable == "SEX") |>
+      dplyr::pull(label),
+    c("F", "M")
+  )
+  expect_equal(
+    tbl$table_body |>
+      dplyr::filter(variable == "RACE") |>
+      dplyr::pull(label),
+    c("WHITE", "BLACK OR AFRICAN AMERICAN", "WHITE", "BLACK OR AFRICAN AMERICAN", "AMERICAN INDIAN OR ALASKA NATIVE")
+  )
+  expect_equal(
+    tbl$table_body |>
+      dplyr::filter(variable == "AETERM") |>
+      dplyr::pull(label),
+    c(
+      "APPLICATION SITE ERYTHEMA", "APPLICATION SITE PRURITUS", "DIARRHOEA", "ERYTHEMA", "APPLICATION SITE PRURITUS",
+      "ATRIOVENTRICULAR BLOCK SECOND DEGREE", "DIARRHOEA", "ERYTHEMA", "APPLICATION SITE ERYTHEMA",
+      "APPLICATION SITE PRURITUS", "ATRIOVENTRICULAR BLOCK SECOND DEGREE", "DIARRHOEA", "ERYTHEMA",
+      "APPLICATION SITE PRURITUS", "DIARRHOEA", "ERYTHEMA", "ERYTHEMA"
     )
   )
 })

--- a/tests/testthat/test-sort_hierarchical.R
+++ b/tests/testthat/test-sort_hierarchical.R
@@ -7,7 +7,7 @@ tbl <- tbl_hierarchical(
   data = ADAE_subset,
   variables = c(SEX, RACE, AETERM),
   by = TRTA,
-  denominator = cards::ADSL |> mutate(TRTA = ARM),
+  denominator = cards::ADSL,
   id = USUBJID,
   overall_row = TRUE
 )
@@ -73,7 +73,7 @@ test_that("sort_hierarchical() works when there is no overall row in x", {
     data = ADAE_subset,
     variables = c(SEX, RACE, AETERM),
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM),
+    denominator = cards::ADSL,
     id = USUBJID,
     overall_row = FALSE
   )
@@ -98,7 +98,7 @@ test_that("sort_hierarchical() works with only one variable in x", {
     data = ADAE_subset,
     variables = AETERM,
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM),
+    denominator = cards::ADSL,
     id = USUBJID,
     overall_row = TRUE
   )
@@ -130,7 +130,7 @@ test_that("sort_hierarchical() works when some variables not included in x", {
     data = ADAE_subset,
     variables = c(SEX, RACE, AETERM),
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM),
+    denominator = cards::ADSL,
     id = USUBJID,
     include = c(SEX, AETERM),
     overall_row = TRUE

--- a/tests/testthat/test-tbl_ard_hierarchical.R
+++ b/tests/testthat/test-tbl_ard_hierarchical.R
@@ -100,11 +100,11 @@ test_that("tbl_ard_hierarchical() preserves ARD sorting", {
     tbl$table_body |>
       select("variable", "label"),
     ard |>
-      filter(variable != "TRTA") |>
-      unlist_ard_columns() |>
+      dplyr::filter(variable != "TRTA") |>
+      cards::unlist_ard_columns() |>
       select(cards::all_ard_variables()) |>
-      rename(label = variable_level) |>
-      distinct(),
+      dplyr::rename(label = variable_level) |>
+      dplyr::distinct(),
     ignore_attr = TRUE
   )
 })

--- a/tests/testthat/test-tbl_ard_hierarchical.R
+++ b/tests/testthat/test-tbl_ard_hierarchical.R
@@ -12,7 +12,7 @@ test_that("tbl_ard_hierarchical() event rates", {
       data = ADAE_subset,
       variables = c(AESOC, AETERM, AESEV),
       by = TRTA,
-      denominator = cards::ADSL |> mutate(TRTA = ARM),
+      denominator = cards::ADSL,
       id = USUBJID
     )
 
@@ -38,7 +38,7 @@ test_that("tbl_ard_hierarchical() event rates", {
       data = ADAE_subset,
       variables = c(AESOC, AETERM, AESEV),
       by = TRTA,
-      denominator = cards::ADSL |> mutate(TRTA = ARM),
+      denominator = cards::ADSL,
       id = USUBJID,
       digits = ~list(p = 1L)
     ) |>
@@ -52,7 +52,7 @@ test_that("tbl_ard_hierarchical() counts", {
       data = ADAE_subset,
       variables = c(AESOC, AETERM),
       by = TRTA,
-      denominator = cards::ADSL |> mutate(TRTA = ARM)
+      denominator = cards::ADSL
     )
 
   expect_error(
@@ -71,7 +71,7 @@ test_that("tbl_ard_hierarchical() counts", {
       data = ADAE_subset,
       variables = c(AESOC, AETERM),
       by = TRTA,
-      denominator = cards::ADSL |> mutate(TRTA = ARM)
+      denominator = cards::ADSL
     ) |>
       as.data.frame(col_labels = FALSE)
   )

--- a/tests/testthat/test-tbl_ard_hierarchical.R
+++ b/tests/testthat/test-tbl_ard_hierarchical.R
@@ -76,3 +76,35 @@ test_that("tbl_ard_hierarchical() counts", {
       as.data.frame(col_labels = FALSE)
   )
 })
+
+test_that("tbl_ard_hierarchical() preserves ARD sorting", {
+  ard <-
+    cards::ard_stack_hierarchical(
+      data = ADAE_subset,
+      variables = c(AESOC, AETERM),
+      by = TRTA,
+      id = USUBJID,
+      denominator = cards::ADSL
+    ) |>
+    cards::sort_ard_hierarchical("descending")
+
+  expect_silent(
+    tbl <- tbl_ard_hierarchical(
+      cards = ard,
+      variables = c(AESOC, AETERM),
+      by = TRTA
+    )
+  )
+
+  expect_equal(
+    tbl$table_body |>
+      select("variable", "label"),
+    ard |>
+      filter(variable != "TRTA") |>
+      unlist_ard_columns() |>
+      select(cards::all_ard_variables()) |>
+      rename(label = variable_level) |>
+      distinct(),
+    ignore_attr = TRUE
+  )
+})

--- a/tests/testthat/test-tbl_ard_summary.R
+++ b/tests/testthat/test-tbl_ard_summary.R
@@ -263,7 +263,8 @@ test_that("tbl_ard_summary(overall)", {
       .attributes = TRUE,
       .total_n = TRUE
     ) |>
-      cards::tidy_ard_row_order()
+      cards::tidy_ard_row_order(),
+    ignore_attr = TRUE
   )
   expect_equal(
     tbl$cards$add_overall |>
@@ -277,7 +278,8 @@ test_that("tbl_ard_summary(overall)", {
       .attributes = TRUE,
       .total_n = TRUE
     ) |>
-      cards::tidy_ard_row_order()
+      cards::tidy_ard_row_order(),
+    ignore_attr = TRUE
   )
 })
 

--- a/tests/testthat/test-tbl_hierarchical.R
+++ b/tests/testthat/test-tbl_hierarchical.R
@@ -196,7 +196,7 @@ test_that("tbl_hierarchical works properly when last variable of hierarchy is or
   # unordered variable
   res_uo <- tbl_hierarchical(
     data = data, variables = c(AESOC, AESEV), by = TRTA, id = USUBJID,
-    denominator = cards::ADSL |> mutate(TRTA = ARM), include = AESEV
+    denominator = cards::ADSL, include = AESEV
   )
 
   # ordered variable
@@ -204,7 +204,7 @@ test_that("tbl_hierarchical works properly when last variable of hierarchy is or
 
   res_o <- tbl_hierarchical(
     data = data, variables = c(AESOC, AESEV), by = TRTA, id = USUBJID,
-    denominator = cards::ADSL |> mutate(TRTA = ARM), include = AESEV, label = list(AESEV = "Highest Severity")
+    denominator = cards::ADSL, include = AESEV, label = list(AESEV = "Highest Severity")
   ) |> suppressMessages()
   expect_snapshot(res_o |> as.data.frame())
 
@@ -214,14 +214,14 @@ test_that("tbl_hierarchical works properly when last variable of hierarchy is or
   # ordered variable, no by
   res <- tbl_hierarchical(
     data = data, variables = c(AESOC, AESEV),
-    denominator = cards::ADSL |> mutate(TRTA = ARM), id = USUBJID
+    denominator = cards::ADSL, id = USUBJID
   ) |> suppressMessages()
   expect_snapshot(res |> as.data.frame())
 
   # ordered variable, include all variables
   res_o <- tbl_hierarchical(
     data = data, variables = c(AESOC, AESEV), by = TRTA, id = USUBJID,
-    denominator = cards::ADSL |> mutate(TRTA = ARM), label = list(AESEV = "Highest Severity")
+    denominator = cards::ADSL, label = list(AESEV = "Highest Severity")
   ) |> suppressMessages()
   expect_snapshot(res_o |> as.data.frame())
 })
@@ -378,7 +378,7 @@ test_that("tbl_hierarchical_count table_body enables sorting", {
       data = ADAE_subset,
       variables = c(SEX, AESOC, AETERM),
       by = TRTA,
-      denominator = cards::ADSL |> mutate(TRTA = ARM),
+      denominator = cards::ADSL,
       id = USUBJID,
       overall_row = TRUE
     )

--- a/vignettes/articles/tbl_ard-functions.Rmd
+++ b/vignettes/articles/tbl_ard-functions.Rmd
@@ -78,7 +78,7 @@ tbl_ae <-
   tbl_hierarchical(
     variables = c(AESOC, AETERM),
     by = TRTA,
-    denominator = cards::ADSL |> mutate(TRTA = ARM),
+    denominator = cards::ADSL,
     id = USUBJID,
     overall_row = TRUE,
     label = list(..ard_hierarchical_overall.. = "Any Adverse Event")


### PR DESCRIPTION
**What changes are proposed in this pull request?**
- Refactored `sort_hierarchical()` to allow for different sorting methods at each hierarchy variable level.
- Updated `sort_hierarchical()` and `filter_hierarchical()` to always keep attribute and total N rows at the bottom of the ARD.
- Removed sorting code from the main hierarchical table functions - default sorting now occurs during the ARD creation step. This prevents sorted ARDs from losing their sorted order when using `tbl_ard_hierarchical()`.
- Removed `TRTA` derivation when using the `cards::ADSL` dataset in examples/tests.

Closes #2280 

Blocked by https://github.com/insightsengineering/cards/pull/493 - update Remotes field after merging cards PR

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] PR branch has pulled the most recent updates from main branch.
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

