### PR TITLE
Adding `tbl_stack(tbl_id_lbls)` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.3.0.9004
+Version: 2.3.0.9005
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* The `tbl_stack(tbl_id_lbls)` argument has been added. When specified, a new column is added to the resulting `.$table_body` labelling the rows associated with each table ID. This argument is utilized in `tbl_strata()` and all returned tables include a hidden column with the stratum levels. (#2288)
+
 * No longer calculating `deff` by default in `tbl_svysummary(type='categorical')`.
 
 * Greatly improved messaging when column headers differ in `tbl_stack()`. (#2266)

--- a/R/tbl_strata.R
+++ b/R/tbl_strata.R
@@ -279,7 +279,7 @@ tbl_strata_internal <- function(data,
   if (.combine_with == "tbl_merge") {
     tbl <- inject(tbl_merge(tbls = df_tbls$tbl, tbl_ids = df_tbls$tbl_id, !!!.combine_args))
   } else if (.combine_with == "tbl_stack") {
-    tbl <- inject(tbl_stack(tbls = df_tbls$tbl, tbl_ids = df_tbls$tbl_id, !!!.combine_args))
+    tbl <- inject(tbl_stack(tbls = df_tbls$tbl, tbl_ids = df_tbls$tbl_id, !!!.combine_args, tbl_id_lbls = df_tbls$strata))
   }
 
   # return tbl -----------------------------------------------------------------

--- a/man/tbl_stack.Rd
+++ b/man/tbl_stack.Rd
@@ -9,7 +9,8 @@ tbl_stack(
   group_header = NULL,
   quiet = FALSE,
   attr_order = seq_along(tbls),
-  tbl_ids = NULL
+  tbl_ids = NULL,
+  tbl_id_lbls = NULL
 )
 }
 \arguments{
@@ -33,6 +34,12 @@ Default is to set precedent in the order tables are passed.}
 Optional character vector of IDs that will be assigned to the input tables.
 The ID is assigned by assigning a name to the \code{tbls} list, which is
 returned in \code{x$tbls}.}
+
+\item{tbl_id_lbls}{(\code{vector})\cr
+Optional vector of the same length \code{tbls}.
+When specified a new, hidden column is added to the returned \code{.$table_body}
+with these labels. \emph{The most common use case of this argument is for
+the development of other functions.}}
 }
 \value{
 A \code{tbl_stack} object

--- a/tests/testthat/test-tbl_strata.R
+++ b/tests/testthat/test-tbl_strata.R
@@ -102,6 +102,10 @@ test_that("tbl_strata(.combine_with) works as expected", {
       )
   )
 
+  # check the `tbl_id1_lbl` column is present
+  expect_true("tbl_id1_lbl" %in% names(tbl$table_body))
+  expect_setequal(tbl$table_body$tbl_id1_lbl, paste("Grade", trial$grade))
+
   # df_strata correct
   expect_equal(nrow(tbl$df_strata), 3)
   expect_equal(names(tbl$df_strata), c("strata_1", "header"))
@@ -282,3 +286,4 @@ test_that("tbl_strata works with survey objects", {
       )
   )
 })
+


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The `tbl_stack(tbl_id_lbls)` argument has been added. When specified, a new column is added to the resulting `.$table_body` labelling the rows associated with each table ID. This argument is utilized in `tbl_strata()` and all returned tables include a hidden column with the stratum levels. (#2288)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2288

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

