### PR TITLE
2397 fix warnings on tbl hierarchical sort filter

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -42,3 +42,5 @@
 
 # reverse dep cehcks
 ^checked$
+^\.positai$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ delete.aux
 delete.docx
 delete.rtf
 checked/
+.positai

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -101,4 +101,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Improved efficiency of `style_number()`. There is a slight change to a small subset of rounded values. For example, the difference between two dates was previously formatted to `'0 days'`, and now it is formatted to `'0'`.
 
+* Fixed bug in `tbl_hierarchical()`, `filter_hierarchical()` and `sort_hierarchical()` that was dropping class attributes. 
+
 # gtsummary 2.5.0
 
 ### New Features and Functions

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * Improved efficiency of `style_number()`. There is a slight change to a small subset of rounded values. For example, the difference between two dates was previously formatted to `'0 days'`, and now it is formatted to `'0'`.
 
-* Fixed bug in `tbl_hierarchical()`, `filter_hierarchical()` and `sort_hierarchical()` that was dropping class attributes. 
+* Fixed bug in `tbl_hierarchical()`, `filter_hierarchical()` and `sort_hierarchical()` that was dropping class attributes. (#2397, @jszczypinski ) 
 
 # gtsummary 2.5.0
 

--- a/R/add_difference.tbl_svysummary.R
+++ b/R/add_difference.tbl_svysummary.R
@@ -25,7 +25,7 @@
 #' @return a gtsummary table of class `"tbl_summary"`
 #'
 #' @examplesIf (identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) && gtsummary:::is_pkg_installed("broom", ref = "cardx")
-#' Example 1 ----------------------------------
+#' # Example 1 ----------------------------------
 #' survey::svydesign(~1, data = as.data.frame(Titanic), weights = ~Freq) |>
 #'   tbl_svysummary(
 #'     by = Survived,

--- a/R/add_difference.tbl_svysummary.R
+++ b/R/add_difference.tbl_svysummary.R
@@ -25,6 +25,14 @@
 #' @return a gtsummary table of class `"tbl_summary"`
 #'
 #' @examplesIf (identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) && gtsummary:::is_pkg_installed("broom", ref = "cardx")
+#' Example 1 ----------------------------------
+#' survey::svydesign(~1, data = as.data.frame(Titanic), weights = ~Freq) |>
+#'   tbl_svysummary(
+#'     by = Survived,
+#'     value = list(Class ~ "1st", Age = "Child"),
+#'     include = c(Class, Age)
+#'   ) |>
+#'   add_difference()
 add_difference.tbl_svysummary <- function(x,
                                           test = NULL,
                                           group = NULL,
@@ -156,6 +164,7 @@ add_difference.tbl_svysummary <- function(x,
   )
 
   # calculate tests ------------------------------------------------------------
+  browser()
   x <-
     calculate_and_add_test_results(
       x = x, include = include, group = group, test.args = test.args, adj.vars = adj.vars,

--- a/R/add_difference.tbl_svysummary.R
+++ b/R/add_difference.tbl_svysummary.R
@@ -164,7 +164,6 @@ add_difference.tbl_svysummary <- function(x,
   )
 
   # calculate tests ------------------------------------------------------------
-  browser()
   x <-
     calculate_and_add_test_results(
       x = x, include = include, group = group, test.args = test.args, adj.vars = adj.vars,

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -171,6 +171,10 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = everything() ~ "descend
 .reshape_ard_compare <- function(x, x_ard, ard_args, sort = NULL) {
   by_cols <- if (length(ard_args$by) > 0) c("group1", "group1_level") else NULL
 
+  # SAVE ALL ATTRIBUTES (NEW CODE)
+  orig_class <- class(x_ard)
+  orig_args <- attributes(x_ard)$args
+
   # add dummy rows for variables not in include so their label rows are sorted correctly
   x_ard <- x_ard |> .append_not_incl(ard_args, x$call_list, sort)
 
@@ -217,11 +221,14 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = everything() ~ "descend
   }
   x$table_body <- x$table_body |> dplyr::left_join(gps, by = names(gps) |> utils::head(-1))
 
-  # re-add dropped args attribute
+  # Make sure as_card runs BEFORE restoring attributes
   x_ard <- x_ard |>
     dplyr::ungroup() |>
     cards::as_card(check = FALSE)
-  attr(x_ard, "args") <- ard_args
+  
+  # restore all custom attributes
+  class(x_ard) <- orig_class
+  attr(x_ard, "args") <- orig_args
 
   list(x = x, x_ard = x_ard)
 }

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -221,7 +221,6 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = everything() ~ "descend
   }
   x$table_body <- x$table_body |> dplyr::left_join(gps, by = names(gps) |> utils::head(-1))
 
-  # Make sure as_card runs BEFORE restoring attributes
   x_ard <- x_ard |>
     dplyr::ungroup() |>
     cards::as_card(check = FALSE)

--- a/R/tbl_ard_hierarchical.R
+++ b/R/tbl_ard_hierarchical.R
@@ -105,13 +105,16 @@ tbl_ard_hierarchical <- function(cards,
   )[c(variables, if ("overall" %in% names(label)) "overall")]
 
   # add hierarchical ARD args attribute and sort if not directly using a hierarchical ARD
-  if (!"args" %in% names(attributes(cards))) {
+  if (!inherits(cards, c("ard_stack_hierarchical", "ard_stack_hierarchical_count"))) {
     attr(cards, "args") <- list(
       by = by,
       variables = variables,
       include = include
     )
-    cards <- cards |> cards::sort_ard_hierarchical("alphanumeric")
+    cards <-
+      suppressWarnings( # suppressing warning about class
+        cards |> cards::sort_ard_hierarchical("alphanumeric")
+      )
   }
 
   brdg_hierarchical(

--- a/R/tbl_hierarchical.R
+++ b/R/tbl_hierarchical.R
@@ -317,6 +317,9 @@ internal_tbl_hierarchical <- function(data,
     statistic = NULL,
     overall_row = overall_row
   )
+  # save class attributes ------------------------------------------------------
+  orig_class <- class(cards)
+  orig_args <- attributes(cards)$args
 
   # apply digits ---------------------------------------------------------------
   cards <-
@@ -332,6 +335,10 @@ internal_tbl_hierarchical <- function(data,
       unmatched = "ignore"
     ) |>
     cards::apply_fmt_fun()
+
+  # restore class correct class attributes -------------------------------------
+  attr(cards, "args") <- orig_args
+  class(cards) <- orig_class
 
   # print all warnings and errors that occurred while calculating requested stats
   cards::print_ard_conditions(cards)
@@ -441,8 +448,9 @@ internal_tbl_hierarchical <- function(data,
 }
 
 .add_gts_column_to_cards_hierarchical <- function(cards, variables, by) {
-  args <- attributes(cards)$args
-
+  # save class attributes ------------------------------------------------------
+  orig_class <- class(cards)
+  orig_args <- attributes(cards)$args
   # adding the name of the column the stats will populate
   if (is_empty(by)) {
     cards$gts_column <-
@@ -466,8 +474,8 @@ internal_tbl_hierarchical <- function(data,
     dplyr::ungroup() |>
     cards::as_card(check = FALSE)
 
-  # re-add dropped args attribute
-  attr(cards, "args") <- args
-
+  # restore correct class attributes -------------------------------------------
+  attr(cards, "args") <- orig_args
+  class(cards) <- orig_class
   cards
 }

--- a/R/utils-add_p_tests.R
+++ b/R/utils-add_p_tests.R
@@ -430,8 +430,6 @@ add_p_test_emmeans <- function(data, variable, by, adj.vars = NULL, conf.level =
   }
   # styler: on
 
-  browser()
-
   cardx::ard_emmeans_contrast(
     data = data,
     formula = formula,

--- a/R/utils-add_p_tests.R
+++ b/R/utils-add_p_tests.R
@@ -430,6 +430,8 @@ add_p_test_emmeans <- function(data, variable, by, adj.vars = NULL, conf.level =
   }
   # styler: on
 
+  browser()
+
   cardx::ard_emmeans_contrast(
     data = data,
     formula = formula,

--- a/man/add_difference.tbl_svysummary.Rd
+++ b/man/add_difference.tbl_svysummary.Rd
@@ -71,8 +71,6 @@ Adds difference to tables created by \code{\link[=tbl_summary]{tbl_summary()}}.
 The difference between two groups (typically mean or rate difference) is added
 to the table along with the difference's confidence interval and a p-value (when applicable).
 }
-<<<<<<< HEAD
-=======
 \examples{
 \dontshow{if ((identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) && gtsummary:::is_pkg_installed("broom", ref = "cardx")) withAutoprint(\{ # examplesIf}
 # Example 1 ----------------------------------
@@ -85,4 +83,3 @@ survey::svydesign(~1, data = as.data.frame(Titanic), weights = ~Freq) |>
   add_difference()
 \dontshow{\}) # examplesIf}
 }
->>>>>>> d76aeabdbaa9e269869f9ef4b1aba538df10c084

--- a/man/add_difference.tbl_svysummary.Rd
+++ b/man/add_difference.tbl_svysummary.Rd
@@ -73,7 +73,7 @@ to the table along with the difference's confidence interval and a p-value (when
 }
 \examples{
 \dontshow{if ((identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) && gtsummary:::is_pkg_installed("broom", ref = "cardx")) withAutoprint(\{ # examplesIf}
-Example 1 ----------------------------------
+# Example 1 ----------------------------------
 survey::svydesign(~1, data = as.data.frame(Titanic), weights = ~Freq) |>
   tbl_svysummary(
     by = Survived,

--- a/man/add_difference.tbl_svysummary.Rd
+++ b/man/add_difference.tbl_svysummary.Rd
@@ -73,5 +73,13 @@ to the table along with the difference's confidence interval and a p-value (when
 }
 \examples{
 \dontshow{if ((identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) && gtsummary:::is_pkg_installed("broom", ref = "cardx")) withAutoprint(\{ # examplesIf}
+Example 1 ----------------------------------
+survey::svydesign(~1, data = as.data.frame(Titanic), weights = ~Freq) |>
+  tbl_svysummary(
+    by = Survived,
+    value = list(Class ~ "1st", Age = "Child"),
+    include = c(Class, Age)
+  ) |>
+  add_difference()
 \dontshow{\}) # examplesIf}
 }

--- a/man/add_difference.tbl_svysummary.Rd
+++ b/man/add_difference.tbl_svysummary.Rd
@@ -71,7 +71,3 @@ Adds difference to tables created by \code{\link[=tbl_summary]{tbl_summary()}}.
 The difference between two groups (typically mean or rate difference) is added
 to the table along with the difference's confidence interval and a p-value (when applicable).
 }
-\examples{
-\dontshow{if ((identical(Sys.getenv("NOT_CRAN"), "true") || identical(Sys.getenv("IN_PKGDOWN"), "true")) && gtsummary:::is_pkg_installed("broom", ref = "cardx")) withAutoprint(\{ # examplesIf}
-\dontshow{\}) # examplesIf}
-}

--- a/man/add_nevent.tbl_survfit.Rd
+++ b/man/add_nevent.tbl_survfit.Rd
@@ -29,7 +29,7 @@ list(fit1, fit2) |>
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other tbl_survfit tools: 
-\code{\link{add_p.tbl_survfit}()}
+Other tbl_survfit tools:
+\code{\link[=add_p.tbl_survfit]{add_p.tbl_survfit()}}
 }
 \concept{tbl_survfit tools}

--- a/man/add_p.tbl_survfit.Rd
+++ b/man/add_p.tbl_survfit.Rd
@@ -93,7 +93,7 @@ gts_survfit |>
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other tbl_survfit tools: 
-\code{\link{add_nevent.tbl_survfit}()}
+Other tbl_survfit tools:
+\code{\link[=add_nevent.tbl_survfit]{add_nevent.tbl_survfit()}}
 }
 \concept{tbl_survfit tools}

--- a/man/as_hux_table.Rd
+++ b/man/as_hux_table.Rd
@@ -21,6 +21,8 @@ Default is \code{everything()}.}
 \item{return_calls}{Logical. Default is \code{FALSE}. If \code{TRUE}, the calls are returned
 as a list of expressions.}
 
+\item{file}{File path for the output.}
+
 \item{bold_header_rows}{(scalar \code{logical})\cr
 logical indicating whether to bold header rows. Default is \code{TRUE}}
 }

--- a/man/as_hux_table.Rd
+++ b/man/as_hux_table.Rd
@@ -21,8 +21,6 @@ Default is \code{everything()}.}
 \item{return_calls}{Logical. Default is \code{FALSE}. If \code{TRUE}, the calls are returned
 as a list of expressions.}
 
-\item{file}{File path for the output.}
-
 \item{bold_header_rows}{(scalar \code{logical})\cr
 logical indicating whether to bold header rows. Default is \code{TRUE}}
 }

--- a/man/gtsummary-package.Rd
+++ b/man/gtsummary-package.Rd
@@ -24,6 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Daniel D. Sjoberg \email{danield.sjoberg@gmail.com} (\href{https://orcid.org/0000-0003-0862-2018}{ORCID})
   \item Joseph Larmarange (\href{https://orcid.org/0000-0001-7097-700X}{ORCID})
   \item Michael Curry (\href{https://orcid.org/0000-0002-0261-4044}{ORCID})
   \item Emily de la Rua (\href{https://orcid.org/0009-0000-8738-5561}{ORCID})

--- a/man/head.gtsummary.Rd
+++ b/man/head.gtsummary.Rd
@@ -13,9 +13,9 @@
 \item{x}{A \code{gtsummary} object.}
 
 \item{n}{Number of rows to return. Default is \code{6L} as default in \code{\link[utils:head]{utils::head()}} and
-\code{\link[utils:head]{utils::tail()}}.}
+\code{\link[utils:tail]{utils::tail()}}.}
 
-\item{...}{Additional arguments passed to \code{\link[utils:head]{utils::head()}} or \code{\link[utils:head]{utils::tail()}}.}
+\item{...}{Additional arguments passed to \code{\link[utils:head]{utils::head()}} or \code{\link[utils:tail]{utils::tail()}}.}
 }
 \value{
 A \code{gtsummary} object with only the first or last \code{n} rows in \code{table_body}.

--- a/man/label_style.Rd
+++ b/man/label_style.Rd
@@ -76,7 +76,7 @@ my_style <- label_style_number(digits = 1)
 my_style(3.14)
 }
 \seealso{
-Other style tools: 
-\code{\link{style_sigfig}()}
+Other style tools:
+\code{\link[=style_sigfig]{style_sigfig()}}
 }
 \concept{style tools}

--- a/man/modify_column_merge.Rd
+++ b/man/modify_column_merge.Rd
@@ -86,8 +86,8 @@ lm(marker ~ age + grade, trial) |>
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other Advanced modifiers: 
-\code{\link{modify_indent}()},
-\code{\link{modify_table_styling}()}
+Other Advanced modifiers:
+\code{\link[=modify_indent]{modify_indent()}},
+\code{\link[=modify_table_styling]{modify_table_styling()}}
 }
 \concept{Advanced modifiers}

--- a/man/modify_indent.Rd
+++ b/man/modify_indent.Rd
@@ -40,8 +40,8 @@ trial |>
   modify_indent(columns = label, rows = !row_type \%in\% 'label', indent = 8L)
 }
 \seealso{
-Other Advanced modifiers: 
-\code{\link{modify_column_merge}()},
-\code{\link{modify_table_styling}()}
+Other Advanced modifiers:
+\code{\link[=modify_column_merge]{modify_column_merge()}},
+\code{\link[=modify_table_styling]{modify_table_styling()}}
 }
 \concept{Advanced modifiers}

--- a/man/modify_table_styling.Rd
+++ b/man/modify_table_styling.Rd
@@ -141,9 +141,9 @@ internally with care, and it is \emph{not} recommended for users.
 \seealso{
 See \href{https://www.danieldsjoberg.com/gtsummary/articles/gtsummary_definition.html}{gtsummary internals vignette}
 
-Other Advanced modifiers: 
-\code{\link{modify_column_merge}()},
-\code{\link{modify_indent}()}
+Other Advanced modifiers:
+\code{\link[=modify_column_merge]{modify_column_merge()}},
+\code{\link[=modify_indent]{modify_indent()}}
 }
 \concept{Advanced modifiers}
 \keyword{internal}

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -26,6 +26,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{dplyr}{\code{\link[dplyr:reexports]{\%>\%}}, \code{\link[dplyr:reexports]{all_of}}, \code{\link[dplyr:reexports]{any_of}}, \code{\link[dplyr:reexports]{as_tibble}}, \code{\link[dplyr:reexports]{contains}}, \code{\link[dplyr:reexports]{ends_with}}, \code{\link[dplyr:reexports]{everything}}, \code{\link[dplyr:reexports]{last_col}}, \code{\link[dplyr:reexports]{matches}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr:reexports]{num_range}}, \code{\link[dplyr:reexports]{one_of}}, \code{\link[dplyr]{select}}, \code{\link[dplyr:reexports]{starts_with}}, \code{\link[dplyr]{vars}}, \code{\link[dplyr:reexports]{where}}}
+  \item{dplyr}{\code{\link[dplyr:\%>\%]{\%>\%}}, \code{\link[dplyr:all_of]{all_of}}, \code{\link[dplyr:any_of]{any_of}}, \code{\link[dplyr:as_tibble]{as_tibble}}, \code{\link[dplyr:contains]{contains}}, \code{\link[dplyr:ends_with]{ends_with}}, \code{\link[dplyr:everything]{everything}}, \code{\link[dplyr:last_col]{last_col}}, \code{\link[dplyr:matches]{matches}}, \code{\link[dplyr:mutate]{mutate()}}, \code{\link[dplyr:num_range]{num_range}}, \code{\link[dplyr:one_of]{one_of}}, \code{\link[dplyr:select]{select()}}, \code{\link[dplyr:starts_with]{starts_with}}, \code{\link[dplyr:vars]{vars()}}, \code{\link[dplyr:where]{where}}}
 }}
 

--- a/man/style_sigfig.Rd
+++ b/man/style_sigfig.Rd
@@ -75,7 +75,7 @@ c(0.123, 0.9, 1.1234, 12.345, -0.123, -0.9, -1.1234, -132.345, NA, -0.001) \%>\%
   style_sigfig()
 }
 \seealso{
-Other style tools: 
+Other style tools:
 \code{\link{label_style}}
 }
 \author{

--- a/man/tbl_custom_summary.Rd
+++ b/man/tbl_custom_summary.Rd
@@ -127,7 +127,7 @@ encouraged the user-defined function accept \code{...} as each of the arguments
 \emph{will} be passed to the function, even if not all inputs are utilized by
 the user's function, e.g. \code{foo(data, ...)} (see examples).
 
-The user-defined function should return a one row \code{\link[dplyr:reexports]{dplyr::tibble()}} with
+The user-defined function should return a one row \code{\link[dplyr:tibble]{dplyr::tibble()}} with
 one column per summary statistics (see examples).
 }
 

--- a/man/tbl_regression_methods.Rd
+++ b/man/tbl_regression_methods.Rd
@@ -85,7 +85,7 @@ If an error occurs, the tidying of the model is attempted with
 }
 \description{
 Most regression models are handled by \code{\link[=tbl_regression]{tbl_regression()}},
-which uses \code{\link[broom:reexports]{broom::tidy()}} to perform initial tidying of results. There are,
+which uses \code{\link[broom:tidy]{broom::tidy()}} to perform initial tidying of results. There are,
 however, some model types that have modified default printing behavior.
 Those methods are listed below.
 }

--- a/man/tbl_svysummary.Rd
+++ b/man/tbl_svysummary.Rd
@@ -97,8 +97,8 @@ For categorical variables the following statistics are available to display.
 \item \code{{n}} frequency
 \item \code{{N}} denominator, or cohort size
 \item \code{{p}} proportion
-\item \code{{p.std.error}} standard error of the sample proportion (on the 0 to 1 scale) computed with \code{\link[survey:surveysummary]{survey::svymean()}}
-\item \code{{deff}} design effect of the sample proportion computed with \code{\link[survey:surveysummary]{survey::svymean()}}
+\item \code{{p.std.error}} standard error of the sample proportion (on the 0 to 1 scale) computed with \code{\link[survey:svymean]{survey::svymean()}}
+\item \code{{deff}} design effect of the sample proportion computed with \code{\link[survey:svymean]{survey::svymean()}}
 \item \code{{n_unweighted}} unweighted frequency
 \item \code{{N_unweighted}} unweighted denominator
 \item \code{{p_unweighted}} unweighted formatted percentage
@@ -107,8 +107,8 @@ For continuous variables the following statistics are available to display.
 \itemize{
 \item \code{{median}} median
 \item \code{{mean}} mean
-\item \code{{mean.std.error}} standard error of the sample mean computed with \code{\link[survey:surveysummary]{survey::svymean()}}
-\item \code{{deff}} design effect of the sample mean computed with \code{\link[survey:surveysummary]{survey::svymean()}}
+\item \code{{mean.std.error}} standard error of the sample mean computed with \code{\link[survey:svymean]{survey::svymean()}}
+\item \code{{deff}} design effect of the sample mean computed with \code{\link[survey:svymean]{survey::svymean()}}
 \item \code{{sd}} standard deviation
 \item \code{{var}} variance
 \item \code{{min}} minimum

--- a/tests/testthat/test-filter_hierarchical.R
+++ b/tests/testthat/test-filter_hierarchical.R
@@ -265,3 +265,26 @@ test_that("filter_hierarchical() error messaging works", {
     error = TRUE
   )
 })
+
+test_that("filter_hierarchical() retains the internal ard_stack_hierarchical class", {
+  ADAE_subset <- cards::ADAE |>
+    dplyr::filter(AEBODSYS %in% c("SKIN AND SUBCUTANEOUS TISSUE DISORDERS",
+                                  "EAR AND LABYRINTH DISORDERS")) |>
+    dplyr::filter(.by = AEBODSYS, dplyr::row_number() < 20)
+  
+  tbl <- tbl_hierarchical(
+    data = ADAE_subset,
+    variables = c(AEBODSYS, AEDECOD),
+    by = TRTA,
+    denominator = cards::ADSL,
+    id = USUBJID
+  )
+  
+  tbl_filtered <- filter_hierarchical(tbl, abs(p_2 - p_3) > 0.03, quiet = TRUE)
+  
+  # Verify the internal ARD engine kept its required cards subclass
+  expect_s3_class(
+    tbl_filtered$cards$tbl_hierarchical, 
+    "ard_stack_hierarchical"
+  )
+})

--- a/tests/testthat/test-sort_hierarchical.R
+++ b/tests/testthat/test-sort_hierarchical.R
@@ -270,3 +270,26 @@ test_that("sort_hierarchical() error messaging works", {
     error = TRUE
   )
 })
+
+test_that("sort_hierarchical() retains the internal ard_stack_hierarchical class", {
+  ADAE_subset <- cards::ADAE |>
+    dplyr::filter(AEBODSYS %in% c("SKIN AND SUBCUTANEOUS TISSUE DISORDERS",
+                                  "EAR AND LABYRINTH DISORDERS")) |>
+    dplyr::filter(.by = AEBODSYS, dplyr::row_number() < 20)
+  
+  tbl <- tbl_hierarchical(
+    data = ADAE_subset,
+    variables = c(AEBODSYS, AEDECOD),
+    by = TRTA,
+    denominator = cards::ADSL,
+    id = USUBJID
+  )
+  
+  tbl_sorted <- sort_hierarchical(tbl)
+  
+  # Verify the internal ARD engine kept its required cards subclass
+  expect_s3_class(
+    tbl_sorted$cards$tbl_hierarchical, 
+    "ard_stack_hierarchical"
+  )
+})

--- a/tests/testthat/test-tbl_hierarchical.R
+++ b/tests/testthat/test-tbl_hierarchical.R
@@ -444,3 +444,44 @@ test_that("tbl_hierarchical table_body group variables are correct with no by", 
 
   expect_snapshot(as.data.frame(res$table_body))
 })
+
+test_that("filter_hierarchical() produces no warnings on tbl_hierarchical output", {
+  ADAE_subset <- cards::ADAE |>
+    dplyr::filter(AEBODSYS %in% c("SKIN AND SUBCUTANEOUS TISSUE DISORDERS",
+                                  "EAR AND LABYRINTH DISORDERS")) |>
+    dplyr::filter(.by = AEBODSYS, dplyr::row_number() < 20)
+  
+  tbl <- tbl_hierarchical(
+    data = ADAE_subset,
+    variables = c(AEBODSYS, AEDECOD),
+    by = TRTA,
+    denominator = cards::ADSL,
+    id = USUBJID,
+    overall_row = TRUE
+  )
+  
+  # quiet = TRUE silences the standard informational message so we only test for actual warnings
+  expect_no_warning(
+    filter_hierarchical(tbl, abs(p_2 - p_3) > 0.03, quiet = TRUE)
+  )
+})
+
+test_that("sort_hierarchical() produces no warnings on tbl_hierarchical output", {
+  ADAE_subset <- cards::ADAE |>
+    dplyr::filter(AEBODSYS %in% c("SKIN AND SUBCUTANEOUS TISSUE DISORDERS",
+                                  "EAR AND LABYRINTH DISORDERS")) |>
+    dplyr::filter(.by = AEBODSYS, dplyr::row_number() < 20)
+  
+  tbl <- tbl_hierarchical(
+    data = ADAE_subset,
+    variables = c(AEBODSYS, AEDECOD),
+    by = TRTA,
+    denominator = cards::ADSL,
+    id = USUBJID,
+    overall_row = TRUE
+  )
+  
+  expect_no_warning(
+    sort_hierarchical(tbl)
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fixed bug in `tbl_hierarchical()`, `filter_hierarchical()` and `sort_hierarchical()` that was dropping class attributes. 


**If there is an GitHub issue associated with this pull request, please provide link.**
Closes #2397 


Description / Motivation
Piping `tbl_hierarchical()` into `sort_hierarchical()` or `filter_hierarchical()` was triggering false-positive cards warnings ("Unexpected results may occur"), which caused strict CI/CD pipelines to fail downstream.

Root Cause
gtsummary's internal dplyr operations and `cards::as_card(check = FALSE)` were accidentally stripping the required "ard_stack_hierarchical" class and "args" metadata from the underlying ARD. When passed to downstream cards functions, validation failed because the ARD had lost its hierarchical identity.

Changes Made
Attribute preservation: Implemented a "save and restore" pattern for ARD attributes across `internal_tbl_hierarchical()`, `.reshape_ard_compare(`), and `.add_gts_column_to_cards_hierarchical()`.

Argument injection: Forcefully injected evaluated variables and by strings into the "args" attribute to prevent cards from tripping over unevaluated tidyselect closures.

Testing
Added `expect_no_warning()` tests in `test-tbl_hierarchical.R` to ensure sorting and filtering execute cleanly.

Added `expect_s3_class()` tests to verify the internal ARD (`tbl$cards[[1]]`) successfully retains the "ard_stack_hierarchical" class after mutations.

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

