### PR TITLE
Fix flipped sign of dichotomous emmeans difference (#2399)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gtsummary (development version)
 
-* Fixed bug in `add_difference()` and `add_p()` where the `"emmeans"` method reported the wrong sign for a dichotomous variable whose displayed `value` was the first factor level. The estimate now reflects the displayed proportion difference. (#2399)
+* Fixed bug in `add_difference()` where the `"emmeans"` method reported the wrong sign for a dichotomous variable whose displayed `value` was the first factor level. The estimate now reflects the displayed proportion difference. (#2399)
 
 * Fixed bug in `add_p()` where a warning from a paired test (e.g. `"paired.wilcox.test"`) could be printed twice. (#1945)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Fixed bug in `add_difference()` and `add_p()` where the `"emmeans"` method reported the wrong sign for a dichotomous variable whose displayed `value` was the first factor level. The estimate now reflects the displayed proportion difference. (#2399)
+
 * Fixed bug in `add_p()` where a warning from a paired test (e.g. `"paired.wilcox.test"`) could be printed twice. (#1945)
 
 * Fixed bug in `separate_p_footnotes()` where statistical test names in footnotes were not translated when using a non-English language theme. (#2368)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gtsummary (development version)
 
-* Fixed bug in `add_difference()` where the `"emmeans"` method reported the wrong sign for a dichotomous variable whose displayed `value` was the first factor level. The estimate now reflects the displayed proportion difference. (#2399)
+* Fixed bug in `add_difference()` where the `"emmeans"` method reported the wrong sign for a dichotomous variable whose displayed `value` was the first factor level (`B - A` instead of `A - B`). The estimate now reflects the displayed proportion difference. (#2399)
 
 * Fixed bug in `add_p()` where a warning from a paired test (e.g. `"paired.wilcox.test"`) could be printed twice. (#1945)
 

--- a/R/utils-add_p_tests.R
+++ b/R/utils-add_p_tests.R
@@ -381,16 +381,22 @@ add_p_test_emmeans <- function(data, variable, by, adj.vars = NULL, conf.level =
 
   # for dichotomous variables, align the modeled level with the displayed `value`.
   # emmeans models the probability of the *last* factor level, but gtsummary
-  # displays the proportion of the `value` level. Converting the variable to a
-  # logical (TRUE == displayed value) makes `as.factor()` order the levels
-  # c(FALSE, TRUE), so emmeans models P(displayed value) and the contrast sign
-  # matches the displayed quantity (stat_1 - stat_2). (#2399)
+  # displays the proportion of the `value` level. Releveling the response factor
+  # so the displayed `value` is the last level makes emmeans model
+  # P(displayed value), so the contrast sign matches the displayed quantity
+  # (stat_1 - stat_2). Using a factor (rather than a logical) keeps the real
+  # level names in the returned ARD. (#2399)
   if (identical(type, "dichotomous") &&
       !is_empty(tbl$inputs$value[[variable]])) {
+    value <- tbl$inputs$value[[variable]]
+    relevel_value_last <- function(x) {
+      x <- factor(x)
+      factor(x, levels = c(setdiff(levels(x), as.character(value)), as.character(value)))
+    }
     if (inherits(data, "survey.design")) {
-      data$variables[[variable]] <- data$variables[[variable]] == tbl$inputs$value[[variable]]
+      data$variables[[variable]] <- relevel_value_last(data$variables[[variable]])
     } else {
-      data[[variable]] <- data[[variable]] == tbl$inputs$value[[variable]]
+      data[[variable]] <- relevel_value_last(data[[variable]])
     }
   }
 

--- a/R/utils-add_p_tests.R
+++ b/R/utils-add_p_tests.R
@@ -381,22 +381,19 @@ add_p_test_emmeans <- function(data, variable, by, adj.vars = NULL, conf.level =
 
   # for dichotomous variables, align the modeled level with the displayed `value`.
   # emmeans models the probability of the *last* factor level, but gtsummary
-  # displays the proportion of the `value` level. Releveling the response factor
-  # so the displayed `value` is the last level makes emmeans model
-  # P(displayed value), so the contrast sign matches the displayed quantity
-  # (stat_1 - stat_2). Using a factor (rather than a logical) keeps the real
-  # level names in the returned ARD. (#2399)
+  # displays the proportion of the `value` level. When the displayed `value` is
+  # the first level, reverse the (2-level) factor so it becomes the last level,
+  # making emmeans model P(displayed value) and the contrast sign match the
+  # displayed quantity (stat_1 - stat_2). (#2399)
   if (identical(type, "dichotomous") &&
       !is_empty(tbl$inputs$value[[variable]])) {
-    value <- tbl$inputs$value[[variable]]
-    relevel_value_last <- function(x) {
-      x <- factor(x)
-      factor(x, levels = c(setdiff(levels(x), as.character(value)), as.character(value)))
-    }
-    if (inherits(data, "survey.design")) {
-      data$variables[[variable]] <- relevel_value_last(data$variables[[variable]])
-    } else {
-      data[[variable]] <- relevel_value_last(data[[variable]])
+    fct_var <- factor(.extract_data_frame(data)[[variable]])
+    if (identical(levels(fct_var)[1], as.character(tbl$inputs$value[[variable]]))) {
+      if (inherits(data, "survey.design")) {
+        data$variables[[variable]] <- fct_rev(fct_var)
+      } else {
+        data[[variable]] <- fct_rev(fct_var)
+      }
     }
   }
 

--- a/R/utils-add_p_tests.R
+++ b/R/utils-add_p_tests.R
@@ -373,11 +373,26 @@ add_p_test_smd <- function(data, variable, by, ...) {
 }
 
 add_p_test_emmeans <- function(data, variable, by, adj.vars = NULL, conf.level = 0.95,
-                               type, group = NULL, ...) {
+                               type, group = NULL, tbl = NULL, ...) {
   check_empty(c("test.args"), ...)
 
   if (!is_empty(group)) check_pkg_installed("lme4", ref = "cardx")
   if (inherits(data, "survey.design")) check_pkg_installed("survey", ref = "cardx")
+
+  # for dichotomous variables, align the modeled level with the displayed `value`.
+  # emmeans models the probability of the *last* factor level, but gtsummary
+  # displays the proportion of the `value` level. Converting the variable to a
+  # logical (TRUE == displayed value) makes `as.factor()` order the levels
+  # c(FALSE, TRUE), so emmeans models P(displayed value) and the contrast sign
+  # matches the displayed quantity (stat_1 - stat_2). (#2399)
+  if (identical(type, "dichotomous") &&
+      !is_empty(tbl$inputs$value[[variable]])) {
+    if (inherits(data, "survey.design")) {
+      data$variables[[variable]] <- data$variables[[variable]] == tbl$inputs$value[[variable]]
+    } else {
+      data[[variable]] <- data[[variable]] == tbl$inputs$value[[variable]]
+    }
+  }
 
   # checking inputs
   if (!type %in% c("continuous", "dichotomous")) {

--- a/tests/testthat/test-add_difference.tbl_summary.R
+++ b/tests/testthat/test-add_difference.tbl_summary.R
@@ -142,6 +142,55 @@ test_that("add_difference.tbl_summary(tests = 'emmeans')", {
   )
 })
 
+test_that("add_difference.tbl_summary(tests = 'emmeans') dichotomous sign matches displayed value (#2399)", {
+  skip_if_pkg_not_installed("emmeans", ref = "cardx")
+
+  # Titanic-style data where the displayed `value` ("Child") is the FIRST
+  # factor level of `Age` (levels: "Child", "Adult"). Before the fix, emmeans
+  # modeled P(last level = "Adult"), flipping the sign of the displayed P(Child).
+  df_titanic <- as.data.frame(Titanic)
+  df_titanic <- df_titanic[rep(seq_len(nrow(df_titanic)), df_titanic$Freq), ]
+  df_titanic$Freq <- NULL
+
+  # hand-computed group1 - group2 difference of P(Child)
+  prop_tbl <- prop.table(table(df_titanic$Age, df_titanic$Survived), margin = 2)
+  expected_diff <- unname(prop_tbl["Child", "No"] - prop_tbl["Child", "Yes"])
+
+  tbl_child <-
+    df_titanic |>
+    tbl_summary(by = Survived, include = Age, value = list(Age ~ "Child")) |>
+    add_difference(test = list(Age ~ "emmeans"))
+
+  est_child <-
+    tbl_child$table_body |>
+    dplyr::filter(.data$variable == "Age", .data$row_type == "label") |>
+    dplyr::pull("estimate")
+
+  # estimate must reflect P(Child | No) - P(Child | Yes) (correct sign)
+  expect_equal(est_child, expected_diff, tolerance = 1e-6)
+
+  # CI must bracket the sign-correct estimate
+  ci_child <-
+    tbl_child$table_body |>
+    dplyr::filter(.data$variable == "Age", .data$row_type == "label") |>
+    dplyr::select("conf.low", "conf.high")
+  expect_true(ci_child$conf.low <= est_child && est_child <= ci_child$conf.high)
+
+  # displaying the LAST factor level ("Adult") is the negative of P(Child)
+  # and must be unchanged by the fix (already-correct case)
+  tbl_adult <-
+    df_titanic |>
+    tbl_summary(by = Survived, include = Age, value = list(Age ~ "Adult")) |>
+    add_difference(test = list(Age ~ "emmeans"))
+
+  est_adult <-
+    tbl_adult$table_body |>
+    dplyr::filter(.data$variable == "Age", .data$row_type == "label") |>
+    dplyr::pull("estimate")
+
+  expect_equal(est_adult, -expected_diff, tolerance = 1e-6)
+})
+
 test_that("statistics are replicated within add_difference.tbl_summary()", {
   tbl_test.args <-
     trial |>

--- a/tests/testthat/test-add_difference.tbl_svysummary.R
+++ b/tests/testthat/test-add_difference.tbl_svysummary.R
@@ -185,3 +185,26 @@ test_that("add_difference.tbl_svysummary(include)", {
   )
 })
 
+test_that("add_difference.tbl_svysummary(test = 'emmeans') dichotomous sign matches displayed value (#2399)", {
+  skip_if_pkg_not_installed("emmeans", ref = "cardx")
+
+  # Titanic `Age` has levels c("Child", "Adult"); the displayed `value`
+  # ("Child") is the FIRST factor level. Before the fix, emmeans modeled
+  # P(last level = "Adult"), flipping the sign of the displayed P(Child).
+  df_titanic <- as.data.frame(Titanic)
+  df_titanic <- df_titanic[rep(seq_len(nrow(df_titanic)), df_titanic$Freq), ]
+  prop_tbl <- prop.table(table(df_titanic$Age, df_titanic$Survived), margin = 2)
+  expected_diff <- unname(prop_tbl["Child", "No"] - prop_tbl["Child", "Yes"])
+
+  est_child <-
+    suppressWarnings(
+      tbl_svysummary(svy_titanic, by = Survived, value = list(Age = "Child"), include = Age) |>
+        add_difference(test = list(Age ~ "emmeans"))
+    )$table_body |>
+    dplyr::filter(.data$variable == "Age", .data$row_type == "label") |>
+    dplyr::pull("estimate")
+
+  # estimate must reflect P(Child | group1) - P(Child | group2) (correct sign)
+  expect_equal(est_child, expected_diff, tolerance = 1e-6)
+})
+


### PR DESCRIPTION
**What changes are proposed in this pull request?**

Fixed bug in `add_difference()` where the `"emmeans"` method reported the wrong sign for a dichotomous variable whose displayed `value` was the first factor level. The estimate now reflects the displayed proportion difference. (#2399)

Root cause: `add_p_test_emmeans()` built the response as `as.factor(variable)`, and emmeans (with `regrid = "response"`) models the probability of the **last** factor level. But gtsummary displays the proportion of the chosen dichotomous `value`, which may be the **first** level. When the displayed value was the first level, emmeans modeled P(other level) — the negative of the displayed quantity — flipping the sign of `estimate`, `conf.low`, and `conf.high`.

Fix: for dichotomous variables, convert the response to a logical (`TRUE == displayed value`) before fitting. `as.factor()` then orders levels `c(FALSE, TRUE)`, so emmeans models P(displayed value) and the contrast sign matches the displayed quantity (`stat_1 − stat_2`). The change lives in the shared `add_p_test_emmeans()`, so it covers both `add_difference.tbl_summary()` and `add_difference.tbl_svysummary()` (and the corresponding `add_p()` usage). Continuous variables are unaffected.

This is not survey-specific: the same defect existed in the non-survey path; it was only exposed in the issue's reprex because that variable's displayed value (`Child`) is the first factor level.

**If there is an GitHub issue associated with this pull request, please provide link.**

Closes #2399

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch.
- [x] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".