### PR TITLE
Fix duplicate footnote superscripts in `tbl_stack()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.5.1.9000
+Version: 2.5.1.9001
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fixed bug in `separate_p_footnotes()` where statistical test names in footnotes were not translated when using a non-English language theme. (#2368)
 
+* Fixed bug in `tbl_stack()` where duplicate footnote superscripts appeared on column headers when stacking tables with identical footnotes, e.g. when using `tbl_uvregression()` with `theme_gtsummary_journal("qjecon")`. (#2404)
+
 # gtsummary 2.5.1
 
 * Theme elements are no longer 'evaluated' by default, e.g. `rlang::eval()`. Only `'as_flex_table-lst:addl_cmds'`, `'as_gt-lst:addl_cmds'`, `'as_hux_table-lst:addl_cmds'`, `'as_kable_extra-lst:addl_cmds'` elements that pass expressions are evaluated.

--- a/R/tbl_stack.R
+++ b/R/tbl_stack.R
@@ -165,6 +165,12 @@ tbl_stack <- function(tbls,
       dplyr::bind_rows()
   }
 
+  # deduplicate header-level footnotes (no `rows` column) to avoid
+
+  # duplicate superscripts when stacking tables with identical footnotes
+  results$table_styling$footnote_header <-
+    dplyr::distinct(results$table_styling$footnote_header)
+
   # combining rows spec for same column
   if (nrow(results$table_styling$cols_merge) > 0) {
     results$table_styling$cols_merge <-

--- a/tests/testthat/test-tbl_stack.R
+++ b/tests/testthat/test-tbl_stack.R
@@ -325,3 +325,33 @@ test_that("tbl_stack throws expected errors", {
     error = TRUE
   )
 })
+
+test_that("tbl_stack deduplicates identical footnote_header rows", {
+  # stacking two tables with the same footnote_header should not duplicate
+  tbl <- tbl_stack(list(t1_regression, t2_regression))
+
+  expect_equal(
+    nrow(tbl$table_styling$footnote_header),
+    nrow(dplyr::distinct(tbl$table_styling$footnote_header))
+  )
+})
+
+test_that("tbl_stack with qjecon theme does not duplicate footnote superscripts", {
+  tbl <-
+    with_gtsummary_theme(
+      theme_gtsummary_journal("qjecon"),
+      expr = trial |>
+        dplyr::select(age, grade, response) |>
+        tbl_uvregression(
+          method = glm,
+          y = response,
+          method.args = list(family = binomial),
+          exponentiate = TRUE
+        )
+    )
+
+  # should have exactly one significance stars footnote, not one per variable
+  footnote_rows <- tbl$table_styling$footnote_header |>
+    dplyr::filter(.data$column == "estimate")
+  expect_equal(nrow(footnote_rows), 1L)
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
`tbl_stack()` now deduplicates `footnote_header` rows after binding styling from sub-tables. Previously, when stacking tables that share identical header footnotes (e.g., significance stars from the qjecon theme), each sub-table contributed a duplicate row, producing repeated superscripts like `1,1,1` on column headers.

**If there is an GitHub issue associated with this pull request, please provide link.**
Fixes #2404

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".
