### PR TITLE
Fix duplicated warnings from paired tests in `add_p()` (#1945)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Fixed bug in `add_p()` where a warning from a paired test (e.g. `"paired.wilcox.test"`) could be printed twice. (#1945)
+
 * Fixed bug in `separate_p_footnotes()` where statistical test names in footnotes were not translated when using a non-English language theme. (#2368)
 
 * Fixed bug in `tbl_stack()` where duplicate footnote superscripts appeared on column headers when stacking tables with identical footnotes, e.g. when using `tbl_uvregression()` with `theme_gtsummary_journal("qjecon")`. (#2404)

--- a/R/utils-add_p_tests.R
+++ b/R/utils-add_p_tests.R
@@ -673,13 +673,19 @@ add_p_tbl_survfit_coxph <- function(data, variable, test_type = c("log", "sc", "
 }
 
 warn_unbalanced_pairs <- function(data, by, variable, group) {
+  # `pivot_wider()` is used only to detect unbalanced pairs. When the data has
+  # duplicate (group, by) entries it emits a "not uniquely identified" warning
+  # that is unrelated to this function's purpose and would otherwise duplicate a
+  # warning already surfaced by the test itself (#1945). Suppress it here.
   balanced_pairs <-
-    data[c(group, by, variable)] |>
-    tidyr::drop_na() |>
-    tidyr::pivot_wider(
-      id_cols = all_of(group),
-      names_from = all_of(by),
-      values_from = all_of(variable)
+    suppressWarnings(
+      data[c(group, by, variable)] |>
+        tidyr::drop_na() |>
+        tidyr::pivot_wider(
+          id_cols = all_of(group),
+          names_from = all_of(by),
+          values_from = all_of(variable)
+        )
     ) |>
     dplyr::select(-all_of(group)) |>
     dplyr::mutate(across(everything(), is.na)) |>

--- a/tests/testthat/test-add_p.tbl_summary.R
+++ b/tests/testthat/test-add_p.tbl_summary.R
@@ -533,3 +533,55 @@ test_that("addressing GH #1513, where the default test was incorrect", {
     "fisher.test"
   )
 })
+
+test_that("add_p() does not duplicate warnings (#1945)", {
+  # repro from #1945: a paired test with duplicate (group, by) entries triggered
+  # the tidyr 'not uniquely identified' warning to be captured twice
+  tmax <- data.frame(
+    Subject = c(1, 1, 1, 1, 2, 2, 2, 2, 4, 4, 4, 4, 5, 5, 5, 5),
+    Treatment = c("T", "R", "T", "R", "R", "T", "R", "T", "T", "R", "T", "R", "R", "T", "R", "T"),
+    TMAX = c(1.333, 1.667, 0.667, 1.667, 2, 0.667, 2, 2, 1, 1, 2, 1, 0.667, 1, 2, 1)
+  )
+
+  tbl <-
+    suppressWarnings(suppressMessages(
+      tmax |>
+        tbl_summary(
+          by = Treatment,
+          include = -Subject,
+          missing = "no",
+          type = list(TMAX ~ "continuous")
+        ) |>
+        add_p(
+          test = list(all_continuous() ~ "paired.wilcox.test"),
+          group = Subject
+        )
+    ))
+
+  # the captured warning for the affected variable must contain the message once
+  ard_warning <-
+    dplyr::bind_rows(tbl$cards$add_p) |>
+    dplyr::filter(.data$stat_name == "p.value") |>
+    dplyr::pull("warning") |>
+    getElement(1L)
+
+  expect_equal(length(ard_warning), length(unique(ard_warning)))
+  expect_equal(
+    sum(grepl("not uniquely identified", ard_warning)),
+    1L
+  )
+})
+
+test_that("warn_unbalanced_pairs() still warns on genuinely unbalanced pairs", {
+  # one subject has a missing value in one arm -> unbalanced pair
+  d <- data.frame(
+    Subject = c(1, 1, 2, 2, 3, 3),
+    Treatment = c("R", "T", "R", "T", "R", "T"),
+    val = c(1, 2, 3, 4, 5, NA)
+  )
+  res <- cards::eval_capture_conditions(
+    warn_unbalanced_pairs(data = d, by = "Treatment", variable = "val", group = "Subject")
+  )
+  expect_length(res$warning, 1L)
+  expect_match(res$warning[[1]], "unbalanced missingness")
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**

Fixed bug in `add_p()` where a warning from a paired test (e.g. `"paired.wilcox.test"`) could be printed twice. (#1945)

**Root cause:** `warn_unbalanced_pairs()` runs its own `tidyr::pivot_wider()` purely to detect unbalanced pairs. When the data has duplicate `(group, by)` entries, that pivot *leaks* the tidyr *"Values from `<var>` are not uniquely identified"* warning as a side effect. The selected test (via cardx) runs `pivot_wider()` internally and embeds the same warning in its ARD. `.calculate_one_test()` then concatenates the outer-captured warning onto the inner ARD warning, so the identical message printed twice.

**Fix:** wrap only the detection `pivot_wider()` pipeline in `warn_unbalanced_pairs()` with `suppressWarnings()`, so the stray warning no longer leaks. The test's own warning still surfaces exactly once via the ARD path, and the function's intended "unbalanced missingness" warning is unaffected.

```r
tmax |>
  tbl_summary(by = Treatment, include = -Subject, missing = "no",
              type = list(TMAX ~ "continuous")) |>
  add_p(test = list(all_continuous() ~ "paired.wilcox.test"), group = Subject)
# warning now printed once (was twice)
```

**If there is an GitHub issue associated with this pull request, please provide link.**

Closes #1945

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [x] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".