### PR TITLE
Fix translation of statistical tests in `separate_p_footnotes()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.5.1
+Version: 2.5.1.9000
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# gtsummary (development version)
+
+* Fixed bug in `separate_p_footnotes()` where statistical test names in footnotes were not translated when using a non-English language theme. (#2368)
+
 # gtsummary 2.5.1
 
 * Theme elements are no longer 'evaluated' by default, e.g. `rlang::eval()`. Only `'as_flex_table-lst:addl_cmds'`, `'as_gt-lst:addl_cmds'`, `'as_hux_table-lst:addl_cmds'`, `'as_kable_extra-lst:addl_cmds'` elements that pass expressions are evaluated.

--- a/R/separate_p_footnotes.R
+++ b/R/separate_p_footnotes.R
@@ -56,7 +56,8 @@ separate_p_footnotes <- function(x) {
       }
     ) |>
     set_names(unique(x$table_body$variable)) |>
-    compact()
+    compact() |>
+    map(translate_string)
 
 
   # adding footnotes to cells in table -----------------------------------------

--- a/tests/testthat/test-separate_p_footnotes.R
+++ b/tests/testthat/test-separate_p_footnotes.R
@@ -42,6 +42,25 @@ test_that("separate_p_footnotes() messaging", {
 })
 
 
+test_that("separate_p_footnotes() translates footnotes", {
+  footnotes <-
+    with_gtsummary_theme(
+      theme_gtsummary_language("es"),
+      expr = trial |>
+        tbl_summary(by = trt, include = c(age, grade)) |>
+        add_p() |>
+        separate_p_footnotes() |>
+        getElement("table_styling") |>
+        getElement("footnote_body") |>
+        dplyr::pull("footnote")
+    )
+
+  # footnotes must contain Spanish translations, not English originals
+  expect_true(any(grepl("prueba chi cuadrado", footnotes, fixed = TRUE)))
+  expect_false(any(grepl("Pearson's Chi-squared test", footnotes, fixed = TRUE)))
+  expect_false(any(grepl("Wilcoxon rank sum test", footnotes, fixed = TRUE)))
+})
+
 # adding test against a `tbl_svysummary()` object
 test_that("separate_p_footnotes() with tbl_svysummary()", {
   skip_if_pkg_not_installed("survey")


### PR DESCRIPTION
**What changes are proposed in this pull request?**
`separate_p_footnotes()` now translates statistical test names in per-variable footnotes when a non-English language theme is active. Previously, footnotes were extracted from ARD cards without translation, so test names like "Kruskal-Wallis rank sum test" appeared in English even when a Spanish (or other) theme was set. This is a regression of #1055.

**If there is an GitHub issue associated with this pull request, please provide link.**
Fixes #2368

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".
