### PR TITLE
docs: fix typos across R source, vignettes, NEWS.md, and tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -134,7 +134,7 @@
 
 * Added `tbl_split_by_rows()` and `tbl_split_by_columns()` to split tables horizontally (row-wise) and vertically (column-wise). (#2216)
 
-* Users are now allows to specify/override the denominator by passing an integer or a data frame to the `tbl_summary(percent)` argument. (#2239) 
+* Users are now allowed to specify/override the denominator by passing an integer or a data frame to the `tbl_summary(percent)` argument. (#2239) 
 
 * Added the `tbl_merge(tbl_ids)` and `tbl_stack(tbl_ids)` arguments that allows used to label the gtsummary input tables. This is particularly helpful when calling `gather_ard()`, which will return a named list of ARDs where the names are the assigned tbl IDs. (#2224) 
 
@@ -409,7 +409,7 @@ Updates to address regressions in the v2.0.0 release:
 * The {gt} package is now the default printer for all Quarto and R markdown output formats.
   - Previously, when printing a gtsummary table in a Quarto or R markdown document, we would detect the output format and convert to gt, flextable, or kable to provide the best-looking table. The {gt} package has matured and provides lovely tables for nearly all output types, and we have now made {gt} the default table drawing tool for all gtsummary tables. These output types are still supported.
 
-* Previously, if I wanted a single statistic to be reported to additional levels of precision in a `tbl_summary()` table, I would need to specify the precision of every summary statistic for a variable. Now, we can simple update the one statistic we're interested in with a named list of vector: `tbl_summary(digits = age ~ list(sd = 2))`.
+* Previously, if I wanted a single statistic to be reported to additional levels of precision in a `tbl_summary()` table, I would need to specify the precision of every summary statistic for a variable. Now, we can simply update the one statistic we're interested in with a named list of vector: `tbl_summary(digits = age ~ list(sd = 2))`.
 
 * New functions `tbl_ard_summary()` and `tbl_ard_continuous()` have been added. These provide general tools for creating bespoke summary tables. Rather than accepting a data frame, these functions accept an ARD object (Analysis Results Dataset often created with the {cards} or {cardx} packages). The ARD objects align with the emerging [CDISC Analysis Results Standard](https://www.cdisc.org/standards/foundational/analysis-results-standard). ARDs are now used throughout the package. See below under the "Internal Storage" heading.
 
@@ -431,7 +431,7 @@ Updates to address regressions in the v2.0.0 release:
 
 * In `tbl_regression()`, the `.$model_obj` is no longer returned with the object. The modeling object is, and always has been, available in `.$inputs$x`.
 
-* When the gtsummary package was first written, the gt package was not on CRAN and the version of the package that was available did not have the ability to merge columns. Due to these limitations, the `"ci"` column was added to show the combined `"conf.low"` and `"conf.high"` columns. Column merging in both gt and gtsummary packages has matured over the years, and we are now adopting a more modern approach by using these features. As a result, the `"ci"` column will eventually be dropped from `.$table_body`. By using column merging, the conf.low and conf.high remain numeric and we can to continue to update how these columns are formatted. Review `?deprecated_ci_column` for details.
+* When the gtsummary package was first written, the gt package was not on CRAN and the version of the package that was available did not have the ability to merge columns. Due to these limitations, the `"ci"` column was added to show the combined `"conf.low"` and `"conf.high"` columns. Column merging in both gt and gtsummary packages has matured over the years, and we are now adopting a more modern approach by using these features. As a result, the `"ci"` column will eventually be dropped from `.$table_body`. By using column merging, the conf.low and conf.high remain numeric and we can continue to update how these columns are formatted. Review `?deprecated_ci_column` for details.
 
 ### Documentation
 
@@ -441,7 +441,7 @@ Updates to address regressions in the v2.0.0 release:
 
 * Argument `add_p.tbl_summary(adj.vars)` was added to more easily add p-values that are adjusted/stratified by other columns in a data frame. 
 
-* Messaging and checks have been improved when tidyselect is invoked in the package, i.e. when the tilda is used to select variables `age ~ "Patient Age"`. The subset of variables that can be selected is now reduced the variables present in the table. For example, if you have a summary table of patient age (and only patient age), and age is a single column from a data set of many columns and you mis-spell age (`aggge ~ "Patient Age"`), the error message will now ask if you meant `"age"` instead of listing every column in the data set. 
+* Messaging and checks have been improved when tidyselect is invoked in the package, i.e. when the tilda is used to select variables `age ~ "Patient Age"`. The subset of variables that can be selected is now reduced to the variables present in the table. For example, if you have a summary table of patient age (and only patient age), and age is a single column from a data set of many columns and you mis-spell age (`aggge ~ "Patient Age"`), the error message will now ask if you meant `"age"` instead of listing every column in the data set. 
   - Note that as before, you can circumvent tidyselect by using a named list, e.g. `list(age = "Patient Age")`. 
 
 * Added the following methods for calculating differences in `add_difference.tbl_summary()`: Hedge's G, Paired data Cohen's D, and Paired data Hedge's G. All three are powered by the {effectsize} package.
@@ -458,7 +458,7 @@ Updates to address regressions in the v2.0.0 release:
 
 * The values passed in `tbl_summary(value)` are now only checked for columns that are summary type `"dichotomous"`. 
 
-* The gtsummary selecting functions, e.g. `all_categorical()`, `all_continuous()`, etc., are now simplified by wrapping `tidyselect::where()`, which not available when these functions were originally written. Previously, these functions would error if used out of context; they now, instead,select no columns when used out-of-context.
+* The gtsummary selecting functions, e.g. `all_categorical()`, `all_continuous()`, etc., are now simplified by wrapping `tidyselect::where()`, which was not available when these functions were originally written. Previously, these functions would error if used out of context; they now, instead, select no columns when used out-of-context.
 
 * The design-based t-test has been added as possible methods for `add_difference.tbl_svysummary()` and is now the default for continuous variables.
 
@@ -494,7 +494,7 @@ Updates to address regressions in the v2.0.0 release:
  
 * The `add_p(test = ~'aov')` test is now deprecated as identical results can be obtained with `add_p(test = ~'oneway.test', test.args = ~list(var.equal = TRUE))`.
 
-* Previously, `add_p.tbl_summary()` would coerce various data types to classes compatible with some base R tests. For example, we would convert `difftime` classes to general numeric before passing to `wilcox.test()`. We have eliminated type- and class-specific handling in these functions and it is now left to the the user pass data compatible with the functions that calculate the p-values or to create a custom test that wraps `wilcox.test()` and performs the conversion. This change is effective immediately.
+* Previously, `add_p.tbl_summary()` would coerce various data types to classes compatible with some base R tests. For example, we would convert `difftime` classes to general numeric before passing to `wilcox.test()`. We have eliminated type- and class-specific handling in these functions and it is now left to the user to pass data compatible with the functions that calculate the p-values or to create a custom test that wraps `wilcox.test()` and performs the conversion. This change is effective immediately.
      
 * Arguments `modify_header(update)`, `modify_footnote(update)`, `modify_spanning_header(update)`, and `modify_fmt_fun(update)` have been deprecated. Use dynamic dots instead, e.g. `modify_header(...)`, which has been the preferred method for passing updates for a few years.
 
@@ -838,7 +838,7 @@ Updates to address regressions in the v2.0.0 release:
 
 * Added new function `modify_column_alignment()` to updated column alignment. Function is a wrapper for the more complex `modify_table_styling()` function.
 
-* New function `tbl_strata2()` that passes both the the stratified data frame as well as the stratum level to the user function. (#1091)
+* New function `tbl_strata2()` that passes both the stratified data frame as well as the stratum level to the user function. (#1091)
 
 * Added a `add_p.tbl_continuous()` method for adding p-values to `tbl_continuous()` tables. (#1023)
 
@@ -1074,7 +1074,7 @@ Updates to address regressions in the v2.0.0 release:
 
 * Added new function `add_significance_stars()` adding star indicators to significant estimates and an explanatory footnote.
 
-* Added new function `tbl_strata()`. The function aids prepares gtsummary tables stratified by one or more variables (#679)
+* Added new function `tbl_strata()`. The function prepares gtsummary tables stratified by one or more variables (#679)
 
 * Adding coefficient `plot()` methods for `tbl_regression()` and `tbl_uvregression()`. Function creates a forest plot of model coefficients via `GGally::ggcoef_plot()`.
 
@@ -1246,7 +1246,7 @@ Updates to address regressions in the v2.0.0 release:
 
 * Added `digits=` argument to `style_percent()` (#690)
 
-* Users may now choose which `tbl_regression()` columns to report with a theme element. they can choose among the `"estimate"`, `"std.error"`, `"statistic"`, `"ci"`, `"conf.low"`, `"conf.high"` and `"p.value"` (#637)
+* Users may now choose which `tbl_regression()` columns to report with a theme element. They can choose among the `"estimate"`, `"std.error"`, `"statistic"`, `"ci"`, `"conf.low"`, `"conf.high"` and `"p.value"` (#637)
 
 * Allow users to include the reference value in `tbl_regression()` via a theme element
 
@@ -1483,7 +1483,7 @@ Updates to address regressions in the v2.0.0 release:
 
 * Bug fix when data frame passed to `tbl_summary()` with a single column (#389)
 
-* In `tbl_summary()` passing an ordered factor in the `by=` argument no longer causes as error. (#453)
+* In `tbl_summary()` passing an ordered factor in the `by=` argument no longer causes an error. (#453)
 
 # gtsummary 1.2.6
 

--- a/R/add_glance.R
+++ b/R/add_glance.R
@@ -14,7 +14,7 @@
 #' @param label ([`formula-list-selector`][syntax])\cr
 #'   specifies statistic labels, e.g. `list(r.squared = "R2", p.value = "P")`
 #' @param fmt_fun ([`formula-list-selector`][syntax])\cr
-#'   Specifies the the functions used to format/round the glance statistics.
+#'   Specifies the functions used to format/round the glance statistics.
 #'   The default is to round
 #'   the number of observations and degrees of freedom to the nearest integer,
 #'   p-values are styled with `style_pvalue()` and the remaining statistics

--- a/R/add_overall.R
+++ b/R/add_overall.R
@@ -136,7 +136,7 @@ add_overall_generic <- function(x, last, col_label, statistic, digits, call, cal
   if (is_empty(x$inputs[["by"]])) {
     cli::cli_inform(
       c("Cannot add an overall column with {.fun add_overall} when original table
-         is not statified with {.code {calling_fun}(by)}.",
+         is not stratified with {.code {calling_fun}(by)}.",
         i = "Returning table unaltered.")
     )
     return(x)
@@ -179,7 +179,7 @@ add_overall_merge <- function(x, tbl_overall, last, col_label, calling_fun) {
   )) {
     cli::cli_abort(
       c(
-        "An error occured in {.fun add_overall}, and the overall statistic cannot be added.",
+        "An error occurred in {.fun add_overall}, and the overall statistic cannot be added.",
         "Have variable labels changed since the original call to {.fun {calling_fun}}?"
       ),
       call = get_cli_abort_call()

--- a/R/add_p.R
+++ b/R/add_p.R
@@ -488,7 +488,7 @@ calculate_and_add_test_results <- function(x, include, group = NULL, test.args, 
       map(~c(.x, lst_captured_results[["warning"]]))
   }
 
-  # if the result is null, replace it with a data frame of of NA
+  # if the result is null, replace it with a data frame of NA
   if (is.null(lst_captured_results[["result"]])) {
     lst_captured_results[["result"]] <-
       rep_named(chr_expected_stats, list(NA)) |>

--- a/R/add_p.tbl_survfit.R
+++ b/R/add_p.tbl_survfit.R
@@ -30,7 +30,7 @@
 #'
 #' @section Note:
 #'
-#' To calculate the p-values, the formula is re-constructed from the the call in the
+#' To calculate the p-values, the formula is re-constructed from the call in the
 #' original `survfit()` object.
 #' When the `survfit()` object is created a for loop, `lapply()`, `purrr::map()`
 #' setting the call _may not_ reflect the true formula which may result in an

--- a/R/add_significance_stars.R
+++ b/R/add_significance_stars.R
@@ -100,7 +100,7 @@ add_significance_stars <- function(x,
   pattern_cols <- .extract_glue_elements(pattern)
   if (is_empty(pattern_cols)) {
     cli::cli_abort(
-      "The {.arg pattern} argumnet must be a string using glue syntax to select columns.",
+      "The {.arg pattern} argument must be a string using glue syntax to select columns.",
       call = get_cli_abort_call()
     )
   }

--- a/R/add_stat.R
+++ b/R/add_stat.R
@@ -37,13 +37,13 @@
 #'     - `tbl=` the original `tbl_summary()`/`tbl_svysummary()` object is also available to utilize
 #'
 #' The user-defined function does not need to utilize each of these inputs. It's
-#' encouraged the user-defined function accept `...` as each of the arguments
+#' encouraged that the user-defined function accept `...` as each of the arguments
 #' *will* be passed to the function, even if not all inputs are utilized by
 #' the user's function, e.g. `foo(data, variable, by, ...)`
 #'
 #' - Use `modify_header()` to update the column headers
 #' - Use `modify_fmt_fun()` to update the functions that format the statistics
-#' - Use `modify_footnote_header()` to add a explanatory footnote
+#' - Use `modify_footnote_header()` to add an explanatory footnote
 #'
 #' If you return a tibble with column names `p.value` or `q.value`, default
 #' p-value formatting will be applied, and you may take advantage of subsequent
@@ -247,7 +247,7 @@ eval_fn_safe <- function(variable, tbl, fn) {
   }
   if (!is_empty(result[["error"]])) {
     cli::cli_inform(
-      c("There was a error for variable {.val {variable}}", "x" = "{result[['error']]}")
+      c("There was an error for variable {.val {variable}}", "x" = "{result[['error']]}")
     )
   }
 

--- a/R/as_kable_extra.R
+++ b/R/as_kable_extra.R
@@ -129,7 +129,7 @@ as_kable_extra <- function(x,
       .init = kable_extra_calls
     )
 
-  # converting to charcter vector ----------------------------------------------
+  # converting to character vector ----------------------------------------------
   cards::process_selectors(
     data = vec_to_df(names(kable_extra_calls)),
     include = {{ include }}

--- a/R/deprecated_ci_column.R
+++ b/R/deprecated_ci_column.R
@@ -16,7 +16,7 @@
 #' As a result, the pre-formatted `"ci"` column will eventually be dropped from `.$table_body`.
 #'
 #' By using column merging, the `conf.low` and `conf.high` remain numeric
-#' and we can to continue to update how these columns are formatted, even after printing the table.
+#' and we can continue to update how these columns are formatted, even after printing the table.
 #'
 #' The `"ci"` column is hidden, meaning that it appears in `.$table_body`, but is not printed.
 #' This means that references to the column in your code will not error, but will likely not have the intended effect.

--- a/R/inline_text.R
+++ b/R/inline_text.R
@@ -148,7 +148,7 @@ inline_text.gtsummary <- function(x,
   if ("row_type" %in% names(df_gtsummary) &&
       nrow(df_gtsummary |> dplyr::filter(.data$row_type %in% "label")) > 1L) {
     cli::cli_inform(
-      "Variable {.cal {variable}} likely not unique in gtsummary table, and
+      "Variable {.val {variable}} likely not unique in gtsummary table, and
        the cell(s) you wish to display may not be accessible.
        This may occur when gtsummary tables with repeated variable
        names are combined using {.fun tbl_stack}.",

--- a/R/modify_source_note.R
+++ b/R/modify_source_note.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' Add and remove source notes from a table.
-#' Source notes are similar to footnotes, expect they are not linked to a cell in
+#' Source notes are similar to footnotes, except they are not linked to a cell in
 #' the table.
 #'
 #' @param x (`gtsummary`)\cr

--- a/R/modify_table_body.R
+++ b/R/modify_table_body.R
@@ -56,7 +56,7 @@ modify_table_body <- function(x, fun, ...) {
       as_function(fun, env = global_env())(x$table_body, ...),
       error = \(e) {
         cli::cli_abort(
-          c("The following error occured while executing {.arg fun} on {.code x$table_body}:",
+          c("The following error occurred while executing {.arg fun} on {.code x$table_body}:",
             "x" = conditionMessage(e)),
           call = get_cli_abort_call()
         )

--- a/R/remove_row_type.R
+++ b/R/remove_row_type.R
@@ -5,7 +5,7 @@
 #' @param x (`gtsummary`)\cr
 #'   A gtsummary object
 #' @param variables ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
-#'   Variables to to remove rows from. Default is `everything()`
+#'   Variables to remove rows from. Default is `everything()`
 #' @param type (`string`)\cr
 #'   Type of row to remove. Must be one of `c("header", "reference", "missing", "level", "all")`
 #' @param level_value (`string`)

--- a/R/set_gtsummary_theme.R
+++ b/R/set_gtsummary_theme.R
@@ -88,7 +88,7 @@ set_gtsummary_theme <- function(x, quiet) {
   if (!all(names(x) %in% df_theme_elements$name)) {
     not_name <- names(x) %>% setdiff(df_theme_elements$name)
     cli::cli_abort(
-      "The following names of {.arg x} are not accepted theme elemets: {.val {not_name}}.",
+      "The following names of {.arg x} are not accepted theme elements: {.val {not_name}}.",
       call = get_cli_abort_call()
     )
   }
@@ -148,7 +148,7 @@ with_gtsummary_theme <- function(x, expr,
 }
 
 .msg_ignored_elements <- function(x, current_theme, msg) {
-  # if no message, dont print one!
+  # if no message, don't print one!
   if (is.null(msg)) {
     return(invisible())
   }
@@ -211,7 +211,7 @@ check_gtsummary_theme <- function(x) {
   else if (!all(names(x) %in% df_theme_elements$name)) {
     not_name <- names(x) %>% setdiff(df_theme_elements$name)
     cli::cli_warn(
-      "The following names of {.arg x} are not accepted theme elemets: {.val {not_name}}."
+      "The following names of {.arg x} are not accepted theme elements: {.val {not_name}}."
     )
   }
 

--- a/R/style_ratio.R
+++ b/R/style_ratio.R
@@ -11,7 +11,7 @@
 #'   Numeric vector
 #' @param digits (`integer`)\cr
 #'   Integer specifying the number of significant
-#'   digits to display for numbers below 1. Numbers larger than 1 will be be `digits + 1`.
+#'   digits to display for numbers below 1. Numbers larger than 1 will be `digits + 1`.
 #'   Default is `digits = 2`.
 #' @inheritParams style_number
 #'

--- a/R/tbl_ard_hierarchical.R
+++ b/R/tbl_ard_hierarchical.R
@@ -1,7 +1,7 @@
 #' ARD Hierarchical Table
 #'
 #' @description `r lifecycle::badge('experimental')`\cr
-#' *This is an preview of this function. There will be changes in the coming releases, and changes will not undergo a formal deprecation cycle.*
+#' *This is a preview of this function. There will be changes in the coming releases, and changes will not undergo a formal deprecation cycle.*
 #'
 #' Constructs tables from nested or hierarchical data  structures (e.g. adverse events).
 #'

--- a/R/tbl_ard_summary.R
+++ b/R/tbl_ard_summary.R
@@ -23,7 +23,7 @@
 #'   - `missing_stat`: statistic to show on missing row. Default is `"{N_miss}"`.
 #'     Possible values are `N_miss`, `N_obs`, `N_nonmiss`, `p_miss`, `p_nonmiss`
 #' @param type ([`formula-list-selector`][syntax])\cr
-#'   Specifies the summary type. Accepted value are
+#'   Specifies the summary type. Accepted values are
 #'   `c("continuous", "continuous2", "categorical", "dichotomous")`.
 #'   Continuous summaries may be assigned `c("continuous", "continuous2")`, while
 #'   categorical and dichotomous cannot be modified.
@@ -32,7 +32,7 @@
 #' @param overall (scalar `logical`)\cr
 #'   When `TRUE`, the `cards` input is parsed into two parts to run
 #'   `tbl_ard_summary(cards_by) |> add_overall(cards_overall)`.
-#'   Can only by used when `by` argument is specified.
+#'   Can only be used when `by` argument is specified.
 #'   Default is `FALSE`.
 #' @inheritParams tbl_summary
 #'
@@ -127,7 +127,7 @@ tbl_ard_summary <- function(cards,
   check_scalar(by, allow_empty = TRUE)
   check_scalar_logical(overall)
   if (isTRUE(overall) && is_empty(by)) {
-    cli::cli_inform(c("Cannot use {.code overall=TRUE} when {.arg by} argment not specified.",
+    cli::cli_inform(c("Cannot use {.code overall=TRUE} when {.arg by} argument not specified.",
                       "*" = "Setting {.code overall=FALSE}."))
     overall <- FALSE
   }
@@ -225,7 +225,7 @@ tbl_ard_summary <- function(cards,
   cards::check_list_elements(
     x = type,
     predicate = \(x) is.character(x) && length(x) == 1L && x %in% c("categorical", "dichotomous", "continuous", "continuous2"),
-    error_msg = "Elements of the {.arg type} argumnet must be one of {.val {c('categorical', 'dichotomous', 'continuous', 'continuous2')}}."
+    error_msg = "Elements of the {.arg type} argument must be one of {.val {c('categorical', 'dichotomous', 'continuous', 'continuous2')}}."
   )
   # if the user passed `type` then check that the values are compatible with ARD summary types
   if (!missing(type)) {
@@ -253,7 +253,7 @@ tbl_ard_summary <- function(cards,
                  length(unique(stats::na.omit(unlist(dplyr::filter(cards, .data$variable %in% .env$variable)$variable_level)))) > 1L) {
           cli::cli_abort(
             "The summary type for variable {.val {variable}} is {.val dichotomous},
-             but there are mutiple {.val variable_level} values present, i.e. {.val {unique(stats::na.omit(unlist(dplyr::filter(cards, .data$variable %in% .env$variable)$variable_level)))}}."
+             but there are multiple {.val variable_level} values present, i.e. {.val {unique(stats::na.omit(unlist(dplyr::filter(cards, .data$variable %in% .env$variable)$variable_level)))}}."
           )
 
         }

--- a/R/tbl_continuous.R
+++ b/R/tbl_continuous.R
@@ -224,7 +224,7 @@ tbl_continuous <- function(data,
 
 .add_gts_column_to_cards_continuous <- function(cards, variables, by) {
   if ("gts_column" %in% names(cards)) {
-    cli::cli_inform("The {.val gts_column} column is alread present. Defining the column has been skipped.")
+    cli::cli_inform("The {.val gts_column} column is already present. Defining the column has been skipped.")
     return(cards)
   }
 

--- a/R/tbl_custom_summary.R
+++ b/R/tbl_custom_summary.R
@@ -58,7 +58,7 @@
 #'     `statistic` argument, for that variable)
 #'
 #' The user-defined does not need to utilize each of these inputs. It's
-#' encouraged the user-defined function accept `...` as each of the arguments
+#' encouraged that the user-defined function accept `...` as each of the arguments
 #' *will* be passed to the function, even if not all inputs are utilized by
 #' the user's function, e.g. `foo(data, ...)` (see examples).
 #'

--- a/R/tbl_merge.R
+++ b/R/tbl_merge.R
@@ -427,7 +427,7 @@ tbl_merge <- function(tbls, tab_spanner = NULL, merge_vars = NULL, tbl_ids = NUL
   for (i in seq_along(tbls)) {
     if (nrow(tbls[[i]]$table_body) != nrow(dplyr::distinct(tbls[[i]]$table_body[merge_vars]))) {
       cli::cli_inform(
-        c("The {.arg merge_vars} columns to do uniquely identify rows in all {.arg tbls},
+        c("The {.arg merge_vars} columns do not uniquely identify rows in all {.arg tbls},
            which may result in rows appearing out of order.",
           i = "See {.help [{.fun tbl_merge}](gtsummary::tbl_merge)} help file for details.
                Use {.code quiet=TRUE} to silence message."),

--- a/R/tbl_strata_nested_stack.R
+++ b/R/tbl_strata_nested_stack.R
@@ -73,9 +73,9 @@ tbl_strata_nested_stack <- function(data, strata, .tbl_fun, ..., row_header = "{
         map(
           .data$data,
           ~cards::eval_capture_conditions(expr(.tbl_fun(.x))) |>
-            # print errors, if they occured
+            # print errors, if they occurred
             cards::captured_condition_as_error(
-              message = c("The following {type} occured while building a table:", x = "{condition}")
+              message = c("The following {type} occurred while building a table:", x = "{condition}")
             )
         )
     )

--- a/R/tbl_summary.R
+++ b/R/tbl_summary.R
@@ -24,7 +24,7 @@
 #'   or function(s). If not specified, default formatting is assigned
 #'   via `assign_summary_digits()`. See below for details.
 #' @param type ([`formula-list-selector`][syntax])\cr
-#'   Specifies the summary type. Accepted value are
+#'   Specifies the summary type. Accepted values are
 #'   `c("continuous", "continuous2", "categorical", "dichotomous")`.
 #'   If not specified, default type is assigned via
 #'   `assign_summary_type()`. See below for details.
@@ -100,7 +100,7 @@
 #' }
 #'
 #' @section digits argument:
-#' The digits argument specifies the the number of digits (or formatting function)
+#' The digits argument specifies the number of digits (or formatting function)
 #' statistics are rounded to.
 #'
 #' The values passed can either be a single integer, a vector of integers, a
@@ -498,7 +498,7 @@ tbl_summary <- function(data,
 
 .add_gts_column_to_cards_summary <- function(cards, variables, by) {
   if ("gts_column" %in% names(cards)) {
-    cli::cli_inform("The {.val gts_column} column is alread present. Defining the column has been skipped.")
+    cli::cli_inform("The {.val gts_column} column is already present. Defining the column has been skipped.")
     return(cards)
   }
 

--- a/R/utils-add_p_tests.R
+++ b/R/utils-add_p_tests.R
@@ -728,7 +728,7 @@ check_empty <- function(x, variable = get("variable", envir = caller_env()),
     \(.x) {
       if (!is_empty(dots[[.x]])) {
         cli::cli_abort(
-          message = "The {.arg {.x}} argument is not used for the test selected for of variable {.val {variable}}.",
+          message = "The {.arg {.x}} argument is not used for the test selected for variable {.val {variable}}.",
           call = call
         )
       }

--- a/R/utils-as.R
+++ b/R/utils-as.R
@@ -296,7 +296,7 @@
 }
 
 # this function orders the footnotes by where they first appear in the table,
-# and assigns them an sequential ID
+# and assigns them a sequential ID
 .number_footnotes <- function(x, type, start_with = 0L) {
   # if empty, return empty data frame
   if (nrow(type) == 0L) {

--- a/tests/testthat/_snaps/add_overall.tbl_continuous.md
+++ b/tests/testthat/_snaps/add_overall.tbl_continuous.md
@@ -3,6 +3,6 @@
     Code
       tbl <- add_overall(tbl_continuous(mtcars, include = gear, variable = mpg))
     Message
-      Cannot add an overall column with `add_overall()` when original table is not statified with `tbl_continuous(by)`.
+      Cannot add an overall column with `add_overall()` when original table is not stratified with `tbl_continuous(by)`.
       i Returning table unaltered.
 

--- a/tests/testthat/_snaps/add_overall.tbl_summary.md
+++ b/tests/testthat/_snaps/add_overall.tbl_summary.md
@@ -3,7 +3,7 @@
     Code
       tbl <- add_overall(tbl_summary(mtcars))
     Message
-      Cannot add an overall column with `add_overall()` when original table is not statified with `tbl_summary(by)`.
+      Cannot add an overall column with `add_overall()` when original table is not stratified with `tbl_summary(by)`.
       i Returning table unaltered.
 
 ---
@@ -13,7 +13,7 @@
         "continuous2"), label = mpg ~ "UPDATED!"))
     Condition
       Error in `add_overall()`:
-      ! An error occured in `add_overall()`, and the overall statistic cannot be added.
+      ! An error occurred in `add_overall()`, and the overall statistic cannot be added.
       Have variable labels changed since the original call to `tbl_summary()`?
 
 ---

--- a/tests/testthat/_snaps/add_overall.tbl_svysummary.md
+++ b/tests/testthat/_snaps/add_overall.tbl_svysummary.md
@@ -3,7 +3,7 @@
     Code
       tbl <- add_overall(tbl_svysummary(svy_mtcars))
     Message
-      Cannot add an overall column with `add_overall()` when original table is not statified with `tbl_svysummary(by)`.
+      Cannot add an overall column with `add_overall()` when original table is not stratified with `tbl_svysummary(by)`.
       i Returning table unaltered.
 
 ---
@@ -13,6 +13,6 @@
         type = all_continuous() ~ "continuous2"), label = mpg ~ "UPDATED!"))
     Condition
       Error in `add_overall()`:
-      ! An error occured in `add_overall()`, and the overall statistic cannot be added.
+      ! An error occurred in `add_overall()`, and the overall statistic cannot be added.
       Have variable labels changed since the original call to `tbl_svysummary()`?
 

--- a/tests/testthat/_snaps/add_stat.md
+++ b/tests/testthat/_snaps/add_stat.md
@@ -3,9 +3,9 @@
     Code
       result <- add_stat(tbl, fns = everything() ~ mean)
     Message
-      There was a error for variable "age"
+      There was an error for variable "age"
       x argument "x" is missing, with no default
-      There was a error for variable "marker"
+      There was an error for variable "marker"
       x argument "x" is missing, with no default
 
 ---
@@ -64,9 +64,9 @@
       })
       as.data.frame(add_stat(tbl, fns = ~curly_error))
     Message
-      There was a error for variable "age"
+      There was an error for variable "age"
       x {curly} error
-      There was a error for variable "marker"
+      There was an error for variable "marker"
       x {curly} error
     Output
           **Characteristic** **Drug A**  \nN = 98 **Drug B**  \nN = 102 add_stat_1

--- a/tests/testthat/_snaps/inline_text.md
+++ b/tests/testthat/_snaps/inline_text.md
@@ -89,7 +89,7 @@
     Code
       tbl_stack(list(t1, t1)) %>% inline_text(variable = marker, column = estimate)
     Message
-      Variable marker likely not unique in gtsummary table, and the cell(s) you wish to display may not be accessible. This may occur when gtsummary tables with repeated variable names are combined using `tbl_stack()`.
+      Variable "marker" likely not unique in gtsummary table, and the cell(s) you wish to display may not be accessible. This may occur when gtsummary tables with repeated variable names are combined using `tbl_stack()`.
     Output
       [1] "-0.05"
 

--- a/tests/testthat/_snaps/modify_table_body.md
+++ b/tests/testthat/_snaps/modify_table_body.md
@@ -20,6 +20,6 @@
         "I made an error."))
     Condition
       Error in `modify_table_body()`:
-      ! The following error occured while executing `fun` on `x$table_body`:
+      ! The following error occurred while executing `fun` on `x$table_body`:
       x I made an error.
 

--- a/tests/testthat/_snaps/theme_gtsummary.md
+++ b/tests/testthat/_snaps/theme_gtsummary.md
@@ -99,7 +99,7 @@
       check_gtsummary_theme(list(not_a_theme_element = letters))
     Condition
       Warning:
-      The following names of `x` are not accepted theme elemets: "not_a_theme_element".
+      The following names of `x` are not accepted theme elements: "not_a_theme_element".
 
 ---
 

--- a/tests/testthat/test-modify_footnote_spanning_header.R
+++ b/tests/testthat/test-modify_footnote_spanning_header.R
@@ -19,7 +19,7 @@ test_that("modify_footnote_spanning_header(footnote)", {
         level = 1L
       ) |>
       modify_footnote_spanning_header(
-        footnote = "Treatment Recieved",
+        footnote = "Treatment Received",
         columns = all_stat_cols()
       )
   )
@@ -29,7 +29,7 @@ test_that("modify_footnote_spanning_header(footnote)", {
       ~column,               ~footnote, ~level, ~text_interpret, ~replace, ~remove,
       "stat_1", "Randomized Treatment",     1L,        "gt::md",     TRUE,   FALSE,
       "stat_1",                     NA,     1L,        "gt::md",     TRUE,    TRUE,
-      "stat_1",   "Treatment Recieved",     1L,        "gt::md",     TRUE,   FALSE
+      "stat_1",   "Treatment Received",     1L,        "gt::md",     TRUE,   FALSE
     )
   )
 

--- a/tests/testthat/test-tbl_merge.R
+++ b/tests/testthat/test-tbl_merge.R
@@ -304,7 +304,7 @@ test_that("tbl_merge() works with tbl_hierarchical()", {
 test_that("tbl_merge() test unlike table merge messaging", {
   expect_message(
     tbl_merge(list(t1, t1), merge_vars = "variable"),
-    "*columns to do uniquely identify rows*"
+    "*columns do not uniquely identify rows*"
   )
 
   expect_message(

--- a/vignettes/articles/gallery.Rmd
+++ b/vignettes/articles/gallery.Rmd
@@ -29,7 +29,7 @@ Headers, Labels and Formatting
 
 1. [How do I **change the value** of the by levels?](#modify-pvalue)
 
-1. [How do I added a **spanning header** row to a table?](#table-header)
+1. [How do I add a **spanning header** row to a table?](#table-header)
 
 1. [How do I change **variable labels**?](#modify-pvalue)
 
@@ -142,7 +142,7 @@ trial |>
 <hr>
 <a id="modify-pvalue"></a>
 
-Modify the function that formats the p-values, change variable labels, updating tumor response header, and add a correction for multiple testing.
+Modify the function that formats the p-values, change variable labels, update tumor response header, and add a correction for multiple testing.
 
 ```{r, message = FALSE}
 trial |> 
@@ -160,7 +160,7 @@ trial |>
 <hr>
 <a id="include-missing"></a>
 
-Include missing tumor response as column using `forcats::fct_na_value_to_level()`.
+Include missing tumor response as a column using `forcats::fct_na_value_to_level()`.
 
 ```{r}
 trial |> 
@@ -435,7 +435,7 @@ trial |>
 <hr>
 <a id="use_robust_errors"></a>
 
-To use robust standard errors in a regression model, the model is prepared use usual, and the variance-covariance matrix of the model is modified via an appropriate function, such as `vcovCL` from the sandwich package. 
+To use robust standard errors in a regression model, the model is prepared as usual, and the variance-covariance matrix of the model is modified via an appropriate function, such as `vcovCL` from the sandwich package.
 
 ```{r}
 dat <- trial |> 

--- a/vignettes/articles/inline_text.Rmd
+++ b/vignettes/articles/inline_text.Rmd
@@ -116,7 +116,7 @@ Here's how the line will appear in your report.
 It is reasonable that you'll need to modify the text.
 To do this, use the `pattern` argument.
 The `pattern` argument syntax follows `glue::glue()` format with referenced R objects being inserted between curly brackets.
-The default is `pattern = "{estimate} ({conf.level*100}% CI {conf.low}, {conf.high}; {p.value})"`.  You have access the to following fields within the `pattern` argument.
+The default is `pattern = "{estimate} ({conf.level*100}% CI {conf.low}, {conf.high}; {p.value})"`.  You have access to the following fields within the `pattern` argument.
 
 ```{r, echo = FALSE}
 dplyr::tribble(
@@ -141,4 +141,4 @@ If you're printing results from a categorical variable, include the `level` argu
 The `inline_text` function has arguments for rounding the p-value (`pvalue_fun`) and the coefficients and confidence interval (`estimate_fun`).
 These default to the same rounding performed in the table, but can be modified when reporting inline.
 
-For more details about inline code, review to the  [RStudio documentation page](https://rmarkdown.rstudio.com/lesson-4.html).
+For more details about inline code, refer to the [RStudio documentation page](https://rmarkdown.rstudio.com/lesson-4.html).

--- a/vignettes/articles/modify-functions.Rmd
+++ b/vignettes/articles/modify-functions.Rmd
@@ -265,11 +265,11 @@ x |>
 ## Footnotes vs Source Notes vs Abbreviations
 
 Within gtsummary, there are three types of notes that appear under a table: [footnotes](https://www.danieldsjoberg.com/gtsummary/reference/modify_footnote2.html), [source notes](https://www.danieldsjoberg.com/gtsummary/reference/modify_source_note.html), and [abbreviations](https://www.danieldsjoberg.com/gtsummary/reference/modify_abbreviation.html).
-Adding, modify, and removing these notes require functions tailored for each type of note.
+Adding, modifying, and removing these notes require functions tailored for each type of note.
 
 - Footnotes place notes with markers that appear in the table, and the marker appears again next to the note below the table: a very standard footnote.
 
-- Source notes are similar to footnotes, expect there is no marker associated with the note.
+- Source notes are similar to footnotes, except there is no marker associated with the note.
 
 - Abbreviations are a special type of source note. All abbreviations that appear in a table are collected and placed in a single note at the bottom of the table.
 

--- a/vignettes/articles/shiny.Rmd
+++ b/vignettes/articles/shiny.Rmd
@@ -30,4 +30,4 @@ If the Shiny app has run out of its free server usage, see below for instruction
 ```{r, eval=FALSE, file='https://raw.githubusercontent.com/ddsjoberg/gtsummary-shiny-example/main/app.R'}
 ```
 
-To run this Shiny app locally on your machine, save the script above as `app.R` in a R Project, open in RStudio, and run the application.
+To run this Shiny app locally on your machine, save the script above as `app.R` in an R Project, open in RStudio, and run the application.

--- a/vignettes/articles/tbl_ard-functions.Rmd
+++ b/vignettes/articles/tbl_ard-functions.Rmd
@@ -18,13 +18,13 @@ theme_gtsummary_compact()
 ## Introduction
 
 Analysis Results Datasets (ARDs) are part of the [CDISC Analysis Results Standard](https://www.cdisc.org/standards/foundational/analysis-results-standard), which aims to facilitate automation, reproducibility, reusability, and traceability of analysis results data (ARD).
-ARDs are highly structured and generalized data frame objects in which store the results of both simple and complex statistical results.
+ARDs are highly structured and generalized data frame objects that store the results of both simple and complex statistical results.
 The {gtsummary} package utilizes ARDs (via the {cards} and {cardx} packages) to perform all calculations.
 
 In this tutorial, we will review how to use the native {gtsummary} functions to build standard and highly customized tables.
 There are two basic approaches to creating summary tables utilizing ARDs: 
 
-1. As ARDs power every calculation and tabulation in the {gtsummary}, ARDs can be extracted from any table created with the `tbl_*()` functions (and their add-ons).
+1. As ARDs power every calculation and tabulation in the {gtsummary} package, ARDs can be extracted from any table created with the `tbl_*()` functions (and their add-ons).
 2. One can also create ARDs first, then pass the ARD to a `tbl_ard_*()` function that will convert the ARD to a summary table.
 
 Both methods will be covered in this tutorial.
@@ -144,7 +144,7 @@ ard_demo
 ```
 
 The optional arguments that can be specified to improve the appearance of the table.
-- `.attributes` summary table will utilize the column label attributes, if available
+- `.attributes` the summary table will utilize the column label attributes, if available
 - `.total_n` the total N is saved internally, and will be used in the printed table.
 - `.overall` the operations will be repeated without `.by` variable
 - `.missing` when missing results are included, users can include missing counts or rates for the variables.
@@ -242,10 +242,10 @@ ard_outcomes |>
 
 #### Final Thoughts
 
-When creating the a custom summary table, you will want to utilize the functions with the `tbl_ard_*()` prefix.
+When creating a custom summary table, you will want to utilize the functions with the `tbl_ard_*()` prefix.
 It will be important to familiarize yourself with the table structures that each of these functions produce, so you know which to use to build your table.
 
-If your table is a combination or mix of table types structures, you can build each part of your table separately and use `tbl_stack()` and `tbl_merge()` to cobble together your final table.
+If your table is a combination or mix of table structures, you can build each part of your table separately and use `tbl_stack()` and `tbl_merge()` to cobble together your final table.
 
 Finally, some tables are entirely unique and would be difficult to create under any framework.
 In these cases, it's often much easier to build a data frame and then convert it to a gtsummary table with `as_gtsummary()`.

--- a/vignettes/articles/tbl_regression.Rmd
+++ b/vignettes/articles/tbl_regression.Rmd
@@ -91,7 +91,7 @@ m1 <- glm(response ~ age + stage, trial, family = binomial)
 summary(m1)$coefficients
 ```
 
-* We will then a **regression model table** to summarize and present these results in just one line of code from {gtsummary}. 
+* We will then create a **regression model table** to summarize and present these results in just one line of code from {gtsummary}.
 
 ```{r, message=FALSE}
 tbl_regression(m1, exponentiate = TRUE)

--- a/vignettes/articles/tbl_summary.Rmd
+++ b/vignettes/articles/tbl_summary.Rmd
@@ -185,7 +185,7 @@ if (identical(Sys.getenv("IN_PKGDOWN"), "true")) {
 
 ### {gtsummary} functions to add information
 
-The {gtsummary} package has functions to adding information or statistics to `tbl_summary()` tables.
+The {gtsummary} package has functions for adding information or statistics to `tbl_summary()` tables.
 
 ```{r echo = FALSE}
 dplyr::tribble(

--- a/vignettes/gtsummary_definition.Rmd
+++ b/vignettes/gtsummary_definition.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 This vignette is meant for those who wish to contribute to {gtsummary}, or users who wish to gain an understanding of the inner-workings of a {gtsummary} object so they may more easily modify them to suit your own needs.
-If this does not describe you, please refer to the [{gtsummary} website](https://www.danieldsjoberg.com/gtsummary/) to an introduction on how to use the package's functions and tutorials on advanced use.
+If this does not describe you, please refer to the [{gtsummary} website](https://www.danieldsjoberg.com/gtsummary/) for an introduction on how to use the package's functions and tutorials on advanced use.
 
 _This overview is for informational purposes. Documenting the internal structures does not mean the internal structures of the package won't be updated. If they are updated, this is not considered a breaking change._
 
@@ -68,7 +68,7 @@ The list contains the following data frames `header`, `footnote_header`, `footno
 **`header`**
 
 The `header` table has the following columns and is one row per column found in `.$table_body`.
-The table contains styling information that applies to entire column or the columns headers.
+The table contains styling information that applies to the entire column or the column headers.
 
 ```{r, echo=FALSE}
 dplyr::tribble(
@@ -97,7 +97,7 @@ dplyr::tribble(
 **`footnote_header`**
 
 Each {gtsummary} table may contain footnotes in the column headers.
-Updates/changes to footnote are appended to the bottom of the tibble.
+Updates/changes to footnotes are appended to the bottom of the tibble.
 
 ```{r, echo=FALSE}
 dplyr::tribble(
@@ -124,7 +124,7 @@ dplyr::tribble(
 **`footnote_body`**
 
 Each {gtsummary} table may include footnotes in the body of the table.
-Updates/changes to footnote are appended to the bottom of the tibble.
+Updates/changes to footnotes are appended to the bottom of the tibble.
 
 ```{r, echo=FALSE}
 dplyr::tribble(
@@ -152,7 +152,7 @@ dplyr::tribble(
 **`footnote_spanning_header`**
 
 Each {gtsummary} table may include footnotes in the spanning headers of the table.
-Updates/changes to footnote are appended to the bottom of the tibble.
+Updates/changes to footnotes are appended to the bottom of the tibble.
 
 ```{r, echo=FALSE}
 dplyr::tribble(
@@ -217,7 +217,7 @@ Source notes are added one at a time and present much like footnotes, but are no
 ```{r, echo=FALSE}
 dplyr::tribble(
   ~Column, ~Description,
-  "id", "Integer idenitfying the source note",
+  "id", "Integer identifying the source note",
   "source_note", "string containing the abbreviation to add",
   "text_interpret", "the {gt} function that is used to interpret the source note, `gt::md()` or `gt::html()`",
   "remove", "logical indicating whether the source note should be included or removed from final table"
@@ -290,7 +290,7 @@ dplyr::tribble(
 
 **`fmt_missing`**
 
-By default, all `NA` values are shown blanks.
+By default, all `NA` values are shown as blanks.
 Missing values in columns/rows are replaced with the `symbol`.
 For example, reference rows in `tbl_regression()` are shown with an em-dash.
 Updates/changes to styling functions are appended to the bottom of the tibble.


### PR DESCRIPTION
## Summary

Repo-wide typo/grammar sweep: misspellings, duplicated words, missing/extra words, and wrong word choices across roxygen docs, `cli::cli_*`/`stop`/`warning` messages, code comments, vignette prose, and `NEWS.md`. No logic, formatting, or wording changes beyond the fixes below. `man/*.Rd` are untouched since they're regenerated from the R/ roxygen comments (`devtools::document()`).

A few source-message fixes required paired updates to `tests/testthat/test-tbl_merge.R`, `tests/testthat/test-modify_footnote_spanning_header.R`, and 7 `_snaps/*.md` snapshot files so expectations stay in sync with the corrected message text. Full affected-test suite passes locally.

## Typos fixed

### User-facing messages (`cli::cli_*` output)

| File | Before | After |
|---|---|---|
| `R/tbl_strata_nested_stack.R` | "occured while building a table" | "occurred while building a table" |
| `R/tbl_ard_summary.R` (×2) | "argment"/"argumnet" | "argument" |
| `R/add_overall.R` (×2) | "not statified" / "error occured" | "not stratified" / "error occurred" |
| `R/modify_table_body.R` | "error occured while executing" | "error occurred while executing" |
| `R/tbl_merge.R` | "columns to do uniquely identify rows" (inverted meaning) | "columns do not uniquely identify rows" |
| `R/utils-add_p_tests.R` | "test selected for of variable" | "test selected for variable" |
| `R/tbl_continuous.R`, `R/tbl_summary.R` | "column is alread present" | "column is already present" |
| `R/set_gtsummary_theme.R` (×2) | "not accepted theme elemets" | "not accepted theme elements" |
| `R/tbl_ard_summary.R` | "there are mutiple" | "there are multiple" |
| `R/add_significance_stars.R` | "pattern argumnet" | "pattern argument" |
| `R/add_stat.R` | "There was a error for variable" | "There was an error for variable" |
| `R/inline_text.R` | `{.cal {variable}}` (invalid cli markup class) | `{.val {variable}}` |

### Roxygen docs (`?function` help pages / pkgdown reference)

| File | Before | After |
|---|---|---|
| `R/tbl_ard_summary.R` | "Can only by used" | "Can only be used" |
| `R/tbl_ard_summary.R`, `R/tbl_summary.R` | "Accepted value are" | "Accepted values are" |
| `R/tbl_ard_hierarchical.R` | "This is an preview" | "This is a preview" |
| `R/add_stat.R`, `R/tbl_custom_summary.R` | "encouraged the user-defined function accept" | "encouraged that the user-defined function accept" |
| `R/add_stat.R` | "add a explanatory footnote" | "add an explanatory footnote" |
| `R/add_glance.R` | "Specifies the the functions" | "Specifies the functions" |
| `R/add_p.tbl_survfit.R` | "re-constructed from the the call" | "re-constructed from the call" |
| `R/remove_row_type.R` | "Variables to to remove" | "Variables to remove" |
| `R/style_ratio.R` | "will be be `digits + 1`" | "will be `digits + 1`" |
| `R/tbl_summary.R` | "specifies the the number of digits" | "specifies the number of digits" |
| `R/modify_source_note.R` | "footnotes, expect they are not linked" | "footnotes, except they are not linked" |
| `R/deprecated_ci_column.R` | "we can to continue to update" | "we can continue to update" |

### Code comments

| File | Before | After |
|---|---|---|
| `R/tbl_strata_nested_stack.R` | "if they occured" | "if they occurred" |
| `R/as_kable_extra.R` | "converting to charcter vector" | "converting to character vector" |
| `R/add_p.R` | "data frame of of NA" | "data frame of NA" |
| `R/utils-as.R` | "assigns them an sequential ID" | "assigns them a sequential ID" |
| `R/set_gtsummary_theme.R` | "if no message, dont print one!" | "if no message, don't print one!" |

### Vignettes / articles

| File | Before | After |
|---|---|---|
| `vignettes/gtsummary_definition.Rmd` | "refer to the website to an introduction" | "refer to the website for an introduction" |
| `vignettes/gtsummary_definition.Rmd` | "applies to entire column or the columns headers" | "applies to the entire column or the column headers" |
| `vignettes/gtsummary_definition.Rmd` (×3) | "Updates/changes to footnote are appended" | "Updates/changes to footnotes are appended" |
| `vignettes/gtsummary_definition.Rmd` | "Integer idenitfying the source note" | "Integer identifying the source note" |
| `vignettes/gtsummary_definition.Rmd` | "`NA` values are shown blanks" | "`NA` values are shown as blanks" |
| `vignettes/articles/gallery.Rmd` | "How do I added a spanning header" | "How do I add a spanning header" |
| `vignettes/articles/gallery.Rmd` | "change variable labels, updating tumor response header" | "...update tumor response header" |
| `vignettes/articles/gallery.Rmd` | "missing tumor response as column" | "missing tumor response as a column" |
| `vignettes/articles/gallery.Rmd` | "the model is prepared use usual" | "the model is prepared as usual" |
| `vignettes/articles/inline_text.Rmd` | "You have access the to following fields" | "access to the following fields" |
| `vignettes/articles/inline_text.Rmd` | "review to the  [RStudio documentation" | "refer to the [RStudio documentation" |
| `vignettes/articles/modify-functions.Rmd` | "Adding, modify, and removing" | "Adding, modifying, and removing" |
| `vignettes/articles/modify-functions.Rmd` | "footnotes, expect there is no marker" | "footnotes, except there is no marker" |
| `vignettes/articles/shiny.Rmd` | "save the script above as `app.R` in a R Project" | "...in an R Project" |
| `vignettes/articles/tbl_ard-functions.Rmd` | "objects in which store the results" | "objects that store the results" |
| `vignettes/articles/tbl_ard-functions.Rmd` | "tabulation in the {gtsummary}, ARDs" | "tabulation in the {gtsummary} package, ARDs" |
| `vignettes/articles/tbl_ard-functions.Rmd` | "`.attributes` summary table will utilize" | "`.attributes` the summary table will utilize" |
| `vignettes/articles/tbl_ard-functions.Rmd` | "When creating the a custom summary table" | "When creating a custom summary table" |
| `vignettes/articles/tbl_ard-functions.Rmd` | "combination or mix of table types structures" | "combination or mix of table structures" |
| `vignettes/articles/tbl_regression.Rmd` | "We will then a regression model table" | "We will then create a regression model table" |
| `vignettes/articles/tbl_summary.Rmd` | "functions to adding information" | "functions for adding information" |

### NEWS.md

| Before | After |
|---|---|
| "now allows to specify" | "now allowed to specify" |
| "we can simple update" | "we can simply update" |
| "we can to continue to update" | "we can continue to update" |
| "now reduced the variables" | "now reduced to the variables" |
| "which not available when" | "which was not available when" |
| "instead,select no columns" | "instead, select no columns" |
| "left to the the user pass data" | "left to the user to pass data" |
| "both the the stratified data frame" | "both the stratified data frame" |
| "function aids prepares gtsummary tables" | "function prepares gtsummary tables" |
| "theme element. they can choose" | "theme element. They can choose" |
| "no longer causes as error" | "no longer causes an error" |

### Test fixture

| File | Before | After |
|---|---|---|
| `tests/testthat/test-modify_footnote_spanning_header.R` (×2) | "Treatment Recieved" | "Treatment Received" |

## Test plan

- [x] Repo-wide grep confirms no residual instances of any fixed string
- [x] `devtools::test(filter = ...)` run for every test file whose expectations/snapshots were touched (`add_overall.*`, `add_stat`, `modify_table_body`, `tbl_merge`, `modify_footnote_spanning_header`, `theme_gtsummary`, `inline_text`, `tbl_ard_summary`, `modify_source_note`, `tbl_custom_summary`) — all pass