### PR TITLE
Using `tbl_summary(percent=<data.frame>)` for header counts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.4.0.9001
+Version: 2.4.0.9002
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Added theme element `"assign_summary_type-arg:cat_threshold"` for greater control over default summary types.
 
+* When a data frame is passed in the `tbl_summary(percent)` argument, the headers are now tabulated with this data frame. (#2322)
+
 # gtsummary 2.4.0
 
 ### New Features and Functions

--- a/R/tbl_summary.R
+++ b/R/tbl_summary.R
@@ -53,6 +53,7 @@
 #'   In rarer cases, you may need to define/override the typical denominators.
 #'   In these cases, pass an integer or a data frame. Refer to the
 #'   [`?cards::ard_tabulate(denominator)`][cards::ard_tabulate] help file for details.
+#'   When a data frame is passed, this data frame is used to calculate header counts.
 #' @param include ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
 #'   Variables to include in the summary table. Default is `everything()`.
 #'
@@ -214,7 +215,15 @@ tbl_summary <- function(data,
   if (is.character(percent)) {
     percent <- arg_match(percent, values = c("column", "row", "cell"))
   }
-  else if (!is.data.frame(percent) && !is_integerish(percent)) {
+  else if (is.data.frame(percent)) {
+    if (!is_empty(by) && !by %in% names(percent)) {
+      cli::cli_abort(
+        "The {.cls data.frame} passed in the {.arg percent} argument must contain the {.val {by}} column.",
+        call = get_cli_abort_call()
+      )
+    }
+  }
+  else if (!is_integerish(percent)) {
     cli::cli_abort(
       "The {.arg percent} argument must be one of {.val {c('column', 'row', 'cell')}} ({.emph the most common input}),
          or a {.cls data.frame} or {.cls integer}; not a {.obj_type_friendly {percent}}.",
@@ -375,12 +384,14 @@ tbl_summary <- function(data,
                          stat_label = ~ default_stat_labels()
       ),
       # adding total N
-      cards::ard_total_n(data),
+      cards::ard_total_n(
+        data = case_switch(is.data.frame(percent) ~ percent, .default = data)
+      ),
       # tabulate by variable for header stats
       case_switch(
         !is_empty(by) ~
           cards::ard_tabulate(
-            data,
+            data = case_switch(is.data.frame(percent) ~ percent, .default = data),
             variables = all_of(by),
             stat_label = ~ default_stat_labels()
           ),

--- a/man/tbl_summary.Rd
+++ b/man/tbl_summary.Rd
@@ -73,7 +73,8 @@ Must be one of \code{c("column", "row", "cell")}. Default is \code{"column"}.
 
 In rarer cases, you may need to define/override the typical denominators.
 In these cases, pass an integer or a data frame. Refer to the
-\code{\link[cards:ard_tabulate]{?cards::ard_tabulate(denominator)}} help file for details.}
+\code{\link[cards:ard_tabulate]{?cards::ard_tabulate(denominator)}} help file for details.
+When a data frame is passed, this data frame is used to calculate header counts.}
 
 \item{include}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
 Variables to include in the summary table. Default is \code{everything()}.}

--- a/tests/testthat/_snaps/tbl_summary.md
+++ b/tests/testthat/_snaps/tbl_summary.md
@@ -442,15 +442,23 @@
     Code
       as.data.frame(tbl)
     Output
-         **Characteristic**    **N = 254**
-      1            DCREASCD           <NA>
-      2       Adverse Event 92 / 254 (36%)
-      3               Death 3 / 254 (1.2%)
-      4         I/E Not Met 3 / 254 (1.2%)
-      5    Lack of Efficacy 4 / 254 (1.6%)
-      6   Lost to Follow-up 2 / 254 (0.8%)
-      7  Physician Decision 3 / 254 (1.2%)
-      8  Protocol Violation 3 / 254 (1.2%)
-      9    Sponsor Decision 7 / 254 (2.8%)
-      10   Withdrew Consent 27 / 254 (11%)
+         **Characteristic**     **N = 508**
+      1            DCREASCD            <NA>
+      2       Adverse Event  92 / 508 (18%)
+      3               Death  3 / 508 (0.6%)
+      4         I/E Not Met  3 / 508 (0.6%)
+      5    Lack of Efficacy  4 / 508 (0.8%)
+      6   Lost to Follow-up  2 / 508 (0.4%)
+      7  Physician Decision  3 / 508 (0.6%)
+      8  Protocol Violation  3 / 508 (0.6%)
+      9    Sponsor Decision  7 / 508 (1.4%)
+      10   Withdrew Consent 27 / 508 (5.3%)
+
+---
+
+    Code
+      tbl_summary(trial, by = trt, include = age, percent = trial["age"])
+    Condition
+      Error in `tbl_summary()`:
+      ! The <data.frame> passed in the `percent` argument must contain the "trt" column.
 

--- a/tests/testthat/test-tbl_summary.R
+++ b/tests/testthat/test-tbl_summary.R
@@ -744,7 +744,7 @@ test_that("tbl_summary(percent = c(<data.frame>))", {
       dplyr::mutate(DCREASCD = ifelse(DCREASCD == "Completed", NA, DCREASCD)) |>
       tbl_summary(
         include = DCREASCD,
-        percent = cards::ADSL,
+        percent = dplyr::bind_rows(cards::ADSL, cards::ADSL),
         statistic = all_categorical() ~ "{n} / {N} ({p}%)",
         missing = "no"
       )
@@ -759,10 +759,21 @@ test_that("tbl_summary(percent = c(<data.frame>))", {
       cards::ADSL |>
         dplyr::mutate(DCREASCD = ifelse(DCREASCD == "Completed", NA, DCREASCD)),
       variables = "DCREASCD",
-      denominator = cards::ADSL
+      denominator = dplyr::bind_rows(cards::ADSL, cards::ADSL)
     ) |>
       dplyr::select(-fmt_fun),
     ignore_attr = TRUE
+  )
+
+  # when data frame does not include the by variable
+  expect_snapshot(
+    error = TRUE,
+    tbl_summary(
+      trial,
+      by = trt,
+      include = age,
+      percent = trial["age"]
+    )
   )
 })
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* When a data frame is passed in the `tbl_summary(percent)` argument, the headers are now tabulated with this data frame. (#2322)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #2322

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] PR branch has pulled the most recent updates from main branch.
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] Increment the version number using `usethis::use_version(which = "dev")` 
- [x] Run `usethis::use_spell_check()` again
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge".

