### PR TITLE
fix(ci): make Bump Dev Version workflow runnable

### DIFF
--- a/.github/workflows/bump-dev-version.yaml
+++ b/.github/workflows/bump-dev-version.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_PAT }}
+          token: ${{ secrets.GH_PAT }}
           fetch-depth: 0
 
       - name: Setup R
@@ -44,9 +44,9 @@ jobs:
             # Run the bump
             Rscript -e 'usethis::use_version(which = "dev")'
 
-            # Commit and push
-            git add DESCRIPTION
-            git commit -m "Bump version [skip ci]"
+            # Commit and push (skip commit if nothing changed)
+            git add DESCRIPTION NEWS.md
+            git diff --staged --quiet || git commit -m "Bump version [skip ci]"
             git push
           else
             echo "Stable version detected ($VERSION). Skipping bump."


### PR DESCRIPTION
## What

Fixes the `Bump Dev Version` GitHub Action, which **has never succeeded** — `gh run list` shows **0/44 runs passing**. Every run dies at the first step with:

```
##[error]Input required and not supplied: token
```

## Why it was broken

The checkout step used `token: ${{ secrets.GITHUB_PAT }}`:

1. **The secret was never defined** (only `CODECOV_TOKEN` exists), so `token:` resolved to empty and checkout aborted before the version was ever inspected.
2. **That name is impossible** — GitHub rejects secret names starting with `GITHUB_` ("Secret names must not start with GITHUB_."), so `GITHUB_PAT` could never be created.

The "only bump dev versions / only on `main`" logic itself was correct; the job just never got far enough to run it.

## Changes

- Rename the token reference `secrets.GITHUB_PAT` → `secrets.GH_PAT` (a legal name).
- Harden the commit step: also stage `NEWS.md`, and skip the commit when nothing changed (`git diff --staged --quiet || git commit …`) so a no-op bump cannot fail the job.

Loop prevention is unchanged: the `[skip ci]` commit message plus the existing `if: !contains(..., 'Bump version')` job guard keep the bump push from re-triggering the workflow.

## Action required before this works ⚠️

A repository secret named **`GH_PAT`** must be created (Settings → Secrets and variables → Actions). It needs a PAT owned by a maintainer with **admin/bypass rights on `main`** (Contents: read/write), because `main` branch protection blocks direct pushes from the built-in `GITHUB_TOKEN`. Without this secret the workflow will still fail at checkout.

## Verification

After the secret exists and this merges, a push to `main` should show a successful run logging `Dev version detected (2.5.1.9003). Bumping...` and a `Bump version [skip ci]` commit advancing `DESCRIPTION` to `2.5.1.9004`, with no second run triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
