### PR TITLE
Corrected "variable" to "variables" calls to the cardx functions

### DIFF
--- a/R/utils-add_p_tests.R
+++ b/R/utils-add_p_tests.R
@@ -15,7 +15,7 @@ add_p_test_t.test <- function(data, variable, by, test.args, conf.level = 0.95, 
   rlang::inject(
     cardx::ard_stats_t_test(
       data = .data_pre_processing(data, factor = by),
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       conf.level = conf.level,
       !!!test.args
@@ -29,7 +29,7 @@ add_p_test_wilcox.test <- function(data, variable, by, test.args, conf.level = 0
   rlang::inject(
     cardx::ard_stats_wilcox_test(
       data = .data_pre_processing(data, factor = by, numeric = variable),
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       conf.int = TRUE,
       conf.level = conf.level,
@@ -54,7 +54,7 @@ add_p_test_mcnemar.test <- function(data, variable, by, group, test.args, ...) {
   rlang::inject(
     cardx::ard_stats_mcnemar_test_long(
       data = data,
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       id = all_of(group),
       !!!test.args
@@ -68,7 +68,7 @@ add_p_test_mcnemar.test_wide <- function(data, variable, by, test.args, ...) {
   rlang::inject(
     cardx::ard_stats_mcnemar_test(
       data = data,
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       !!!test.args
     )
@@ -81,7 +81,7 @@ add_p_test_chisq.test <- function(data, variable, by, test.args, ...) {
   rlang::inject(
     cardx::ard_stats_chisq_test(
       data = .data_pre_processing(data, factor = by),
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       !!!test.args
     )
@@ -108,7 +108,7 @@ add_p_test_mood.test <- function(data, variable, by, test.args, ...) {
   rlang::inject(
     cardx::ard_stats_mood_test(
       data = .data_pre_processing(data, factor = by),
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       !!!test.args
     )
@@ -121,7 +121,7 @@ add_p_test_kruskal.test <- function(data, variable, by, ...) {
 
   cardx::ard_stats_kruskal_test(
     data = .data_pre_processing(data, factor = by),
-    variable = all_of(variable),
+    variables = all_of(variable),
     by = all_of(by)
   )
 }
@@ -132,7 +132,7 @@ add_p_test_fisher.test <- function(data, variable, by, test.args, conf.level = 0
   rlang::inject(
     cardx::ard_stats_fisher_test(
       data = .data_pre_processing(data, factor = by),
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       conf.level = conf.level,
       !!!test.args
@@ -206,7 +206,7 @@ add_p_tbl_summary_paired.t.test <- function(data, variable, by, group, test.args
   rlang::inject(
     cardx::ard_stats_paired_t_test(
       data = data,
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       id = all_of(group),
       conf.level = conf.level,
@@ -223,7 +223,7 @@ add_p_tbl_summary_paired.wilcox.test <- function(data, variable, by, group, test
   rlang::inject(
     cardx::ard_stats_paired_wilcox_test(
       data = data,
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       id = all_of(group),
       conf.level = conf.level,
@@ -244,7 +244,7 @@ add_p_test_prop.test <- function(data, variable, by, test.args, conf.level = 0.9
   rlang::inject(
     cardx::ard_stats_prop_test(
       data = data,
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       conf.level = conf.level,
       !!!test.args
@@ -301,7 +301,7 @@ add_p_test_cohens_d <- function(data, variable, by, test.args, conf.level = 0.95
   rlang::inject(
     cardx::ard_effectsize_cohens_d(
       data = data,
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       conf.level = conf.level,
       verbose = FALSE,
@@ -318,7 +318,7 @@ add_p_test_paired_cohens_d <- function(data, variable, by, test.args, group, con
   rlang::inject(
     cardx::ard_effectsize_paired_cohens_d(
       data = data,
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       id = all_of(group),
       conf.level = conf.level,
@@ -334,7 +334,7 @@ add_p_test_hedges_g <- function(data, variable, by, test.args, conf.level = 0.95
   rlang::inject(
     cardx::ard_effectsize_hedges_g(
       data = data,
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       conf.level = conf.level,
       verbose = FALSE,
@@ -351,7 +351,7 @@ add_p_test_paired_hedges_g <- function(data, variable, by, test.args, group, con
   rlang::inject(
     cardx::ard_effectsize_paired_hedges_g(
       data = data,
-      variable = all_of(variable),
+      variables = all_of(variable),
       by = all_of(by),
       id = all_of(group),
       conf.level = conf.level,
@@ -366,7 +366,7 @@ add_p_test_smd <- function(data, variable, by, ...) {
 
   cardx::ard_smd_smd(
     data = data,
-    variable = all_of(variable),
+    variables = all_of(variable),
     by = all_of(by),
     std.error = TRUE
   )
@@ -503,7 +503,7 @@ add_p_test_svy.t.test <- function(data, variable, by, conf.level = 0.95, ...) {
 
   cardx::ard_survey_svyttest(
     data = data,
-    variable = all_of(variable),
+    variables = all_of(variable),
     by = all_of(by),
     conf.level = conf.level
   )
@@ -519,7 +519,7 @@ add_p_test_svy.svyranktest <- function(data,
 
   cardx::ard_survey_svyranktest(
     data = data,
-    variable = all_of(variable),
+    variables = all_of(variable),
     by = all_of(by),
     test = test
   )
@@ -536,7 +536,7 @@ add_p_test_svychisq.test <- function(data,
 
   cardx::ard_survey_svychisq(
     data = data,
-    variable = all_of(variable),
+    variables = all_of(variable),
     by = all_of(by),
     statistic = statistic
   )


### PR DESCRIPTION
#2304 - fixed partial matching for the calls to the functions in cardx

Specifically, that the name of the argument passed properly matches the argument the functions in cardx accepts: "variables"