### PR TITLE
perf: vectorize tbl_hierarchical() table assembly and helpers

### DIFF
--- a/.github/scripts/benchmark.R
+++ b/.github/scripts/benchmark.R
@@ -40,6 +40,32 @@ run_benchmarks <- function(version = "main", n_rounds = 5L) {
     bench_statistic <- bench_tbl$inputs$statistic
     bench_by <- "trt"
 
+    # Setup for brdg_hierarchical / sort / filter benchmarks: build the tables
+    # once so the assembly (brdg) and post-processing (sort/filter) steps can be
+    # benchmarked in isolation from the ARD computation.
+    suppressMessages({
+      bench_h_tbl <- gtsummary::tbl_hierarchical(
+        data = cards::ADAE,
+        variables = c(AESOC, AETERM, AESEV),
+        by = TRTA,
+        id = USUBJID,
+        denominator = cards::ADSL,
+        overall_row = TRUE,
+        label = list(..ard_hierarchical_overall.. = "Any Adverse Event")
+      )
+      # `include = AESEV` leaves AESOC/AETERM out, exercising `.append_not_incl()`
+      bench_h_incl_tbl <- gtsummary::tbl_hierarchical(
+        data = cards::ADAE,
+        variables = c(AESOC, AETERM, AESEV),
+        by = TRTA,
+        id = USUBJID,
+        denominator = cards::ADSL,
+        include = AESEV
+      )
+    })
+    bench_h_cards <- bench_h_tbl$cards[[1]]
+    bench_h_args <- bench_h_tbl$inputs
+
     # dummy data for style and translation
     x <- rnorm(10000)
     d <- rep_len(c(0L, 1L, 2L), 10000)
@@ -117,7 +143,30 @@ run_benchmarks <- function(version = "main", n_rounds = 5L) {
         iterations = 20, check = FALSE
       )
 
-      all_res <- rbind(style_res, trans_res, pipe_res, brdg_res)
+      # brdg_hierarchical (table assembly in isolation)
+      brdg_h_res <- bench::mark(
+        brdg_hierarchical = gtsummary::brdg_hierarchical(
+          cards = bench_h_cards,
+          variables = bench_h_args$variables,
+          by = bench_h_args$by,
+          include = bench_h_args$include,
+          statistic = bench_h_args$statistic,
+          overall_row = bench_h_args$overall_row,
+          count = FALSE,
+          is_ordered = FALSE,
+          label = bench_h_args$label
+        ),
+        iterations = 20, check = FALSE
+      )
+
+      # sort / filter hierarchical (post-processing, include-subset path)
+      sort_filter_h_res <- bench::mark(
+        sort_hierarchical = gtsummary::sort_hierarchical(bench_h_incl_tbl, sort = "descending"),
+        filter_hierarchical = gtsummary::filter_hierarchical(bench_h_incl_tbl, sum(n) > 5),
+        iterations = 10, check = FALSE
+      )
+
+      all_res <- rbind(style_res, trans_res, pipe_res, brdg_res, brdg_h_res, sort_filter_h_res)
       data.frame(
         expression = as.character(all_res$expression),
         median_s = as.numeric(all_res$median),
@@ -214,11 +263,13 @@ style_names <- c("style_number", "style_number varying digits", "style_sigfig")
 trans_names <- c("translate_string en", "translate_string es")
 pipe_names <- c("tbl_summary", "tbl_hierarchical", "tbl_strata")
 brdg_names <- c("brdg_summary")
+hier_names <- c("brdg_hierarchical", "sort_hierarchical", "filter_hierarchical")
 
 style_tab <- tab[tab$expression %in% style_names, ]
 trans_tab <- tab[tab$expression %in% trans_names, ]
 pipe_tab <- tab[tab$expression %in% pipe_names, ]
 brdg_tab <- tab[tab$expression %in% brdg_names, ]
+hier_tab <- tab[tab$expression %in% hier_names, ]
 
 header <- paste0(
   "## Performance Benchmark\n\n",
@@ -251,9 +302,14 @@ pipe_section <- paste0(
 brdg_section <- paste0(
   "### `brdg_summary` (50 variables)\n\n",
   paste(knitr::kable(brdg_tab, format = "markdown", row.names = FALSE), collapse = "\n"),
+  "\n\n"
+)
+hier_section <- paste0(
+  "### Hierarchical internals (`cards::ADAE`)\n\n",
+  paste(knitr::kable(hier_tab, format = "markdown", row.names = FALSE), collapse = "\n"),
   "\n"
 )
 
-report <- paste0(header, style_section, trans_section, pipe_section, brdg_section)
+report <- paste0(header, style_section, trans_section, pipe_section, brdg_section, hier_section)
 writeLines(report, "bench_report.md")
 cat(report)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtsummary (development version)
 
+* Improved the speed and memory efficiency of `tbl_hierarchical()`, `tbl_hierarchical_count()`, `tbl_ard_hierarchical()`, and the `sort_hierarchical()`/`filter_hierarchical()` helpers. The table assembly step (`brdg_hierarchical()`) now vectorizes the statistic formatting instead of looping over every cell, making the pipeline roughly 8 times faster with lower memory allocation. There is no change to the returned tables. (#2442)
+
 * Improved the speed and memory efficiency of `tbl_summary()` and the internals it shares with `tbl_svysummary()`, `tbl_custom_summary()`, and `tbl_ard_summary()`. The table assembly step (`brdg_summary()`) is roughly 2.6 times faster with lower memory allocation. There is no change to the returned tables. (#2440)
 
 * Added a `levels` argument to `add_difference.tbl_summary()` and `add_difference.tbl_svysummary()` to select which two `by` groups to compare. This makes `add_difference()` usable when `by=` has more than two levels, and lets users flip the direction of the difference for two-level `by` variables. (#2151)

--- a/R/brdg_hierarchical.R
+++ b/R/brdg_hierarchical.R
@@ -89,40 +89,43 @@ brdg_hierarchical <- function(cards,
   )
 
   # add label rows for variables not in 'include'
-  for (i in which(!variables %in% include)) {
-    prior_gp <- paste0("group", 1:i + n_by)
-    prior_gp_lvl <- paste0(prior_gp, "_level")
-    groupX <- dplyr::last(prior_gp)
-    groupX_lvl <- dplyr::last(prior_gp_lvl)
-
-    # create dummy rows
-    tbl_rows <- table_body |>
-      dplyr::filter(!dplyr::if_any(cards::all_ard_groups("names"), ~ .x == " ")) |>
-      select(all_of(c("row_type", prior_gp, prior_gp_lvl))) |>
-      unique() |>
-      mutate(
-        var_label = .data[[groupX_lvl]],
-        variable = .data[[groupX]],
-        label = .data[[groupX_lvl]]
-      )
-
+  excl <- which(!variables %in% include)
+  if (length(excl) > 0L) {
     all_gps <- table_body |> select(cards::all_ard_groups("names")) |> names()
     ord <- utils::head(c(rbind(paste0(all_gps, "_level"), all_gps)), -1)
 
-    tbl_rows <- dplyr::bind_rows(
-      table_body,
-      tbl_rows |> mutate(row_type = "label")
-    ) |>
-      mutate(across(cards::all_ard_groups(), .fns = ~tidyr::replace_na(., " "))) |>
-      dplyr::group_by(across(cards::all_ard_groups("levels"))) |>
-      dplyr::arrange(across(all_of(c(ord, "var_label")))) |>
-      dplyr::ungroup()
+    # complete-path rows are the invariant source for every depth's label rows:
+    # rows carrying a value in every group-name column. (Label rows added below
+    # would carry " "/NA in deeper group columns, so they are never a source --
+    # which is why a single pass reproduces the former per-variable loop.)
+    complete_rows <- table_body |>
+      dplyr::filter(!dplyr::if_any(all_of(all_gps), ~ is.na(.x) | .x == " "))
 
-    table_body <- tbl_rows
+    lst_dummy <- lapply(excl, function(i) {
+      prior_gp <- paste0("group", 1:i + n_by)
+      prior_gp_lvl <- paste0(prior_gp, "_level")
+      groupX <- dplyr::last(prior_gp)
+      groupX_lvl <- dplyr::last(prior_gp_lvl)
+
+      complete_rows |>
+        select(all_of(c("row_type", prior_gp, prior_gp_lvl))) |>
+        unique() |>
+        mutate(
+          var_label = .data[[groupX_lvl]],
+          variable = .data[[groupX]],
+          label = .data[[groupX_lvl]],
+          row_type = "label"
+        )
+    })
+
+    table_body <-
+      rlang::inject(dplyr::bind_rows(table_body, !!!lst_dummy)) |>
+      mutate(across(cards::all_ard_groups(), .fns = ~tidyr::replace_na(., " "))) |>
+      dplyr::arrange(across(all_of(c(ord, "var_label"))))
   }
 
   if (overall_row) {
-    table_body <- dplyr::bind_rows(over_row, table_body)
+    table_body <- vctrs::vec_rbind(over_row, table_body)
   }
 
   # add hierarchy levels to table_body for sorting & filtering -----------------
@@ -258,68 +261,108 @@ pier_summary_hierarchical <- function(cards,
   # subsetting cards object on categorical summaries ----------------------------
   cards_no_attr <-
     cards |>
-    dplyr::filter(.data$variable %in% .env$variables, !.data$context %in% "attributes") |>
-    cards::apply_fmt_fun() |>
-    mutate(sort_idx = dplyr::row_number())
+    dplyr::filter(.data$variable %in% .env$variables, !.data$context %in% "attributes")
+
+  # both internal callers (internal_tbl_hierarchical() and tbl_ard_hierarchical())
+  # already apply formatting functions before reaching this function. Only re-apply
+  # when a cell actually needs it, which exactly reproduces `apply_fmt_fun(replace = FALSE)`.
+  if (!"stat_fmt" %in% names(cards_no_attr) ||
+    any(vapply(cards_no_attr$stat_fmt, is.null, logical(1)) &
+      vapply(cards_no_attr$fmt_fun, Negate(is.null), logical(1)))) {
+    cards_no_attr <- cards::apply_fmt_fun(cards_no_attr)
+  }
+  cards_no_attr <- cards_no_attr |> mutate(sort_idx = dplyr::row_number())
 
   # construct formatted statistics ---------------------------------------------
+  # Vectorize the glue interpolation: pivot the ARD wide (one column per stat_name)
+  # and glue once per variable, rather than looping group-by-group. Rows with a
+  # populated `variable_level` are the per-level stats (one table row each); rows
+  # with a NULL `variable_level` are variable-scope stats that glue appends to
+  # every level of the group, with the variable-scope stat winning on any name
+  # collision (matching the prior `c(level_stats, variable_stats)` order, which
+  # under `glue_data()` resolves duplicate names last-wins).
+  group_cols <- cards_no_attr |> select(cards::all_ard_groups()) |> colnames()
+  hier_group_cols <- setdiff(group_cols, by_cols)
+  stat_cols <- unique(cards_no_attr$stat_name)
+
+  is_level <- !map_lgl(cards_no_attr$variable_level, is.null)
+  level_rows <- cards_no_attr[is_level, , drop = FALSE]
+  # per-level sort key = smallest stat-row index within the level (equivalent to
+  # the prior `df_variable_level_stats$sort_idx[1]`, since row order is preserved)
+  gid <- vctrs::vec_group_id(level_rows[c("gts_column", group_cols, "variable", "variable_level")])
+  level_rows$sort_idx <- stats::ave(level_rows$sort_idx, gid, FUN = min)
+  # level label, combining the length-1 `variable_level` cells to their common type
+  # (e.g. factor + character levels across variables -> character), matching the
+  # prior per-group `unlist()` followed by a cross-variable row-bind
+  level_rows$label <- vctrs::list_unchop(level_rows$variable_level)
+
+  level_wide <-
+    tidyr::pivot_wider(
+      level_rows,
+      id_cols = c("variable", "gts_column", all_of(group_cols), "label", "sort_idx"),
+      names_from = "stat_name",
+      values_from = "stat_fmt",
+      values_fn = list
+    )
+  # unlist only the wide stat columns; the group `*_level` id columns must remain
+  # list columns for the downstream unnest
+  sc <- intersect(stat_cols, names(level_wide))
+  level_wide[sc] <- .unlist_wide_stat_cols(level_wide[sc])
+
+  # merge variable-scope stats onto each level of the same group; variable-scope wins
+  var_rows <- cards_no_attr[!is_level, , drop = FALSE]
+  if (nrow(var_rows) > 0L) {
+    key <- c("variable", "gts_column", group_cols)
+    var_wide <-
+      tidyr::pivot_wider(
+        var_rows,
+        id_cols = all_of(key),
+        names_from = "stat_name",
+        values_from = "stat_fmt",
+        values_fn = list
+      )
+    var_sc <- intersect(stat_cols, names(var_wide))
+    var_wide[var_sc] <- .unlist_wide_stat_cols(var_wide[var_sc])
+    # presence indicator: a variable-scope stat overrides only where its ARD row exists
+    var_present <-
+      tidyr::pivot_wider(
+        var_rows |> mutate(..present.. = TRUE),
+        id_cols = all_of(key),
+        names_from = "stat_name",
+        values_from = "..present..",
+        values_fn = function(x) TRUE,
+        values_fill = FALSE
+      )
+    idx <- vctrs::vec_match(level_wide[key], var_wide[key])
+    for (col in setdiff(names(var_wide), key)) {
+      has <- !is.na(idx) & col %in% names(var_present) & var_present[[col]][idx]
+      has[is.na(has)] <- FALSE
+      if (!col %in% names(level_wide)) level_wide[[col]] <- NA
+      level_wide[[col]][has] <- var_wide[[col]][idx[has]]
+    }
+  }
+
+  # evaluate the glue statistic per variable (vectorized over that variable's levels)
   df_glued <-
-    # construct stat columns with glue by grouping variables and primary summary variable
-    cards_no_attr |>
-    dplyr::group_by(across(c("gts_column", cards::all_ard_groups(), "variable"))) |>
-    dplyr::group_map(
-      function(df_variable_stats, df_groups_and_variable) {
-        lst_variable_stats <-
-          cards::get_ard_statistics(
-            df_variable_stats,
-            .data$variable_level %in% list(NULL),
-            .column = "stat_fmt"
-          )
-
-        str_statistic_pre_glue <-
-          statistic[[df_groups_and_variable$variable[1]]]
-
-        mutate(
-          .data = df_groups_and_variable,
-          df_stats =
-            dplyr::filter(df_variable_stats, !.data$variable_level %in% list(NULL)) |>
-            dplyr::bind_cols(
-              df_groups_and_variable |>
-                select(cards::all_ard_groups(), -all_of(by_cols))
-            ) |>
-            dplyr::group_by(.data$variable_level) |>
-            dplyr::group_map(
-              function(df_variable_level_stats, df_variable_levels) {
-                mutate(
-                  .data = df_variable_levels,
-                  stat =
-                    map(
-                      str_statistic_pre_glue,
-                      function(str_to_glue) {
-                        stat <-
-                          glue::glue_data(
-                            .x =
-                              cards::get_ard_statistics(df_variable_level_stats, .column = "stat_fmt") |>
-                              c(lst_variable_stats),
-                            str_to_glue
-                          ) |>
-                          as.character()
-                      }
-                    ),
-                  label = .data$variable_level |> unlist(),
-                  sort_idx = df_variable_level_stats$sort_idx[1]
-                ) |>
-                  dplyr::bind_cols(
-                    df_variable_level_stats[1, ] |> select(cards::all_ard_groups())
-                  )
-              }
-            ) |>
-            dplyr::bind_rows() |>
-            list()
-        )
+    lapply(
+      variables,
+      function(var) {
+        df_var <- level_wide[level_wide$variable == var, , drop = FALSE]
+        if (nrow(df_var) == 0L) {
+          return(NULL)
+        }
+        keep_cols <- setdiff(names(df_var), stat_cols)
+        rlang::inject(vctrs::vec_rbind(!!!lapply(
+          statistic[[var]],
+          function(str_to_glue) {
+            out <- df_var[, keep_cols, drop = FALSE]
+            out$stat <- as.character(glue::glue_data(df_var, str_to_glue))
+            out
+          }
+        )))
       }
     ) |>
-    dplyr::bind_rows() %>%
+    (function(lst) rlang::inject(vctrs::vec_rbind(!!!lst)))() %>%
     # this ensures the correct order when there are 10+ hierarchy levels
     dplyr::left_join(
       cards_no_attr |> dplyr::distinct(!!sym("gts_column")),
@@ -330,32 +373,11 @@ pier_summary_hierarchical <- function(cards,
   # reshape results for final table --------------------------------------------
   df_result_levels <-
     df_glued |>
-    # merge in variable label
-    dplyr::left_join(
-      cards |>
-        dplyr::filter(
-          .data$variable %in% .env$variables,
-          .data$context %in% "attributes",
-          .data$stat_name %in% "label"
-        ) |>
-        select("variable", var_label = "stat"),
-      by = "variable"
-    )
-
-  # add var_label
-  df_result_levels <- df_result_levels |> mutate(var_label = NA_character_)
-
-  df_result_levels <-
-    df_result_levels |>
-    mutate(
-      .by = "variable",
-      row_type = "level",
-      var_label = unlist(.data$var_label),
-      .after = 0L
+    mutate(row_type = "level", var_label = NA_character_) |>
+    select(
+      "row_type", "var_label", "variable", "label",
+      all_of(hier_group_cols), "gts_column", "stat", "sort_idx"
     ) |>
-    select(-cards::all_ard_groups()) |>
-    tidyr::unnest(cols = "df_stats") |>
-    tidyr::unnest(cols = "stat") |>
     dplyr::arrange(.data$sort_idx) |>
     tidyr::pivot_wider(
       id_cols = c("row_type", "var_label", "variable", "label", cards::all_ard_groups()),
@@ -377,13 +399,16 @@ pier_summary_hierarchical <- function(cards,
   if (length(variables) > 1 && length(include) > 1) {
     gps <- df_result_levels |> select(cards::all_ard_groups("names")) |> names()
 
+    # per-column subset assignment (avoids copying the whole frame each iteration)
     for (i in seq_along(gps)) {
-      df_result_levels[df_result_levels$variable == variables[i], ] <-
-        df_result_levels[df_result_levels$variable == variables[i], ] |>
-        mutate(
-          !!gps[i] := dplyr::coalesce(!!sym(gps[i]), .data$variable),
-          !!paste0(gps[i], "_level") := dplyr::coalesce(!!sym(paste0(gps[i], "_level")), .data$label)
-        )
+      idx <- which(df_result_levels$variable == variables[i])
+      if (length(idx) == 0L) next
+      gp <- gps[i]
+      gp_lvl <- paste0(gp, "_level")
+      df_result_levels[[gp]][idx] <-
+        dplyr::coalesce(df_result_levels[[gp]][idx], df_result_levels$variable[idx])
+      df_result_levels[[gp_lvl]][idx] <-
+        dplyr::coalesce(df_result_levels[[gp_lvl]][idx], df_result_levels$label[idx])
     }
   }
 
@@ -391,17 +416,21 @@ pier_summary_hierarchical <- function(cards,
 }
 
 .construct_hierarchical_footnote <- function(card, include, statistic) {
+  # the stat_name -> stat_label lookup does not depend on the loop variable,
+  # so compute it once instead of re-filtering the full ARD for each variable
+  lst_labels <- card |>
+    dplyr::filter(.data$variable %in% .env$include) |>
+    select("stat_name", "stat_label") |>
+    dplyr::distinct() %>%
+    {stats::setNames(as.list(.$stat_label), .$stat_name)} # styler: off
+
   include |>
     lapply(
       function(variable) {
-        card |>
-          dplyr::filter(.data$variable %in% .env$include) |>
-          select("stat_name", "stat_label") |>
-          dplyr::distinct() %>%
-          {stats::setNames(as.list(.$stat_label), .$stat_name)} |> # styler: off
-          glue::glue_data(
-            gsub("\\{(p)\\}%", "{\\1}", x = statistic[[variable]])
-          )
+        glue::glue_data(
+          lst_labels,
+          gsub("\\{(p)\\}%", "{\\1}", x = statistic[[variable]])
+        )
       }
     ) |>
     stats::setNames(include) |>

--- a/R/sort_hierarchical.R
+++ b/R/sort_hierarchical.R
@@ -178,13 +178,18 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = everything() ~ "descend
   # add dummy rows for variables not in include so their label rows are sorted correctly
   x_ard <- x_ard |> .append_not_incl(ard_args, x$call_list, sort)
 
-  # add indices to ARD
-  x_ard <- x_ard |>
-    dplyr::group_by(across(c(cards::all_ard_groups(), cards::all_ard_variables(), -all_of(by_cols)))) |>
-    dplyr::mutate(pre_idx = dplyr::cur_group_id())
+  # add indices to ARD. `group_rows()` numbers groups exactly like
+  # `cur_group_id()` (same grouped object), so fill `pre_idx` from it without a
+  # grouped mutate (which would copy the full ARD and strip the card class)
+  grouped <- x_ard |>
+    dplyr::group_by(across(c(cards::all_ard_groups(), cards::all_ard_variables(), -all_of(by_cols))))
+  grows <- dplyr::group_rows(grouped)
+  pre_idx <- integer(nrow(x_ard))
+  for (g in seq_along(grows)) pre_idx[grows[[g]]] <- g
+  x_ard$pre_idx <- pre_idx
 
   # get grouping structure
-  gps <- x_ard |>
+  gps <- grouped |>
     dplyr::group_keys() |>
     dplyr::mutate(pre_idx = dplyr::row_number()) |>
     cards::as_card(check = FALSE)
@@ -250,35 +255,48 @@ sort_hierarchical.tbl_hierarchical <- function(x, sort = everything() ~ "descend
 
     for (v in not_incl) {
       i <- length(ard_args$by) + which(ard_args$variables == v)
-      x_sum_rows <- x |>
-        dplyr::group_by(across(all_of(cards::all_ard_group_n((length(ard_args$by) + 1):i)))) |>
-        dplyr::group_map(function(.df, .g) {
-          stat_nm <- setdiff(.df$stat_name, "N")[1]
-          # get pseudo-summary row stat value for descending sort
-          if (!is.null(sort) && sort[v] == "descending") {
-            sum <- .df |>
-              dplyr::filter(.data$variable == dplyr::last(ard_args$include) & .data$stat_name == !!stat_nm) |>
-              dplyr::summarize(sum_stat = sum(unlist(.data$stat))) |>
-              dplyr::pull("sum_stat")
-          }
-          g_cur <- .g[[ncol(.g) - 1]]
-          if (!is.na(g_cur) && g_cur == v) {
-            # dummy summary row to add in
-            .df[.df$stat_name == stat_nm, ][1, ] |>
-              select(-cards::all_ard_group_n(i:length(ard_args$variables))) |>
-              mutate(
-                variable = g_cur,
-                variable_level = .g[[ncol(.g)]],
-                stat_name = if (!is.null(sort) && sort[v] == "descending") stat_nm else "no_stat",
-                stat = if (!is.null(sort) && sort[v] == "descending") list(sum) else list(0),
-                tmp = TRUE
-              )
-          } else {
-            NULL
-          }
-        }, .keep = TRUE)
+      descending <- !is.null(sort) && sort[v] == "descending"
 
-      x <- x |> dplyr::bind_rows(x_sum_rows)
+      # extract the grouping structure once, then build every dummy row with
+      # vectorized slicing instead of materializing a tibble per group
+      grouped <- x |>
+        dplyr::group_by(across(all_of(cards::all_ard_group_n((length(ard_args$by) + 1):i))))
+      keys <- dplyr::group_keys(grouped)
+      grows <- dplyr::group_rows(grouped)
+      ncol_k <- ncol(keys)
+      # groups whose depth-`i` hierarchy variable is `v` are the ones that get a dummy row
+      g_cur <- keys[[ncol_k - 1]]
+      sel <- which(!is.na(g_cur) & g_cur == v)
+
+      if (length(sel) > 0) {
+        base_idx <- integer(length(sel))
+        stat_nm_v <- character(length(sel))
+        stat_val <- vector("list", length(sel))
+        for (k in seq_along(sel)) {
+          ridx <- grows[[sel[k]]]
+          snames <- x$stat_name[ridx]
+          snm <- setdiff(snames, "N")[1]
+          stat_nm_v[k] <- snm
+          base_idx[k] <- ridx[match(snm, snames)]
+          # pseudo-summary row stat value for descending sort
+          if (descending) {
+            sub <- ridx[x$variable[ridx] == dplyr::last(ard_args$include) & x$stat_name[ridx] == snm]
+            stat_val[[k]] <- sum(unlist(x$stat[sub]))
+          } else {
+            stat_val[[k]] <- 0
+          }
+        }
+
+        x_sum_rows <- x[base_idx, ] |>
+          select(-cards::all_ard_group_n(i:length(ard_args$variables)))
+        x_sum_rows$variable <- v
+        x_sum_rows$variable_level <- keys[[ncol_k]][sel]
+        x_sum_rows$stat_name <- if (descending) stat_nm_v else "no_stat"
+        x_sum_rows$stat <- stat_val
+        x_sum_rows$tmp <- TRUE
+
+        x <- x |> dplyr::bind_rows(x_sum_rows)
+      }
     }
   }
 

--- a/R/tbl_hierarchical.R
+++ b/R/tbl_hierarchical.R
@@ -322,19 +322,26 @@ internal_tbl_hierarchical <- function(data,
   orig_args <- attributes(cards)$args
 
   # apply digits ---------------------------------------------------------------
-  cards <-
-    cards |>
-    dplyr::rows_update(
-      imap(
-        digits,
-        ~ enframe(.x, "stat_name", "fmt_fun") |>
-          dplyr::mutate(variable = .y)
-      ) |>
-        dplyr::bind_rows(),
-      by = c("variable", "stat_name"),
-      unmatched = "ignore"
+  # the digits frame is tiny (one row per variable x stat_name) with unique keys,
+  # while `cards` is long with heavily duplicated keys; a direct `vctrs::vec_match()`
+  # from `cards` into the digits frame updates every matching row like the former
+  # `dplyr::rows_update(unmatched = "ignore")`, without copying the full ARD.
+  df_digits <-
+    imap(
+      digits,
+      ~ enframe(.x, "stat_name", "fmt_fun") |>
+        dplyr::mutate(variable = .y)
     ) |>
-    cards::apply_fmt_fun()
+    dplyr::bind_rows()
+  if (nrow(df_digits) > 0L) {
+    m <- vctrs::vec_match(
+      vctrs::data_frame(variable = cards$variable, stat_name = cards$stat_name),
+      vctrs::data_frame(variable = df_digits$variable, stat_name = df_digits$stat_name)
+    )
+    hit <- which(!is.na(m))
+    cards$fmt_fun[hit] <- df_digits$fmt_fun[m[hit]]
+  }
+  cards <- cards |> cards::apply_fmt_fun()
 
   # restore class correct class attributes -------------------------------------
   attr(cards, "args") <- orig_args
@@ -448,10 +455,11 @@ internal_tbl_hierarchical <- function(data,
 }
 
 .add_gts_column_to_cards_hierarchical <- function(cards, variables, by) {
-  # save class attributes ------------------------------------------------------
-  orig_class <- class(cards)
-  orig_args <- attributes(cards)$args
-  # adding the name of the column the stats will populate
+  # adding the name of the column the stats will populate.
+  # `dplyr::group_rows()` returns row indices per group in the same order that
+  # `dplyr::cur_group_id()` numbers them (including first-appearance ordering for
+  # the list-valued `*_level` columns), so this reproduces the former grouped
+  # mutates without stripping/restoring the card class or copying the frame.
   if (is_empty(by)) {
     cards$gts_column <-
       ifelse(
@@ -460,22 +468,20 @@ internal_tbl_hierarchical <- function(data,
         NA_character_
       )
   } else {
-    cards <- cards |>
-      dplyr::group_by(.data$group1_level) |>
-      dplyr::mutate(gts_column = paste0("stat_", dplyr::cur_group_id()))
+    gts <- character(nrow(cards))
+    rows <- dplyr::group_rows(dplyr::group_by(cards, .data$group1_level))
+    for (g in seq_along(rows)) gts[rows[[g]]] <- paste0("stat_", g)
 
-    # process overall row
-    cards[cards$variable %in% by, ] <- cards[cards$variable %in% by, ] |>
-      dplyr::group_by(.data$variable_level) |>
-      dplyr::mutate(gts_column = paste0("stat_", dplyr::cur_group_id()))
+    # process overall row: within the `by` rows, number by `variable_level`
+    by_idx <- which(cards$variable %in% by)
+    if (length(by_idx) > 0L) {
+      rows2 <- dplyr::group_rows(
+        dplyr::group_by(vctrs::data_frame(v = vctrs::vec_slice(cards$variable_level, by_idx)), .data$v)
+      )
+      for (g in seq_along(rows2)) gts[by_idx[rows2[[g]]]] <- paste0("stat_", g)
+    }
+    cards$gts_column <- gts
   }
 
-  cards <- cards |>
-    dplyr::ungroup() |>
-    cards::as_card(check = FALSE)
-
-  # restore correct class attributes -------------------------------------------
-  attr(cards, "args") <- orig_args
-  class(cards) <- orig_class
   cards
 }


### PR DESCRIPTION
## What & why

`tbl_hierarchical()` still used the pre-#2440 table-assembly pattern that #2440 already removed from `tbl_summary()`: nested `dplyr::group_by() |> group_map()` loops with a per-cell `glue::glue_data()` call. Profiling the CI benchmark case (`cards::ADAE`, AESOC/AETERM/AESEV, by TRTA, id USUBJID, overall_row) showed ~86% of the time in the assembly bridge. This PR applies the same playbook — pivot the ARD wide and glue once per variable, `vctrs::vec_rbind`/`vec_match` in place of dplyr row machinery, and hoist/skip redundant work.

**No user-facing change.** Inputs and outputs are identical; the internal `table_body` layout (which `sort_hierarchical()`/`filter_hierarchical()` depend on) is preserved byte-for-byte.

## Changes

**`R/brdg_hierarchical.R`** (the hot path)
- Vectorize `pier_summary_hierarchical()`: pivot the ARD wide (one column per `stat_name`) and glue once per variable instead of once per cell, preserving `sort_idx` ordering, hierarchical group list-columns, and variable-scope-wins collision semantics.
- Guard the redundant second `apply_fmt_fun()` — both callers (`internal_tbl_hierarchical()`, `tbl_ard_hierarchical()`) already format; the guard reproduces `replace = FALSE` exactly and keeps the exported `pier_summary_hierarchical()` working on unformatted input.
- Delete a dead `var_label` `left_join` (unconditionally clobbered on the next line).
- Collapse the per-excluded-variable label-row loop into a single pass (the source rows are invariant across iterations; the intermediate `group_by` before `arrange` was inert).
- Replace whole-frame `df[rows, ] <- ...` copies in the coalesce loop with per-column subset assignment.

**`R/tbl_hierarchical.R`**
- Digits: replace `dplyr::rows_update()` on the full ARD with a `vctrs::vec_match()` from the ARD into the tiny (~variables × stats) digits frame.
- `.add_gts_column_to_cards_hierarchical()`: rebuild on `dplyr::group_rows()` (which numbers groups exactly like `cur_group_id()`, including first-appearance ordering of the list-valued `*_level` columns), dropping two grouped-mutate copies and the class strip/restore.

**`R/sort_hierarchical.R`**
- Vectorize `.append_not_incl()` (the dominant `sort_hierarchical()` cost when `include` is a subset) via `group_keys()`/`group_rows()` + vectorized slicing.
- Replace the `pre_idx` grouped mutate in `.reshape_ard_compare()` with a `group_rows()` fill.

**`.github/scripts/benchmark.R`** — add isolated `brdg_hierarchical` and `sort/filter_hierarchical` benchmarks so the pieces changed here get their own before/after numbers.

## Results (local, `cards::ADAE`)

| Benchmark | Before | After | Speedup |
|---|---|---|---|
| `tbl_hierarchical` (3-level, overall) | 18.1s | 2.2s | ~8.2× |
| `tbl_hierarchical_count` | 15.0s | 0.9s | ~16.8× |
| `sort_hierarchical` (include subset) | 1.75s | 0.35s | ~5× |
| Memory (`tbl_hierarchical`) | 110MB | 87.6MB | ~20% less |

The CI benchmark workflow (perf-titled PR) will post authoritative main-vs-PR numbers.

## Verification

- **Byte-identical output** vs a clean `main` checkout: a 12-case output battery, a 4-case stored-cards battery (`fmt_fun` compared by source since closures differ by environment across loads), and a 13-case sort/filter battery (descending, alphanumeric, count, no-by, chained) — all `identical()`.
- **Full test suite green**: FAIL=0 WARN=0 across 821 tests.

## Reviewer notes

- The verified collision semantics are **variable-scope-wins** (last in the prior `c(level_stats, variable_stats)` list under `glue_data()`), the opposite of the `pier_summary_categorical` comment; the rewrite preserves this. In practice `tbl_hierarchical` ARDs carry no variable-scope stat rows, so this only matters for hand-built `tbl_ard_hierarchical()` input.
- `.rows_update_base()` was intentionally **not** reused for the digits update: it is first-match-only, and the ARD has heavily duplicated `(variable, stat_name)` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)