### PR TITLE
Add error when `add_overall()` is called twice

### DIFF
--- a/R/add_overall.R
+++ b/R/add_overall.R
@@ -125,6 +125,12 @@ add_overall.tbl_hierarchical_count <- function(x,
 add_overall_generic <- function(x, last, col_label, statistic, digits, call, calling_fun) {
   check_scalar_logical(last)
   check_string(col_label, allow_empty = TRUE)
+  if ("add_overall" %in% names(x$call_list)) {
+    cli::cli_abort(
+      "The {.fun add_overall} function has already been called and cannot be called again.",
+      call = get_cli_abort_call()
+    )
+  }
 
   # checking that input x has a by var
   if (is_empty(x$inputs[["by"]])) {

--- a/tests/testthat/_snaps/add_overall.tbl_summary.md
+++ b/tests/testthat/_snaps/add_overall.tbl_summary.md
@@ -16,3 +16,11 @@
       ! An error occured in `add_overall()`, and the overall statistic cannot be added.
       Have variable labels changed since the original call to `tbl_summary()`?
 
+---
+
+    Code
+      add_overall(add_overall(tbl_summary(trial, include = age, by = trt)))
+    Condition
+      Error in `add_overall()`:
+      ! The `add_overall()` function has already been called and cannot be called again.
+

--- a/tests/testthat/test-add_overall.tbl_summary.R
+++ b/tests/testthat/test-add_overall.tbl_summary.R
@@ -98,4 +98,12 @@ test_that("add_overall.tbl_summary() messaging", {
       add_stat_label(label = mpg ~ "UPDATED!") |>
       add_overall()
   )
+
+  # Running add_overall() twice
+  expect_snapshot(
+    error = TRUE,
+    tbl_summary(trial, include = age, by = trt) |>
+      add_overall() |>
+      add_overall()
+  )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
<< Insert text here that can be directly copied into NEWS.md by your reviewer. >>

**If there is an GitHub issue associated with this pull request, please provide link.**


--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [ ] `spelling::spell_check_package()` runs with no spelling errors in documentation
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# gtsummary (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).

When the branch is ready to be merged into master:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

