### PR TITLE
Improve messaging in `tbl_stack()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.3.0.9002
+Version: 2.3.0.9003
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Greatly improved messaging when column headers differ in `tbl_stack()`. (#2266)
+
 * The {cardx} package is now a strong dependency. (#2256)
 
 * Refactored `sort_hierarchical()` to allow for different sorting methods at each hierarchy variable level.

--- a/R/tbl_stack.R
+++ b/R/tbl_stack.R
@@ -191,31 +191,39 @@ tbl_stack <- function(tbls, group_header = NULL, quiet = FALSE, attr_order = seq
 
 # function prints changes to column labels and spanning headers
 .print_stack_differences <- function(tbls) {
-  tbl_differences <-
-    map2(
-      tbls, seq_len(length(tbls)),
-      ~ .x[["table_styling"]][["header"]] |>
-        dplyr::mutate(..tbl_id.. = .y)
+  any_header_difference <-
+    lapply(
+      tbls,
+      FUN = \(x) {
+        x[["table_styling"]][["header"]] |>
+          dplyr::filter(!hide) |>
+          dplyr::select("column", "label")
+      }
     ) |>
     dplyr::bind_rows() |>
-    dplyr::select("..tbl_id..", "column", "label") |>
-    tidyr::pivot_longer(cols = c("label")) |>
-    dplyr::group_by(.data$column, .data$name) |>
     dplyr::mutate(
-      new_value = .data$value[1],
-      name_fmt = dplyr::case_when(
-        name == "label" ~ "Column header"
-      )
+      .by = "column",
+      label_difference = .data$label != .data$label[1]
     ) |>
-    dplyr::filter(.data$new_value != .data$value) |>
-    dplyr::ungroup() |>
-    dplyr::arrange(.data$name != "label", .data$name_fmt, .data$..tbl_id..)
+    dplyr::pull("label_difference") |>
+    any()
 
-  if (nrow(tbl_differences) > 0) {
+  # if there are difference, print them to the console
+  if (any_header_difference) {
     cli::cli_inform(
-      c("Column headers among stacked tables differ. Headers from the first table are used.",
-        i = "Check the header is correct and use {.fun modify_header} to update,
-             or {.code quiet = TRUE} to suppress this message.")
+      c("Column headers among stacked tables differ.",
+        i = "Use {.fun modify_header} to update or {.code quiet = TRUE} to suppress this message.")
+    )
+
+    walk(
+      seq_along(tbls),
+      ~ tbls[[.x]] |>
+        getElement("table_styling") |>
+        getElement("header") |>
+        dplyr::filter(!hide) |>
+        dplyr::select("column", "label") |>
+        dplyr::mutate(label =  cli::cli_format(.data$label)) |>
+        tibble_as_cli(label = list(column = glue("Table {.x} Column Name"), label = "Header"))
     )
   }
 

--- a/tests/testthat/_snaps/tbl_stack.md
+++ b/tests/testthat/_snaps/tbl_stack.md
@@ -1,3 +1,18 @@
+# tbl_stack returns expected message when unique column names are present
+
+    Code
+      tbl <- tbl_stack(list(t1, t2))
+    Message
+      Column headers among stacked tables differ.
+      i Use `modify_header()` to update or `quiet = TRUE` to suppress this message.
+    Output
+      Table 1 Column Name   Header                  
+      label                 "**Characteristic**"    
+      stat_0                "**Statistic**"         
+      Table 2 Column Name   Header                  
+      label                 "**Characteristic**"    
+      stat_0                "Replaced label"        
+
 # tbl_stack throws expected errors
 
     Code

--- a/tests/testthat/test-tbl_stack.R
+++ b/tests/testthat/test-tbl_stack.R
@@ -107,7 +107,7 @@ test_that("tbl_stack(attr_order) works", {
 
   # check that we get the header from the second table (with the OR in the header)
   expect_equal(
-    tbl_stack(list(tbl1, tbl2), attr_order = 2) |>
+    tbl_stack(list(tbl1, tbl2), attr_order = 2, quiet = TRUE) |>
       as.data.frame() |>
       names() |>
       getElement(2),
@@ -289,10 +289,7 @@ test_that("tbl_stack returns expected message when unique column names are prese
   t2 <- t2_summary |>
     modify_header(stat_0 ~ "Replaced label")
 
-  expect_message(
-    tbl_stack(list(t1, t2)),
-    "Column headers among stacked tables differ"
-  )
+  expect_snapshot(tbl <- tbl_stack(list(t1, t2)))
 })
 
 test_that("tbl_stack() can stack tbl that have been previosly stacked", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Greatly improved messaging when column headers differ in `tbl_stack()`. (#2266)

**If there is an GitHub issue associated with this pull request, please provide link.**
close #2266

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

