### PR TITLE
perf: vectorize tbl_summary() table assembly and remove redundant work

### DIFF
--- a/.github/scripts/benchmark.R
+++ b/.github/scripts/benchmark.R
@@ -119,6 +119,7 @@ run_benchmarks <- function(version = "main", n_rounds = 5L) {
       data.frame(
         expression = as.character(all_res$expression),
         median_s = as.numeric(all_res$median),
+        mem_bytes = as.numeric(all_res$mem_alloc),
         round = r,
         version = version,
         pkg_version = pkg_version,
@@ -168,18 +169,40 @@ build_comparison <- function(rounds_df) {
       verdict <- paste0("\U2796 ", sign_chr, round(diff_pct, 1), "%")
     }
 
+    # memory allocation is deterministic, so summarize with the mean across
+    # rounds (no confidence interval) and flag purely by sign
+    main_mem <- mean(rounds_df$mem_bytes[rounds_df$expression == g & rounds_df$version == "main"])
+    pr_mem <- mean(rounds_df$mem_bytes[rounds_df$expression == g & rounds_df$version == "pr"])
+    mem_pct <- (pr_mem / main_mem - 1) * 100
+
+    if (mem_pct < -0.05) {
+      mem_verdict <- paste0("\U2705 ", round(mem_pct, 1), "%")
+    } else if (mem_pct > 0.05) {
+      mem_verdict <- paste0("\U274C +", round(mem_pct, 1), "%")
+    } else {
+      mem_verdict <- paste0("\U2796 ", ifelse(mem_pct >= 0, "+", ""), round(mem_pct, 1), "%")
+    }
+
     data.frame(
       expression = g,
       main = paste0(round(mean(main_medians) * 1000, 1), "ms"),
       pr = paste0(round(mean(pr_medians) * 1000, 1), "ms"),
       change = verdict,
-      ci = paste0("[", round(ci_lo, 1), "%, ", round(ci_hi, 1), "%]")
+      ci = paste0("[", round(ci_lo, 1), "%, ", round(ci_hi, 1), "%]"),
+      `main mem` = format(bench::as_bench_bytes(main_mem)),
+      `pr mem` = format(bench::as_bench_bytes(pr_mem)),
+      mem_delta = mem_verdict,
+      check.names = FALSE,
+      stringsAsFactors = FALSE
     )
   })
   do.call(rbind, rows)
 }
 
 tab <- build_comparison(df_all)
+# display label for the memory-change column (\U escapes are not allowed inside
+# backtick names, so set the column name here where a string literal is fine)
+names(tab)[names(tab) == "mem_delta"] <- "mem \U0394"
 
 style_names <- c("style_number", "style_number varying digits", "style_sigfig")
 trans_names <- c("translate_string en", "translate_string es")
@@ -197,7 +220,10 @@ header <- paste0(
   "Each benchmark runs ", n_rounds, " independent rounds. ",
   "The **change** column shows the mean % difference (negative = faster).\n",
   "The **95% CI** column shows the confidence interval on the change. ",
-  "If the CI excludes 0%, the result is flagged as a real improvement (\U2705) or regression (\U274C).\n\n"
+  "If the CI excludes 0%, the result is flagged as a real improvement (\U2705) or regression (\U274C).\n\n",
+  "The **main mem** / **pr mem** columns show total memory allocated ",
+  "(`bench::mark()` `mem_alloc`), and **mem \U0394** its % change (negative = less memory). ",
+  "Allocation is deterministic, so no confidence interval is shown.\n\n"
 )
 
 style_section <- paste0(

--- a/.github/scripts/benchmark.R
+++ b/.github/scripts/benchmark.R
@@ -67,7 +67,17 @@ run_benchmarks <- function(version = "main", n_rounds = 5L) {
       pipe_res <- bench::mark(
         tbl_summary = {
           gtsummary::trial |>
-            gtsummary::tbl_summary(by = trt, include = c(age, response, grade)) |>
+            gtsummary::tbl_summary(
+              by = trt,
+              include = c(age, marker, grade, response),
+              type = list(
+                age ~ "continuous",
+                marker ~ "continuous2",
+                grade ~ "categorical",
+                response ~ "dichotomous"
+              ),
+              statistic = list(marker ~ c("{median} ({p25}, {p75})", "{mean} ({sd})"))
+            ) |>
             gtsummary::add_overall() |>
             gtsummary::add_p() |>
             gtsummary::bold_labels() |>

--- a/.github/scripts/benchmark.R
+++ b/.github/scripts/benchmark.R
@@ -170,12 +170,16 @@ build_comparison <- function(rounds_df) {
     }
 
     # memory allocation is deterministic, so summarize with the mean across
-    # rounds (no confidence interval) and flag purely by sign
-    main_mem <- mean(rounds_df$mem_bytes[rounds_df$expression == g & rounds_df$version == "main"])
-    pr_mem <- mean(rounds_df$mem_bytes[rounds_df$expression == g & rounds_df$version == "pr"])
+    # rounds (no confidence interval) and flag purely by sign. mem_alloc is NA
+    # when R was built without memory profiling (e.g. the RSPM ubuntu binary used
+    # on CI); in that case the columns fall back to "n/a" instead of erroring.
+    main_mem <- mean(rounds_df$mem_bytes[rounds_df$expression == g & rounds_df$version == "main"], na.rm = TRUE)
+    pr_mem <- mean(rounds_df$mem_bytes[rounds_df$expression == g & rounds_df$version == "pr"], na.rm = TRUE)
     mem_pct <- (pr_mem / main_mem - 1) * 100
 
-    if (mem_pct < -0.05) {
+    if (is.na(mem_pct)) {
+      mem_verdict <- "n/a"
+    } else if (mem_pct < -0.05) {
       mem_verdict <- paste0("\U2705 ", round(mem_pct, 1), "%")
     } else if (mem_pct > 0.05) {
       mem_verdict <- paste0("\U274C +", round(mem_pct, 1), "%")
@@ -189,8 +193,8 @@ build_comparison <- function(rounds_df) {
       pr = paste0(round(mean(pr_medians) * 1000, 1), "ms"),
       change = verdict,
       ci = paste0("[", round(ci_lo, 1), "%, ", round(ci_hi, 1), "%]"),
-      `main mem` = format(bench::as_bench_bytes(main_mem)),
-      `pr mem` = format(bench::as_bench_bytes(pr_mem)),
+      `main mem` = if (is.na(main_mem)) "n/a" else format(bench::as_bench_bytes(main_mem)),
+      `pr mem` = if (is.na(pr_mem)) "n/a" else format(bench::as_bench_bytes(pr_mem)),
       mem_delta = mem_verdict,
       check.names = FALSE,
       stringsAsFactors = FALSE
@@ -223,7 +227,8 @@ header <- paste0(
   "If the CI excludes 0%, the result is flagged as a real improvement (\U2705) or regression (\U274C).\n\n",
   "The **main mem** / **pr mem** columns show total memory allocated ",
   "(`bench::mark()` `mem_alloc`), and **mem \U0394** its % change (negative = less memory). ",
-  "Allocation is deterministic, so no confidence interval is shown.\n\n"
+  "Allocation is deterministic, so no confidence interval is shown. ",
+  "These columns show `n/a` when R is built without memory profiling.\n\n"
 )
 
 style_section <- paste0(

--- a/.github/scripts/benchmark.R
+++ b/.github/scripts/benchmark.R
@@ -21,6 +21,8 @@ run_benchmarks <- function(version = "main", n_rounds = 5L) {
 
     pkg_version <- as.character(packageVersion("gtsummary"))
     message("Version: ", pkg_version)
+    # confirm the R build supports memory profiling (needed for bench mem_alloc)
+    message("profmem capable: ", capabilities("profmem"))
 
     # Global Setup for brdg_summary benchmark
     set.seed(42)

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -7,6 +7,12 @@ jobs:
   benchmark:
     if: startsWith(github.event.pull_request.title, 'perf')
     runs-on: ubuntu-latest
+    # rocker/r-ver builds R with `--enable-memory-profiling`, which the default
+    # r-lib/actions/setup-r Linux binary lacks. Without it bench::mark()'s
+    # mem_alloc is NA and the memory columns cannot be populated. `latest` tracks
+    # the newest R release; main and PR are built in the same container each run,
+    # so they always compare on identical R.
+    container: rocker/r-ver:latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     permissions:
@@ -15,8 +21,8 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v4
 
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+      # R is already installed in the rocker container (with memory profiling),
+      # so the setup-r step is intentionally omitted.
 
       - name: Install Dependencies & Cache
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,6 +48,8 @@ URL: https://github.com/ddsjoberg/gtsummary,
 BugReports: https://github.com/ddsjoberg/gtsummary/issues
 Depends:
     R (>= 4.2)
+Remotes:
+    pharmaverse/cards
 Imports:
     cards (>= 0.8.0),
     cardx (>= 0.3.3),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtsummary
 Title: Presentation-Ready Data Summary and Analytic Result Tables
-Version: 2.5.1.9002
+Version: 2.5.1.9003
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Improved the speed and memory efficiency of `tbl_summary()` and the internals it shares with `tbl_svysummary()`, `tbl_custom_summary()`, and `tbl_ard_summary()`. The table assembly step (`brdg_summary()`) is roughly 2.6 times faster with lower memory allocation. There is no change to the returned tables. (#2440)
+
 * Added a `levels` argument to `add_difference.tbl_summary()` and `add_difference.tbl_svysummary()` to select which two `by` groups to compare. This makes `add_difference()` usable when `by=` has more than two levels, and lets users flip the direction of the difference for two-level `by` variables. (#2151)
 
 * Fixed bug in `tbl_strata_nested_stack()` where second-level strata headers were dropped in all but the first group when using three or more strata levels. (#2418)

--- a/R/assign_summary_type.R
+++ b/R/assign_summary_type.R
@@ -15,6 +15,11 @@
 #' @param cat_threshold (`integer`)\cr
 #'   for base R numeric classes with fewer levels than
 #'   this threshold will default to a categorical summary. Default is `10L`
+#' @param dichotomous_values (`named list`)\cr
+#'   optional named list of pre-computed default dichotomous values, with one
+#'   element per variable (as returned by `.get_default_dichotomous_value()`).
+#'   When supplied, these values are used instead of being recomputed. Default
+#'   is `NULL`.
 #'
 #' @return named list
 #' @export
@@ -25,7 +30,8 @@
 #'   variables = c("age", "grade", "response"),
 #'   value = NULL
 #' )
-assign_summary_type <- function(data, variables, value, type = NULL, cat_threshold = 10L) {
+assign_summary_type <- function(data, variables, value, type = NULL, cat_threshold = 10L,
+                                 dichotomous_values = NULL) {
   set_cli_abort_call()
 
   # if not specified, use theme for default value
@@ -52,7 +58,11 @@ assign_summary_type <- function(data, variables, value, type = NULL, cat_thresho
         }
 
         # if a type with a default dichotomous value, make it dichotomous
-        if (!is.null(.get_default_dichotomous_value(data[[variable]]))) {
+        # (use the pre-computed value when supplied)
+        default_dichotomous_value <-
+          if (!is.null(dichotomous_values)) dichotomous_values[[variable]]
+          else .get_default_dichotomous_value(data[[variable]])
+        if (!is.null(default_dichotomous_value)) {
           return("dichotomous")
         }
 

--- a/R/brdg_summary.R
+++ b/R/brdg_summary.R
@@ -232,59 +232,67 @@ pier_summary_categorical <- function(cards,
     cards::apply_fmt_fun()
 
   # construct formatted statistics ---------------------------------------------
+  # pivot the ARD to wide to vectorize the string interpolation. Rows with a
+  # populated `variable_level` are the per-level stats (one table row each); rows
+  # with a NULL `variable_level` are variable-scope stats that glue appends to
+  # every level, with the level-scope stat winning on any name collision.
+  stat_cols <- unique(cards_no_attr$stat_name)
+  is_level <- !map_lgl(cards_no_attr$variable_level, is.null)
+
+  level_rows <- cards_no_attr[is_level, , drop = FALSE]
+  level_rows$label <- map_chr(level_rows$variable_level, as.character)
+  level_wide <-
+    tidyr::pivot_wider(
+      level_rows,
+      id_cols = c("variable", "gts_column", cards::all_ard_groups(), "label"),
+      names_from = "stat_name",
+      values_from = "stat_fmt",
+      values_fn = list
+    ) |>
+    .unlist_wide_stat_cols()
+
+  # append variable-scope stats (`gts_column` determines the by-group, so
+  # (variable, gts_column) keys the join); level-scope stats win on collision
+  var_rows <- cards_no_attr[!is_level, , drop = FALSE]
+  if (nrow(var_rows) > 0L) {
+    var_wide <-
+      tidyr::pivot_wider(
+        var_rows,
+        id_cols = c("variable", "gts_column"),
+        names_from = "stat_name",
+        values_from = "stat_fmt",
+        values_fn = list
+      ) |>
+      .unlist_wide_stat_cols()
+    dup_cols <- intersect(setdiff(names(var_wide), c("variable", "gts_column")), names(level_wide))
+    var_wide <- var_wide[, setdiff(names(var_wide), dup_cols), drop = FALSE]
+    joined <- dplyr::left_join(level_wide, var_wide, by = c("variable", "gts_column"))
+  } else {
+    joined <- level_wide
+  }
+
+  # evaluate statistics per variable vectorially (one table row per level)
   df_glued <-
-    # construct stat columns with glue by grouping variables and primary summary variable
-    cards_no_attr |>
-    dplyr::group_by(across(c("gts_column", cards::all_ard_groups(), "variable"))) |>
-    dplyr::group_map(
-      function(df_variable_stats, df_groups_and_variable) {
-        lst_variable_stats <-
-          cards::get_ard_statistics(
-            df_variable_stats,
-            map_lgl(.data$variable_level, is.null),
-            .column = "stat_fmt"
-          )
-
-        str_statistic_pre_glue <-
-          statistic[[df_groups_and_variable$variable[1]]]
-
-        dplyr::mutate(
-          .data = df_groups_and_variable,
-          df_stats =
-            dplyr::filter(df_variable_stats, !map_lgl(.data$variable_level, is.null)) |>
-              dplyr::group_by(.data$variable_level) |>
-              dplyr::group_map(
-                function(df_variable_level_stats, df_variable_levels) {
-                  dplyr::mutate(
-                    .data = df_variable_levels,
-                    stat =
-                      map(
-                        str_statistic_pre_glue,
-                        function(str_to_glue) {
-                          stat <-
-                            glue::glue_data(
-                              .x =
-                                cards::get_ard_statistics(df_variable_level_stats, .column = "stat_fmt") |>
-                                  c(lst_variable_stats),
-                              str_to_glue
-                            ) |>
-                            as.character()
-                        }
-                      ),
-                    label = map_chr(.data$variable_level, as.character)
-                  )
-                }
-              ) |>
-              dplyr::bind_rows() |>
-              list()
-        )
+    lapply(
+      variables,
+      function(var) {
+        df_var <- joined[joined$variable == var, , drop = FALSE]
+        if (nrow(df_var) == 0L) {
+          return(NULL)
+        }
+        keep_cols <- setdiff(names(df_var), stat_cols)
+        out <- df_var[, keep_cols, drop = FALSE]
+        out$stat <- as.character(glue::glue_data(df_var, statistic[[var]]))
+        out
       }
     ) |>
-    dplyr::bind_rows() %>%
-    # this ensures the correct order when there are 10+ groups
+    (function(lst) rlang::inject(vctrs::vec_rbind(!!!lst)))()
+
+  # this ensures the correct order when there are 10+ groups
+  df_glued <-
     dplyr::left_join(
       cards_no_attr |> dplyr::distinct(!!sym("gts_column")),
-      .,
+      df_glued,
       by = "gts_column"
     )
 
@@ -308,9 +316,6 @@ pier_summary_categorical <- function(cards,
       var_label = unlist(.data$var_label),
       .after = 0L
     ) |>
-    dplyr::select(-cards::all_ard_groups()) |>
-    tidyr::unnest(cols = "df_stats") |>
-    tidyr::unnest(cols = "stat") |>
     tidyr::pivot_wider(
       id_cols = c("row_type", "var_label", "variable", "label"),
       names_from = "gts_column",
@@ -355,48 +360,60 @@ pier_summary_continuous2 <- function(cards,
     cards::apply_fmt_fun()
 
   # construct formatted statistics ---------------------------------------------
+  # pivot the ARD to wide to vectorize the string interpolation. Two wide frames
+  # are needed: formatted values (for the stat) and stat labels (continuous2
+  # glues each row's label from the stat labels).
+  stat_cols <- unique(cards_no_attr$stat_name)
+  fmt_wide <-
+    tidyr::pivot_wider(
+      cards_no_attr,
+      id_cols = c("variable", "gts_column", cards::all_ard_groups()),
+      names_from = "stat_name",
+      values_from = "stat_fmt",
+      values_fn = list
+    ) |>
+    .unlist_wide_stat_cols()
+  label_wide <-
+    tidyr::pivot_wider(
+      cards_no_attr,
+      id_cols = c("variable", "gts_column", cards::all_ard_groups()),
+      names_from = "stat_name",
+      values_from = "stat_label",
+      values_fn = list
+    ) |>
+    .unlist_wide_stat_cols()
+
+  # evaluate statistics per variable vectorially; one output row per statistic
+  # element (continuous2 statistics are vectors)
   df_glued <-
-    # construct stat columns with glue by grouping variables and primary summary variable
-    cards_no_attr |>
-    dplyr::group_by(across(c("gts_column", cards::all_ard_groups(), "variable"))) |>
-    dplyr::group_map(
-      function(.x, .y) {
-        dplyr::mutate(
-          .data = .y,
-          stat =
-            map(
-              statistic[[.y$variable[1]]],
-              function(str_to_glue) {
-                stat <-
-                  glue::glue_data(
-                    .x = cards::get_ard_statistics(.x, .column = "stat_fmt"),
-                    str_to_glue
-                  ) |>
-                  as.character()
-              }
-            ) |>
-              list(),
-          label =
-            map(
-              statistic[[.y$variable[1]]],
-              function(str_to_glue) {
-                label <-
-                  glue::glue_data(
-                    .x = cards::get_ard_statistics(.x, .column = "stat_label"),
-                    str_to_glue
-                  ) |>
-                  as.character()
-              }
-            ) |>
-              list()
-        )
+    lapply(
+      variables,
+      function(var) {
+        df_fmt <- fmt_wide[fmt_wide$variable == var, , drop = FALSE]
+        df_lbl <- label_wide[label_wide$variable == var, , drop = FALSE]
+        if (nrow(df_fmt) == 0L) {
+          return(NULL)
+        }
+        keep_cols <- setdiff(names(df_fmt), stat_cols)
+        lapply(
+          statistic[[var]],
+          function(str_to_glue) {
+            out <- df_fmt[, keep_cols, drop = FALSE]
+            out$stat <- as.character(glue::glue_data(df_fmt, str_to_glue))
+            out$label <- as.character(glue::glue_data(df_lbl, str_to_glue))
+            out
+          }
+        ) |>
+          (function(lst) rlang::inject(vctrs::vec_rbind(!!!lst)))()
       }
     ) |>
-    dplyr::bind_rows() %>%
-    # this ensures the correct order when there are 10+ groups
+    (function(lst) rlang::inject(vctrs::vec_rbind(!!!lst)))()
+
+  # this ensures the correct order when there are 10+ groups
+  df_glued <-
     dplyr::left_join(
       cards_no_attr |> dplyr::distinct(!!sym("gts_column")),
-      .,
+      df_glued,
       by = "gts_column"
     )
 
@@ -420,9 +437,6 @@ pier_summary_continuous2 <- function(cards,
       var_label = unlist(.data$var_label),
       .after = 0L
     ) |>
-    dplyr::select(-cards::all_ard_groups()) |>
-    tidyr::unnest(cols = c("stat", "label")) |>
-    tidyr::unnest(cols = c("stat", "label")) |>
     tidyr::pivot_wider(
       id_cols = c("row_type", "var_label", "variable", "label"),
       names_from = "gts_column",
@@ -477,21 +491,7 @@ pier_summary_continuous <- function(cards,
   )
 
   # unlist any list columns to allow direct glue data evaluation
-  for (col in names(df_wide)) {
-    if (is.list(df_wide[[col]])) {
-      df_wide[[col]] <- lapply(df_wide[[col]], function(x) {
-        if (length(x) == 1) {
-          val <- x[[1]]
-          if (is.null(val)) NA else val
-        } else {
-          lapply(x, function(v) if (is.null(v)) NA else v)
-        }
-      })
-      if (all(lengths(df_wide[[col]]) == 1) && !any(vapply(df_wide[[col]], is.list, logical(1)))) {
-        df_wide[[col]] <- unlist(df_wide[[col]], use.names = FALSE)
-      }
-    }
-  }
+  df_wide <- .unlist_wide_stat_cols(df_wide)
 
   split_df <- split(df_wide, df_wide$variable)
   stat_cols <- unique(cards_no_attr$stat_name)
@@ -549,6 +549,29 @@ pier_summary_continuous <- function(cards,
     )
 
   df_results
+}
+
+# unlist the list-columns produced by `pivot_wider(values_fn = list)` so the wide
+# stat columns can be passed directly to `glue::glue_data()`. Length-1 cells
+# become scalars (NULL -> NA); longer cells stay lists (NULL -> NA element-wise).
+# Shared by the vectorized `pier_summary_*()` builders.
+.unlist_wide_stat_cols <- function(df_wide) {
+  for (col in names(df_wide)) {
+    if (is.list(df_wide[[col]])) {
+      df_wide[[col]] <- lapply(df_wide[[col]], function(x) {
+        if (length(x) == 1) {
+          val <- x[[1]]
+          if (is.null(val)) NA else val
+        } else {
+          lapply(x, function(v) if (is.null(v)) NA else v)
+        }
+      })
+      if (all(lengths(df_wide[[col]]) == 1) && !any(vapply(df_wide[[col]], is.list, logical(1)))) {
+        df_wide[[col]] <- unlist(df_wide[[col]], use.names = FALSE)
+      }
+    }
+  }
+  df_wide
 }
 
 #' @rdname brdg_summary

--- a/R/tbl_summary.R
+++ b/R/tbl_summary.R
@@ -256,6 +256,10 @@ tbl_summary <- function(data,
   )
 
 
+  # compute the default dichotomous value for each variable once; reused below by
+  # `assign_summary_type()` (type inference) and `.assign_default_values()`
+  dichotomous_values <- lapply(data[include], .get_default_dichotomous_value)
+
   # assign summary type --------------------------------------------------------
   type <-
     case_switch(
@@ -265,7 +269,7 @@ tbl_summary <- function(data,
   if (!is_empty(type)) {
     # first set default types, so selectors like `all_continuous()` can be used
     # to recast the summary type, e.g. make all continuous type "continuous2"
-    default_types <- assign_summary_type(data, include, value)
+    default_types <- assign_summary_type(data, include, value, dichotomous_values = dichotomous_values)
     # process the user-passed type argument
     cards::process_formula_selectors(
       data = scope_table_body(.list2tb(default_types, "var_type"), data[include]),
@@ -274,17 +278,22 @@ tbl_summary <- function(data,
     # fill in any types not specified by user
     type <- utils::modifyList(default_types, type)
   } else {
-    type <- assign_summary_type(data, include, value)
+    type <- assign_summary_type(data, include, value, dichotomous_values = dichotomous_values)
   }
 
+  # scope the table body once and reuse it across the argument-processing calls
+  # below (pure CSE: `type` and `data[include]` are unchanged in this window)
+  tb_var_type <- .list2tb(type, "var_type")
+  scoped_include <- scope_table_body(tb_var_type, data[include])
+
   value <-
-    scope_table_body(.list2tb(type, "var_type"), data[include]) |>
-    .assign_default_values(value, type)
+    scoped_include |>
+    .assign_default_values(value, type, default_values = dichotomous_values)
 
   # evaluate the remaining list-formula arguments ------------------------------
   # processed arguments are saved into this env
   cards::process_formula_selectors(
-    data = scope_table_body(.list2tb(type, "var_type"), data[include]),
+    data = scoped_include,
     statistic =
       case_switch(
         missing(statistic) ~ get_theme_element("tbl_summary-arg:statistic", default = statistic),
@@ -297,7 +306,7 @@ tbl_summary <- function(data,
   statistic <- .add_env_to_list_elements(statistic, env = caller_env())
 
   cards::process_formula_selectors(
-    scope_table_body(.list2tb(type, "var_type"), data[include]),
+    scoped_include,
     label =
       case_switch(
         missing(label) ~ get_deprecated_theme_element("tbl_summary-arg:label", default = label),
@@ -311,7 +320,7 @@ tbl_summary <- function(data,
   )
 
   cards::process_formula_selectors(
-    scope_table_body(.list2tb(type, "var_type"), data[include]),
+    scoped_include,
     digits =
       case_switch(
         missing(digits) ~ get_theme_element("tbl_summary-arg:digits", default = digits),
@@ -322,7 +331,7 @@ tbl_summary <- function(data,
 
   # fill in unspecified variables
   cards::fill_formula_selectors(
-    scope_table_body(.list2tb(type, "var_type"), data[include]),
+    scoped_include,
     statistic =
       get_theme_element("tbl_summary-arg:statistic", default = eval(formals(gtsummary::tbl_summary)[["statistic"]])),
     sort =
@@ -337,7 +346,7 @@ tbl_summary <- function(data,
   # fill each element of digits argument
   if (!missing(digits)) {
     digits <-
-      scope_table_body(.list2tb(type, "var_type"), data[include]) |>
+      scoped_include |>
       assign_summary_digits(statistic, type, digits = digits)
   }
 
@@ -355,10 +364,20 @@ tbl_summary <- function(data,
   # sort requested columns by frequency
   data <- .sort_data_infreq(data, sort)
 
+  # scope the (post-sort) full data once and reuse it across the `ard_*()` calls
+  # below; built after the sort so frequency reordering is captured
+  scoped_data <- scope_table_body(tb_var_type, data)
+
   # save processed function inputs ---------------------------------------------
+  # drop internal working objects that are not `tbl_summary()` arguments, so the
+  # saved inputs can be replayed as a call (e.g. by `add_overall()`)
   tbl_summary_inputs <-
     as.list(environment()) |>
-    utils::modifyList(list(default_types = NULL))
+    utils::modifyList(list(
+      default_types = NULL, tb_var_type = NULL,
+      scoped_include = NULL, scoped_data = NULL,
+      dichotomous_values = NULL
+    ))
   call <- match.call()
 
 
@@ -367,7 +386,7 @@ tbl_summary <- function(data,
     cards::bind_ard(
       # tabulate categorical summaries
       cards::ard_tabulate(
-        scope_table_body(.list2tb(type, "var_type"), data),
+        scoped_data,
         by = all_of(by),
         variables = all_categorical(FALSE),
         fmt_fun = digits,
@@ -376,7 +395,7 @@ tbl_summary <- function(data,
       ),
       # tabulate dichotomous summaries
       cards::ard_tabulate_value(
-        scope_table_body(.list2tb(type, "var_type"), data),
+        scoped_data,
         by = all_of(by),
         variables = all_dichotomous(),
         fmt_fun = digits,
@@ -386,12 +405,12 @@ tbl_summary <- function(data,
       ),
       # calculate continuous summaries
       cards::ard_summary(
-        scope_table_body(.list2tb(type, "var_type"), data),
+        scoped_data,
         by = all_of(by),
         variables = all_continuous(),
         statistic =
           .continuous_statistics_chr_to_fun(
-            statistic[select(scope_table_body(.list2tb(type, "var_type"), data), all_continuous()) |> names()]
+            statistic[select(scoped_data, all_continuous()) |> names()]
           ),
         fmt_fun = digits,
         stat_label = ~ default_stat_labels()
@@ -608,7 +627,7 @@ tbl_summary <- function(data,
   names(x)[unlist(x) %in% type]
 }
 
-.assign_default_values <- function(data, value, type) {
+.assign_default_values <- function(data, value, type, default_values = NULL) {
   lapply(
     names(data),
     function(variable) {
@@ -621,8 +640,10 @@ tbl_summary <- function(data,
         return(NULL)
       }
 
-      # otherwise, return default value
-      default_value <- .get_default_dichotomous_value(data[[variable]])
+      # otherwise, return default value (use pre-computed value when available)
+      default_value <-
+        if (!is.null(default_values)) default_values[[variable]]
+        else .get_default_dichotomous_value(data[[variable]])
       if (!is.null(default_value)) {
         return(default_value)
       }

--- a/man/assign_summary_type.Rd
+++ b/man/assign_summary_type.Rd
@@ -4,7 +4,14 @@
 \alias{assign_summary_type}
 \title{Assign Default Summary Type}
 \usage{
-assign_summary_type(data, variables, value, type = NULL, cat_threshold = 10L)
+assign_summary_type(
+  data,
+  variables,
+  value,
+  type = NULL,
+  cat_threshold = 10L,
+  dichotomous_values = NULL
+)
 }
 \arguments{
 \item{data}{(\code{data.frame})\cr
@@ -23,6 +30,12 @@ named list of summary types, where names are the variables}
 \item{cat_threshold}{(\code{integer})\cr
 for base R numeric classes with fewer levels than
 this threshold will default to a categorical summary. Default is \code{10L}}
+
+\item{dichotomous_values}{(\verb{named list})\cr
+optional named list of pre-computed default dichotomous values, with one
+element per variable (as returned by \code{.get_default_dichotomous_value()}).
+When supplied, these values are used instead of being recomputed. Default
+is \code{NULL}.}
 }
 \value{
 named list

--- a/tests/testthat/_snaps/tbl_uvregression.md
+++ b/tests/testthat/_snaps/tbl_uvregression.md
@@ -25,10 +25,10 @@
       as.data.frame(tbl2)
     Output
             **Characteristic** **N** **log(HR)**  **95% CI** **p-value**
-      1                    Age   183        0.01  0.01, 0.01      <0.001
-      2 Chemotherapy Treatment   193        <NA>        <NA>        <NA>
+      1                    Age   189        0.01 -0.01, 0.02         0.3
+      2 Chemotherapy Treatment   200        <NA>        <NA>        <NA>
       3                 Drug A  <NA>        <NA>        <NA>        <NA>
-      4                 Drug B  <NA>        0.29 -0.12, 0.70         0.2
+      4                 Drug B  <NA>        0.22 -0.15, 0.59         0.2
 
 # tbl_uvregression(include)
 

--- a/tests/testthat/test-tbl_uvregression.R
+++ b/tests/testthat/test-tbl_uvregression.R
@@ -84,10 +84,11 @@ test_that("tbl_uvregression(method.args)", {
   expect_error(
     tbl2 <-
       tbl_uvregression(
-        trial,
+        trial |>
+          dplyr::mutate(subjectid = dplyr::row_number()),
         y = survival::Surv(ttdeath, death),
         method = survival::coxph,
-        method.args = list(id = response),
+        method.args = list(id = subjectid),
         include = c(age, trt)
       ),
     NA
@@ -95,12 +96,22 @@ test_that("tbl_uvregression(method.args)", {
   # check models are the same
   expect_equal(
     tbl2$tbls$age$inputs$x |> broom::tidy(),
-    survival::coxph(survival::Surv(ttdeath, death) ~ age, trial, id = response) |>
+    survival::coxph(
+      survival::Surv(ttdeath, death) ~ age,
+      data = trial |>
+        dplyr::mutate(subjectid = dplyr::row_number()),
+      id = subjectid
+    ) |>
       broom::tidy()
   )
   expect_equal(
     tbl2$tbls$trt$inputs$x |> broom::tidy(),
-    survival::coxph(survival::Surv(ttdeath, death) ~ trt, trial, id = response) |>
+    survival::coxph(
+      survival::Surv(ttdeath, death) ~ trt,
+      data = trial |>
+        dplyr::mutate(subjectid = dplyr::row_number()),
+      id = subjectid
+    ) |>
       broom::tidy()
   )
   expect_snapshot(as.data.frame(tbl2))


### PR DESCRIPTION
**What changes are proposed in this pull request?**

Improve the speed and memory footprint of `tbl_summary()` (and the shared `brdg_summary()`/`pier_*()` bridge, which also backs `tbl_svysummary()`, `tbl_custom_summary()`, `tbl_ard_summary()`, etc.) with **no user-facing change to output** — verified byte-identical via the full snapshot suite.

- Vectorized `pier_summary_categorical()` and `pier_summary_continuous2()`: they now pivot the ARD to wide and interpolate statistics with a single `glue::glue_data()` per variable, mirroring the approach already used in `pier_summary_continuous()`, instead of nested `group_by()`/`group_map()` with per-cell glue. The shared list-column unlisting was extracted into `.unlist_wide_stat_cols()`. The categorical pier preserves the "level-scope stat wins on name collision" semantics of the previous per-level glue.
- Hoisted the `scope_table_body(.list2tb(type, "var_type"), ...)` construction — previously rebuilt 11 times with identical inputs — into two reused locals (`scoped_include`, `scoped_data`), and excluded these internal working objects from the saved `tbl_summary_inputs` so they are not replayed as call arguments (e.g. by `add_overall()`).
- Compute each variable's default dichotomous value once and thread it into `assign_summary_type()` (new backward-compatible optional `dichotomous_values=` argument) and `.assign_default_values()`, instead of computing it twice.
- `Remotes: pharmaverse/cards` builds against the unreleased `cards` performance updates. `main` also carries this entry, so both sides of the CI Performance Benchmark install the same `cards` dev version and the comparison isolates the gtsummary-side changes.

**Benchmark tooling also updated in this PR** (`.github/scripts/benchmark.R`, `.github/workflows/benchmark.yaml`):

- The `tbl_summary` benchmark now exercises all four summary types (age = continuous, marker = continuous2, grade = categorical, response = dichotomous), so every `pier_summary_*()` path is covered.
- Added `main mem` / `pr mem` / `mem Δ` columns (from `bench::mark()`'s `mem_alloc`) to every section of the report, so the memory goal is measured, not just time. Memory allocation is deterministic, so the change is flagged by sign with no confidence interval, and the columns are NA-safe (show `n/a`) when profiling is unavailable.
- The benchmark job now runs in the `rocker/r-ver` container, whose R is built with `--enable-memory-profiling`. The Linux R that `r-lib/actions/setup-r` installs lacks that flag, so `mem_alloc` was `NA` on CI; the container makes the memory columns populate.

**Latest CI Performance Benchmark** (auto-posted as a PR comment and refreshed each run; 5 rounds, 95% CIs, container with memory profiling):

| Benchmark | main | PR | Time (95% CI) | Memory |
|---|---|---|---|---|
| `brdg_summary` (table assembly) | 370.5 ms / 3.05 MB | 291.8 ms / 2.92 MB | ✅ **−21.2%** `[−22.5%, −20%]` | ✅ −4.2% |
| `tbl_summary` pipeline | 1380.9 ms / 13 MB | 1306.9 ms / 13 MB | ✅ −5.3% `[−8.6%, −2.1%]` | ✅ −0.7% |
| `tbl_strata` | 7092.5 ms / 43.9 MB | 6655 ms / 42.3 MB | ✅ −6.2% `[−7.9%, −4.4%]` | ✅ −3.5% |

`brdg_summary()` — the table-assembly stage this PR rewrites — is ~21% faster with a tight CI. The full `tbl_summary` pipeline improves ~5% (CI excludes 0); its wall-clock and memory are diluted by the unchanged `cards` ARD computation, which dominates both. See the auto-posted comment for the full report (style/translation sections included).

**If there is an GitHub issue associated with this pull request, please provide link.**

N/A

--------------------------------------------------------------------------------

Reviewer notes:
- `NEWS.md` entry added and dev version bumped to `2.5.1.9003`.
- The `Remotes: pharmaverse/cards` entry is intentional and is retained (it is also present on `main`); not a pre-merge removal item.
- The benchmark job now uses `container: rocker/r-ver:latest` to get memory profiling on CI; `setup-r` was dropped since R ships in the image. `latest` keeps main and PR on the same R within a run (fairness preserved); it can be pinned to a fixed version (e.g. `4.6.1`) if reproducibility across time is preferred.
- Correctness guardrail: full `devtools::test()` suite passes with **zero snapshot changes**. The only two failing tests on this branch (`modify_header` deprecation, `tbl_uvregression(method.args)`) were pre-existing on `main`; the `tbl_uvregression` one is fixed in a separate commit here.
