### PR TITLE
Update emmeans `cardx` function name to resolve deprecation warnings

### DIFF
--- a/R/utils-add_p_tests.R
+++ b/R/utils-add_p_tests.R
@@ -430,7 +430,7 @@ add_p_test_emmeans <- function(data, variable, by, adj.vars = NULL, conf.level =
   }
   # styler: on
 
-  cardx::ard_emmeans_mean_difference(
+  cardx::ard_emmeans_contrast(
     data = data,
     formula = formula,
     method = method,

--- a/tests/testthat/test-add_difference.tbl_summary.R
+++ b/tests/testthat/test-add_difference.tbl_summary.R
@@ -67,7 +67,7 @@ test_that("add_difference.tbl_summary(tests = 'emmeans')", {
         -cards::all_ard_variables(),
         -fmt_fun
       ),
-    cardx::ard_emmeans_mean_difference(
+    cardx::ard_emmeans_contrast(
       data = trial,
       formula = ttdeath ~ trt,
       method = "lm",
@@ -96,7 +96,7 @@ test_that("add_difference.tbl_summary(tests = 'emmeans')", {
         -cards::all_ard_variables(),
         -fmt_fun
       ),
-    cardx::ard_emmeans_mean_difference(
+    cardx::ard_emmeans_contrast(
       data = trial,
       formula = ttdeath ~ trt + (1 | grade),
       method = "lmer",
@@ -126,7 +126,7 @@ test_that("add_difference.tbl_summary(tests = 'emmeans')", {
         -cards::all_ard_variables(),
         -fmt_fun
       ),
-    cardx::ard_emmeans_mean_difference(
+    cardx::ard_emmeans_contrast(
       data = trial,
       formula = response ~ trt,
       method = "glm",

--- a/tests/testthat/test-add_difference.tbl_svysummary.R
+++ b/tests/testthat/test-add_difference.tbl_svysummary.R
@@ -100,7 +100,7 @@ test_that("add_difference.tbl_svysummary(test)", {
       dplyr::select(any_of(c("estimate", "conf.low", "conf.high", "p.value"))) |>
       unlist() |>
       as.list(),
-    cardx::ard_emmeans_mean_difference(svy_trial2,
+    cardx::ard_emmeans_contrast(svy_trial2,
                                        method = survey::svyglm,
                                        formula = age_emmeans ~ trt,
                                        response_type = "continuous") |>
@@ -114,7 +114,7 @@ test_that("add_difference.tbl_svysummary(test)", {
       dplyr::select(any_of(c("estimate", "conf.low", "conf.high", "p.value"))) |>
       unlist() |>
       as.list(),
-    cardx::ard_emmeans_mean_difference(svy_trial2,
+    cardx::ard_emmeans_contrast(svy_trial2,
                                        method = survey::svyglm,
                                        method.args = list(family = binomial),
                                        formula = response_emmeans ~ trt,

--- a/tests/testthat/test-add_p.tbl_svysummary.R
+++ b/tests/testthat/test-add_p.tbl_svysummary.R
@@ -78,7 +78,7 @@ test_that("add_p.tbl_svysummary(test)", {
     tbl$table_body |>
       dplyr::filter(variable == "response_emmeans", row_type == "label") |>
       dplyr::pull(p.value),
-    cardx::ard_emmeans_mean_difference(svy_trial2,
+    cardx::ard_emmeans_contrast(svy_trial2,
                                        method = survey::svyglm,
                                        method.args = list(family = binomial),
                                        formula = response_emmeans ~ trt,
@@ -93,7 +93,7 @@ test_that("add_p.tbl_svysummary(test)", {
     tbl$table_body |>
       dplyr::filter(variable == "age_emmeans", row_type == "label") |>
       dplyr::pull(p.value),
-    cardx::ard_emmeans_mean_difference(svy_trial2,
+    cardx::ard_emmeans_contrast(svy_trial2,
                                        method = survey::svyglm,
                                        formula = age_emmeans ~ trt,
                                        response_type = "continuous") |>


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Updated deprecated `cardx::ard_emmeans_mean_difference()` function name to `cardx::ard_emmeans_contrast()`.

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

