### PR TITLE
perf: add matrix support to `style_*()` functions by replacing `case_when()` with indexing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.5.1.9001
+Version: 2.5.1.9002
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed bug in `tbl_stack()` where duplicate footnote superscripts appeared on column headers when stacking tables with identical footnotes, e.g. when using `tbl_uvregression()` with `theme_gtsummary_journal("qjecon")`. (#2404)
 
+* `style_sigfig()`, `style_percent()`, `style_pvalue()`, and `style_ratio()` now work with matrix input. (#2409)
+
 # gtsummary 2.5.1
 
 * Theme elements are no longer 'evaluated' by default, e.g. `rlang::eval()`. Only `'as_flex_table-lst:addl_cmds'`, `'as_gt-lst:addl_cmds'`, `'as_hux_table-lst:addl_cmds'`, `'as_kable_extra-lst:addl_cmds'` elements that pass expressions are evaluated.

--- a/R/style_percent.R
+++ b/R/style_percent.R
@@ -47,16 +47,29 @@ style_percent <- function(x,
       get_theme_element("style_number-arg:big.mark", default = ifelse(decimal.mark == ",", "\U2009", ","))
   }
 
-  y <- dplyr::case_when(
-    x * 100 >= 10 ~ style_number(x * 100, digits = digits, big.mark = big.mark, decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...),
-    x * 100 >= 10^(-(digits + 1)) ~ style_number(x * 100, digits = digits + 1, big.mark = big.mark, decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...),
-    x > 0 ~ paste0("<", style_number(
-      x = 10^(-(digits + 1)), digits = digits + 1, big.mark = big.mark,
-      decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...
-    )),
-    x == 0 ~ paste0(prefix, "0", suffix),
-    is.na(x) ~ na
-  )
+  y <- rep(NA_character_, length(x))
+
+  na_mask <- is.na(x)
+  y[na_mask] <- na
+
+  idx <- !na_mask & x == 0
+  y[idx] <- paste0(prefix, "0", suffix)
+
+  idx <- !na_mask & x > 0 & x * 100 < 10^(-(digits + 1))
+  y[idx] <- paste0("<", style_number(
+    x = 10^(-(digits + 1)), digits = digits + 1, big.mark = big.mark,
+    decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...
+  ))
+
+  idx <- !na_mask & x * 100 >= 10^(-(digits + 1)) & x * 100 < 10
+  if (any(idx)) {
+    y[idx] <- style_number(x[idx] * 100, digits = digits + 1, big.mark = big.mark, decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...)
+  }
+
+  idx <- !na_mask & x * 100 >= 10
+  if (any(idx)) {
+    y[idx] <- style_number(x[idx] * 100, digits = digits, big.mark = big.mark, decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...)
+  }
 
   attributes(y) <- attributes(unclass(x))
   return(y)

--- a/R/style_pvalue.R
+++ b/R/style_pvalue.R
@@ -41,81 +41,85 @@ style_pvalue <- function(x,
   }
 
   # rounding large p-values to 1 digits
+  na_mask <- is.na(x)
+  p_fmt <- rep(NA_character_, length(x))
+  p_fmt[na_mask] <- na
+
+  # allowing some leeway for numeric storage errors
+  out_of_range <- !na_mask & (x > 1 + 1e-15 | x < 0 - 1e-15)
+
+  lt_str <- paste0("<", style_number(
+    x = 0.001, digits = 3, big.mark = big.mark,
+    decimal.mark = decimal.mark, na = na, ...
+  ))
+
   if (digits == 1) {
-    p_fmt <-
-      dplyr::case_when(
-        # allowing some leeway for numeric storage errors
-        x > 1 + 1e-15 ~ NA_character_,
-        x < 0 - 1e-15 ~ NA_character_,
-        x > 0.9 ~ paste0(">", style_number(
-          x = 0.9, digits = 1, big.mark = big.mark,
-          decimal.mark = decimal.mark, na = na, ...
-        )),
-        cards::round5(x, 1) >= 0.2 ~ style_number(x,
-                                                  digits = 1, big.mark = big.mark,
-                                                  decimal.mark = decimal.mark, na = na, ...
-        ),
-        cards::round5(x, 2) >= 0.1 ~ style_number(x,
-                                                  digits = 2, big.mark = big.mark,
-                                                  decimal.mark = decimal.mark, na = na, ...
-        ),
-        x >= 0.001 ~ style_number(x,
-                                  digits = 3, big.mark = big.mark,
-                                  decimal.mark = decimal.mark, na = na, ...
-        ),
-        x < 0.001 ~ paste0("<", style_number(
-          x = 0.001, digits = 3, big.mark = big.mark,
-          decimal.mark = decimal.mark, na = na, ...
-        )),
-        is.na(x) ~ na
-      )
+    idx <- !na_mask & !out_of_range & x < 0.001
+    p_fmt[idx] <- lt_str
+
+    idx <- !na_mask & !out_of_range & x >= 0.001 & !(cards::round5(x, 2) >= 0.1)
+    if (any(idx)) {
+      p_fmt[idx] <- style_number(x[idx], digits = 3, big.mark = big.mark,
+                                 decimal.mark = decimal.mark, na = na, ...)
+    }
+
+    idx <- !na_mask & !out_of_range & cards::round5(x, 2) >= 0.1 & !(cards::round5(x, 1) >= 0.2)
+    if (any(idx)) {
+      p_fmt[idx] <- style_number(x[idx], digits = 2, big.mark = big.mark,
+                                 decimal.mark = decimal.mark, na = na, ...)
+    }
+
+    idx <- !na_mask & !out_of_range & cards::round5(x, 1) >= 0.2 & x <= 0.9
+    if (any(idx)) {
+      p_fmt[idx] <- style_number(x[idx], digits = 1, big.mark = big.mark,
+                                 decimal.mark = decimal.mark, na = na, ...)
+    }
+
+    idx <- !na_mask & !out_of_range & x > 0.9
+    p_fmt[idx] <- paste0(">", style_number(
+      x = 0.9, digits = 1, big.mark = big.mark,
+      decimal.mark = decimal.mark, na = na, ...
+    ))
   }
   # rounding large p-values to 2 digits
   else if (digits == 2) {
-    p_fmt <-
-      dplyr::case_when(
-        x > 1 + 1e-15 ~ NA_character_,
-        x < 0 - 1e-15 ~ NA_character_,
-        x > 0.99 ~ paste0(">", style_number(
-          x = 0.99, digits = 2, big.mark = big.mark,
-          decimal.mark = decimal.mark, na = na, ...
-        )),
-        cards::round5(x, 2) >= 0.1 ~ style_number(x,
-                                                  digits = 2, big.mark = big.mark,
-                                                  decimal.mark = decimal.mark, na = na, ...
-        ),
-        x >= 0.001 ~ style_number(x,
-                                  digits = 3, big.mark = big.mark,
-                                  decimal.mark = decimal.mark, na = na, ...
-        ),
-        x < 0.001 ~ paste0("<", style_number(
-          x = 0.001, digits = 3, big.mark = big.mark,
-          decimal.mark = decimal.mark, na = na, ...
-        )),
-        is.na(x) ~ na
-      )
-  }
+    idx <- !na_mask & !out_of_range & x < 0.001
+    p_fmt[idx] <- lt_str
 
+    idx <- !na_mask & !out_of_range & x >= 0.001 & !(cards::round5(x, 2) >= 0.1)
+    if (any(idx)) {
+      p_fmt[idx] <- style_number(x[idx], digits = 3, big.mark = big.mark,
+                                 decimal.mark = decimal.mark, na = na, ...)
+    }
+
+    idx <- !na_mask & !out_of_range & cards::round5(x, 2) >= 0.1 & x <= 0.99
+    if (any(idx)) {
+      p_fmt[idx] <- style_number(x[idx], digits = 2, big.mark = big.mark,
+                                 decimal.mark = decimal.mark, na = na, ...)
+    }
+
+    idx <- !na_mask & !out_of_range & x > 0.99
+    p_fmt[idx] <- paste0(">", style_number(
+      x = 0.99, digits = 2, big.mark = big.mark,
+      decimal.mark = decimal.mark, na = na, ...
+    ))
+  }
   # rounding large pvalues to 3 digit
   else if (digits == 3) {
-    p_fmt <-
-      dplyr::case_when(
-        x > 1 + 1e-15 ~ NA_character_,
-        x < 0 - 1e-15 ~ NA_character_,
-        x > 0.999 ~ paste0(">", style_number(
-          x = 0.999, digits = 3, big.mark = big.mark,
-          decimal.mark = decimal.mark, na = na, ...
-        )),
-        x >= 0.001 ~ style_number(x,
-                                  digits = 3, big.mark = big.mark,
-                                  decimal.mark = decimal.mark, na = na, ...
-        ),
-        x < 0.001 ~ paste0("<", style_number(
-          x = 0.001, digits = 3, big.mark = big.mark,
-          decimal.mark = decimal.mark, na = na, ...
-        )),
-        is.na(x) ~ na
-      )
+    idx <- !na_mask & !out_of_range & x < 0.001
+    p_fmt[idx] <- lt_str
+
+    idx <- !na_mask & !out_of_range & x >= 0.001 & x <= 0.999
+    if (any(idx)) {
+      p_fmt[idx] <- style_number(x[idx], digits = 3, big.mark = big.mark,
+                                 decimal.mark = decimal.mark, na = na, ...)
+    }
+
+    idx <- !na_mask & !out_of_range & x > 0.999
+    p_fmt[idx] <- paste0(">", style_number(
+      x = 0.999, digits = 3, big.mark = big.mark,
+      decimal.mark = decimal.mark, na = na, ...
+    ))
   } else {
     cli::cli_abort(
       "The {.arg digits} argument must be one of {.val {1:3}}.",
@@ -125,12 +129,12 @@ style_pvalue <- function(x,
 
   # prepending a p = in front of value
   if (prepend_p == TRUE) {
-    p_fmt <- dplyr::case_when(
-      is.na(p_fmt) ~ NA_character_,
-      (is.na(na) & is.na(p_fmt)) | p_fmt == na ~ na,
-      grepl(pattern = "<|>", x = p_fmt) ~ paste0("p", p_fmt),
-      TRUE ~ paste0("p=", p_fmt)
-    )
+    has_ltgt <- !is.na(p_fmt) & grepl(pattern = "<|>", x = p_fmt)
+    is_na_val <- is.na(p_fmt) | (!is.na(na) & p_fmt == na)
+    idx <- !is_na_val & has_ltgt
+    p_fmt[idx] <- paste0("p", p_fmt[idx])
+    idx <- !is_na_val & !has_ltgt
+    p_fmt[idx] <- paste0("p=", p_fmt[idx])
   }
 
   attributes(p_fmt) <- attributes(unclass(x))

--- a/R/style_ratio.R
+++ b/R/style_ratio.R
@@ -42,16 +42,24 @@ style_ratio <- function(x,
       get_theme_element("style_number-arg:big.mark", default = ifelse(decimal.mark == ",", "\U2009", ","))
   }
 
-  x_fmt <-
-    dplyr::case_when(
-      cards::round5(abs(x), digits = digits) < 1 ~
-        style_sigfig(x, digits = digits, big.mark = big.mark, decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...),
-      x > 0 ~
-        style_sigfig(pmax(1, x), digits = digits + 1, big.mark = big.mark, decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...),
-      x < 0 ~
-        style_sigfig(pmin(-1, x), digits = digits + 1, big.mark = big.mark, decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...),
-      is.na(x) ~ na
-    )
+  na_mask <- is.na(x)
+  x_fmt <- rep(NA_character_, length(x))
+  x_fmt[na_mask] <- na
+
+  idx <- !na_mask & cards::round5(abs(x), digits = digits) < 1
+  if (any(idx)) {
+    x_fmt[idx] <- style_sigfig(x[idx], digits = digits, big.mark = big.mark, decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...)
+  }
+
+  idx <- !na_mask & x > 0 & cards::round5(abs(x), digits = digits) >= 1
+  if (any(idx)) {
+    x_fmt[idx] <- style_sigfig(pmax(1, x[idx]), digits = digits + 1, big.mark = big.mark, decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...)
+  }
+
+  idx <- !na_mask & x < 0 & cards::round5(abs(x), digits = digits) >= 1
+  if (any(idx)) {
+    x_fmt[idx] <- style_sigfig(pmin(-1, x[idx]), digits = digits + 1, big.mark = big.mark, decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...)
+  }
 
   attributes(x_fmt) <- attributes(unclass(x))
   x_fmt

--- a/R/style_sigfig.R
+++ b/R/style_sigfig.R
@@ -53,16 +53,17 @@ style_sigfig <- function(x,
   }
 
   # calculating the number of digits to round number
-  d <-
-    paste0(
-      "cards::round5(abs(x * scale), digits = ", digits:1 + 1L, ") ",
-      "< 10^(", 1:digits - 1, ") - 0.5 * 10^(", -(digits:1), ") ~ ", digits:1,
-      collapse = ", "
-    ) %>%
-    {paste0("dplyr::case_when(", ., ", TRUE ~ 0)")} %>% # styler: off
-    # converting strings into expressions to run
-    parse(text = .) %>%
-    eval()
+  # process from least-specific (fewest digits) to most-specific so later
+  # assignments overwrite earlier ones, matching the original case_when order
+  d <- rep(0L, length(x))
+  digit_seq <- digits:1  # e.g. c(2, 1) for digits=2
+  for (i in rev(seq_along(digit_seq))) {
+    dig <- digit_seq[i]
+    threshold <- 10^(i - 1) - 0.5 * 10^(-dig)
+    mask <- cards::round5(abs(x * scale), digits = dig + 1L) < threshold
+    mask[is.na(mask)] <- FALSE
+    d[mask] <- dig
+  }
 
   # formatting number
   style_number(x, digits = d, scale = scale, big.mark = big.mark, decimal.mark = decimal.mark, prefix = prefix, suffix = suffix, na = na, ...)

--- a/tests/testthat/test-style_number.R
+++ b/tests/testthat/test-style_number.R
@@ -47,3 +47,14 @@ test_that("style_number() works", {
     "must be strings."
   )
 })
+
+test_that("style_number() works with matrix input", {
+  vec <- c(-1.25, 1.25, 0.5, NA)
+  mat <- matrix(vec, nrow = 2, dimnames = list(c("r1", "r2"), c("c1", "c2")))
+  result <- style_number(mat, digits = 1)
+
+  expect_true(is.matrix(result))
+  expect_equal(dim(result), c(2L, 2L))
+  expect_equal(dimnames(result), list(c("r1", "r2"), c("c1", "c2")))
+  expect_equal(as.vector(result), style_number(vec, digits = 1))
+})

--- a/tests/testthat/test-style_percent.R
+++ b/tests/testthat/test-style_percent.R
@@ -26,3 +26,14 @@ test_that("style_percent() works", {
   )
 })
 
+test_that("style_percent() works with matrix input", {
+  vec <- c(0, 0.0001, 0.10, NA)
+  mat <- matrix(vec, nrow = 2, dimnames = list(c("r1", "r2"), c("c1", "c2")))
+  result <- style_percent(mat)
+
+  expect_true(is.matrix(result))
+  expect_equal(dim(result), c(2L, 2L))
+  expect_equal(dimnames(result), list(c("r1", "r2"), c("c1", "c2")))
+  expect_equal(as.vector(result), style_percent(vec))
+})
+

--- a/tests/testthat/test-style_pvalue.R
+++ b/tests/testthat/test-style_pvalue.R
@@ -61,3 +61,14 @@ test_that("style_pvalue() messaging", {
     style_pvalue(0.05, digits = 8)
   )
 })
+
+test_that("style_pvalue() works with matrix input", {
+  vec <- c(0.5, 0.001, 0.0001, NA)
+  mat <- matrix(vec, nrow = 2, dimnames = list(c("r1", "r2"), c("c1", "c2")))
+  result <- style_pvalue(mat)
+
+  expect_true(is.matrix(result))
+  expect_equal(dim(result), c(2L, 2L))
+  expect_equal(dimnames(result), list(c("r1", "r2"), c("c1", "c2")))
+  expect_equal(as.vector(result), style_pvalue(vec))
+})

--- a/tests/testthat/test-style_ratio.R
+++ b/tests/testthat/test-style_ratio.R
@@ -34,3 +34,14 @@ test_that("style_ratio() works", {
     c("$0.00*", "$1.00*", "$11.0*",  NA)
   )
 })
+
+test_that("style_ratio() works with matrix input", {
+  vec <- c(0.123, 0.9, 1.1234, NA)
+  mat <- matrix(vec, nrow = 2, dimnames = list(c("r1", "r2"), c("c1", "c2")))
+  result <- style_ratio(mat)
+
+  expect_true(is.matrix(result))
+  expect_equal(dim(result), c(2L, 2L))
+  expect_equal(dimnames(result), list(c("r1", "r2"), c("c1", "c2")))
+  expect_equal(as.vector(result), style_ratio(vec))
+})

--- a/tests/testthat/test-style_sigfig.R
+++ b/tests/testthat/test-style_sigfig.R
@@ -38,3 +38,14 @@ test_that("style_sigfig() works", {
     c("$0.00*", "$1.0*", "NE", "$11*",  "NE")
   )
 })
+
+test_that("style_sigfig() works with matrix input", {
+  vec <- c(0.123, 0.9, 1.1234, NA)
+  mat <- matrix(vec, nrow = 2, dimnames = list(c("r1", "r2"), c("c1", "c2")))
+  result <- style_sigfig(mat)
+
+  expect_true(is.matrix(result))
+  expect_equal(dim(result), c(2L, 2L))
+  expect_equal(dimnames(result), list(c("r1", "r2"), c("c1", "c2")))
+  expect_equal(as.vector(result), style_sigfig(vec))
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
`style_sigfig()`, `style_percent()`, `style_pvalue()`, and `style_ratio()` now accept matrix input. The fix replaces `dplyr::case_when()` — which rejects matrices — with index-based assignment (`x[mask] <- ...`). `style_number()` already worked on matrices and is unchanged. The `label_style_*()` wrappers inherit matrix support automatically.

The indexing approach should also be faster than `case_when()` since it avoids dplyr overhead.

**If there is an GitHub issue associated with this pull request, please provide link.**
Fixes #2409

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading \"`# gtsummary (development version)`\". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = \"dev\")`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use \"Squash and merge\".
